### PR TITLE
[TEST-FIX] Cleanup nxos_acl_interfaces properly

### DIFF
--- a/tests/integration/targets/nxos_acl_interfaces/tests/cli/remove_config.yaml
+++ b/tests/integration/targets/nxos_acl_interfaces/tests/cli/remove_config.yaml
@@ -2,10 +2,11 @@
 - name: Remove config
   ansible.netcommon.cli_config:
     config: "no ip access-list ACL1v4\nno ip access-list NewACLv4\nno ip access-list\
-      \ PortACL\nno ipv6 access-list ACL1v6\nno ipv6 access-list ACL1v6\ninterface\
+      \ PortACL\nno ipv6 access-list ACL1v6\nno ipv6 access-list NewACLv6\ninterface\
       \ Ethernet1/2\n  no ipv6 traffic-filter ACL1v6 in\ninterface Ethernet1/5\n\
       \  no ip access-group ACL1v4 out\n  no ip port access-group PortACL in\n \
       \ no ipv6 traffic-filter ACL1v6 in\ninterface Ethernet1/3\n  no ipv6 port\
       \ traffic-filter NewACLv6 in\n  no ip access-group ACL1v4 out\n  no ip port\
       \ access-group PortACL in\ninterface Ethernet1/4\n  no ip access-group NewACLv4\
       \ out\n"
+  ignore_errors: True


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- nxos_acls is sending an extra command in overridden test to remove `NewACLv6`, this is unaccounted for and is a result of improper cleanup in acl_interfaces.

Test failure:
https://object-storage-ca-ymq-1.vexxhost.net/v1/a0b4156a37f9453eb4ec7db5422272df/ansible_22/22/53e8d97b01fbccd727fd935816ab86ca3ba60bef/check/ansible-test-network-integration-nxos-cli-python36/3182342/controller/ara-report/reports/b7c4da90-4bc7-40a9-9b04-fd34659cb276.html

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
targets/nxos_acl_interfaces
