### PR TITLE
Add python3 as a base python for tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = linters
 skipsdist = True
 
 [testenv]
+basepython = python3
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 


### PR DESCRIPTION
This PR adds python3 as a base for all the testenvs on tox.