### PR TITLE
Remove starts with from error regex

### DIFF
--- a/plugins/terminal/nxos.py
+++ b/plugins/terminal/nxos.py
@@ -39,7 +39,7 @@ class TerminalModule(TerminalBase):
 
     terminal_stderr_re = [
         re.compile(br"% ?Error"),
-        re.compile(br"^error:(.*)", re.I),
+        re.compile(br"\nerror:(.*)", re.I),
         re.compile(br"^% \w+", re.M),
         re.compile(br"% ?Bad secret"),
         re.compile(br"invalid input", re.I),


### PR DESCRIPTION

Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- The response received doesn't start with (Error|error), instead in most cases it starts with the last command sent. As a result, the terminal error regex fails to catch it and the task doesn't fail. This PR removes the starts with from the regex.

```
response = b'redistribute bgp 65589 route-map rmap_8\r\r\nError: bgp-65578 is already distributed, Only one is allowed\r\r\nNexus9000v(config-router-vrf)#
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
terminal/nxos.py