### PR TITLE
Add new states to nxos_bfd_interfaces

### DIFF
--- a/plugins/module_utils/network/nxos/argspec/bfd_interfaces/bfd_interfaces.py
+++ b/plugins/module_utils/network/nxos/argspec/bfd_interfaces/bfd_interfaces.py
@@ -38,6 +38,7 @@ class Bfd_interfacesArgs(object):  # pylint: disable=R0903
         pass
 
     argument_spec = {
+        "running_config": {"type": "str"},
         "config": {
             "elements": "dict",
             "options": {
@@ -48,7 +49,15 @@ class Bfd_interfacesArgs(object):  # pylint: disable=R0903
             "type": "list",
         },
         "state": {
-            "choices": ["merged", "replaced", "overridden", "deleted"],
+            "choices": [
+                "merged",
+                "replaced",
+                "overridden",
+                "deleted",
+                "gathered",
+                "rendered",
+                "parsed",
+            ],
             "default": "merged",
             "type": "str",
         },

--- a/tests/integration/targets/nxos_bfd_interfaces/defaults/main.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/defaults/main.yaml
@@ -1,2 +1,2 @@
 ---
-testcase: '*'
+testcase: '[^_].*'

--- a/tests/integration/targets/nxos_bfd_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tasks/cli.yaml
@@ -1,14 +1,22 @@
 ---
 - name: collect common test cases
   find:
-    paths: '{{ role_path }}/tests/cli'
+    paths: '{{ role_path }}/tests/common'
     patterns: '{{ testcase }}.yaml'
+    use_regex: True
   connection: local
   register: test_cases
 
+- name: collect cli test cases
+  find:
+    paths: '{{ role_path }}/tests/cli'
+    patterns: '{{ testcase }}.yaml'
+  connection: local
+  register: cli_cases
+
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }}'
+      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_bfd_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tasks/main.yaml
@@ -2,3 +2,7 @@
 - include: cli.yaml
   tags:
     - cli
+
+- include: nxapi.yaml
+  tags:
+    - nxapi

--- a/tests/integration/targets/nxos_bfd_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tasks/nxapi.yaml
@@ -3,6 +3,7 @@
   find:
     paths: '{{ role_path }}/tests/common'
     patterns: '{{ testcase }}.yaml'
+    use_regex: True
   connection: local
   register: test_cases
 
@@ -21,8 +22,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=ansible.netcommon.httpapi)
-  include: '{{ test_case_to_run }} ansible_connection=ansible.netcommon.httpapi
-    connection={{ nxapi }}'
+  include: '{{ test_case_to_run }} ansible_connection=ansible.netcommon.httpapi'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_bfd_interfaces/tests/common/_populate_config.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tests/common/_populate_config.yaml
@@ -1,0 +1,14 @@
+- name: Populate config - 1
+  cisco.nxos.nxos_config:
+    lines:
+      - "feature bfd"
+      - "interface {{ nxos_int1 }}"
+      - "  no switchport"
+      - "  no bfd"
+
+- name: Populate config - 2
+  cisco.nxos.nxos_config:
+    lines:
+      - "interface {{ nxos_int2 }}"
+      - "  no switchport"
+      - "  no bfd echo"

--- a/tests/integration/targets/nxos_bfd_interfaces/tests/common/_remove_config.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tests/common/_remove_config.yaml
@@ -1,0 +1,8 @@
+- name: Remove config
+  cisco.nxos.nxos_config:
+    lines:
+      - "no feature bfd"
+      - "default interface {{ nxos_int1 }}"
+      - "default interface {{ nxos_int2 }}"
+      - "default interface {{ nxos_int3 }}"
+  ignore_errors: True

--- a/tests/integration/targets/nxos_bfd_interfaces/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tests/common/deleted.yaml
@@ -11,14 +11,19 @@
   when: platform is not search('N5K|N6K')
 
 - name: setup1
-  ansible.netcommon.cli_config: &id002
-    config: "no feature bfd\ndefault interface {{ test_int1 }}\n"
+  cisco.nxos.nxos_config: &id002
+    lines:
+      - "no feature bfd"
+      - "default interface {{ test_int1 }}"
 
 - block:
 
     - name: setup2
-      ansible.netcommon.cli_config:
-        config: "feature bfd\ninterface {{ test_int1 }}\n  no switchport\n"
+      cisco.nxos.nxos_config:
+        lines:
+          - "feature bfd"
+          - "interface {{ test_int1 }}"
+          - "  no switchport"
 
     - name: setup initial bfd state
       cisco.nxos.nxos_bfd_interfaces:
@@ -67,4 +72,4 @@
   always:
 
     - name: teardown
-      ansible.netcommon.cli_config: *id002
+      cisco.nxos.nxos_config: *id002

--- a/tests/integration/targets/nxos_bfd_interfaces/tests/common/empty_config.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tests/common/empty_config.yaml
@@ -1,0 +1,62 @@
+---
+- debug:
+    msg: START nxos_bfd_interfaces empty_config integration tests on connection={{ ansible_connection }}
+
+- name: Merged with empty config should give appropriate error message
+  register: result
+  ignore_errors: true
+  cisco.nxos.nxos_bfd_interfaces:
+    config:
+    state: merged
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state merged'
+
+- name: Replaced with empty config should give appropriate error message
+  register: result
+  ignore_errors: true
+  cisco.nxos.nxos_bfd_interfaces:
+    config:
+    state: replaced
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state replaced'
+
+- name: Overridden with empty config should give appropriate error message
+  register: result
+  ignore_errors: true
+  cisco.nxos.nxos_bfd_interfaces:
+    config:
+    state: overridden
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state overridden'
+
+- name: Rendered with empty config should give appropriate error message
+  register: result
+  ignore_errors: true
+  cisco.nxos.nxos_bfd_interfaces:
+    config:
+    state: rendered
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state rendered'
+
+
+- name: Parsed with empty config should give appropriate error message
+  register: result
+  ignore_errors: true
+  cisco.nxos.nxos_bfd_interfaces:
+    running_config:
+    state: parsed
+
+- assert:
+    that:
+      - result.msg == 'value of running_config parameter must not be empty for state parsed'
+
+- debug:
+    msg: END nxos_bfd_interfaces empty_config integration tests on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_bfd_interfaces/tests/common/gathered.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tests/common/gathered.yaml
@@ -1,0 +1,26 @@
+---
+- debug:
+    msg: START nxos_bfd_interfaces gathered integration tests on connection={{ ansible_connection
+      }}
+
+- include_tasks: _remove_config.yaml
+
+- include_tasks: _populate_config.yaml
+
+- block:
+
+    - name: Gather bfd_interfaces facts from the device using nxos_bfd_interfaces
+      register: result
+      cisco.nxos.nxos_bfd_interfaces:
+        state: gathered
+
+    - assert:
+        that: "{{ result['gathered'][:3] | symmetric_difference(gathered)\
+          \ |length == 0 }}"
+  always:
+
+    - include_tasks: _remove_config.yaml
+
+    - debug:
+        msg: END nxos_bfd_interfaces gathered integration tests on connection={{ ansible_connection
+          }}

--- a/tests/integration/targets/nxos_bfd_interfaces/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tests/common/merged.yaml
@@ -11,14 +11,19 @@
   when: platform is not search('N5K|N6K')
 
 - name: setup1
-  ansible.netcommon.cli_config: &id002
-    config: "no feature bfd\ndefault interface {{ test_int1 }}\n"
+  cisco.nxos.nxos_config: &id002
+    lines:
+      - "no feature bfd"
+      - "default interface {{ test_int1 }}"
 
 - block:
 
     - name: setup2
-      ansible.netcommon.cli_config:
-        config: "feature bfd\ninterface {{ test_int1 }}\n  no switchport\n"
+      cisco.nxos.nxos_config:
+        lines:
+          - "feature bfd"
+          - "interface {{ test_int1 }}"
+          - "  no switchport"
 
     - name: Merged
       register: result
@@ -65,4 +70,4 @@
   always:
 
     - name: teardown
-      ansible.netcommon.cli_config: *id002
+      cisco.nxos.nxos_config: *id002

--- a/tests/integration/targets/nxos_bfd_interfaces/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tests/common/overridden.yaml
@@ -13,16 +13,26 @@
   when: platform is not search('N5K|N6K')
 
 - name: setup1
-  ansible.netcommon.cli_config: &id002
-    config: "no feature bfd\ndefault interface {{ test_int1 }}\ndefault interface\
-      \ {{ test_int2 }}\n"
+  cisco.nxos.nxos_config: &id002
+    lines: 
+      - "no feature bfd"
+      - "default interface {{ test_int1 }}"
+      - "default interface {{ test_int2 }}"
 
 - block:
 
     - name: setup2
-      ansible.netcommon.cli_config:
-        config: "feature bfd\ninterface {{ test_int1 }}\n  no switchport\ninterface\
-          \ {{ test_int2 }}\n  no switchport\n"
+      cisco.nxos.nxos_config:
+        lines:
+          - "feature bfd"
+          - "interface {{ test_int1 }}"
+          - "  no switchport"
+    
+    - name: setup3
+      cisco.nxos.nxos_config:
+        lines:
+          - "interface {{ test_int2 }}"
+          - "  no switchport"
 
     - name: setup initial bfd state
       cisco.nxos.nxos_bfd_interfaces:
@@ -65,4 +75,4 @@
   always:
 
     - name: teardown
-      ansible.netcommon.cli_config: *id002
+      cisco.nxos.nxos_config: *id002

--- a/tests/integration/targets/nxos_bfd_interfaces/tests/common/parsed.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tests/common/parsed.yaml
@@ -1,0 +1,34 @@
+---
+- debug:
+    msg: START nxos_bfd_interfaces parsed integration tests on connection={{ ansible_connection
+      }}
+
+- block:
+    # Interfaces used in the task don't actually exist on the appliance
+    - name: Use parsed state to convert externally supplied config to structured format
+      register: result
+      cisco.nxos.nxos_bfd_interfaces:
+        running_config: |
+          feature bfd
+          interface Ethernet1/800
+            no switchport
+            no bfd
+            no bfd echo
+          interface Ethernet1/801
+            no switchport
+            no bfd
+          interface Ethernet1/802
+            no switchport
+            no bfd echo
+          interface mgmt0
+            ip address dhcp
+            vrf member management
+        state: parsed
+
+    - assert:
+       that: "{{ parsed | symmetric_difference(result['parsed']) |length==0\
+         \ }}"
+
+- debug:
+    msg: END nxos_bfd_interfaces parsed integration tests on connection={{ ansible_connection
+      }}

--- a/tests/integration/targets/nxos_bfd_interfaces/tests/common/rendered.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tests/common/rendered.yaml
@@ -1,0 +1,41 @@
+---
+- debug:
+    msg: START nxos_bfd_interfaces rendered integration tests on connection={{ ansible_connection
+      }}
+
+- include_tasks: _remove_config.yaml
+
+- block:
+    # Interfaces used here doesn't actually exist on the device
+    - name: Use rendered state to convert task input to device specific commands
+      register: result
+      cisco.nxos.nxos_bfd_interfaces:
+        config:
+          - name: Ethernet1/800
+            bfd: enable
+            echo: enable
+          - name: Ethernet1/801
+            bfd: disable
+            echo: disable
+        state: rendered
+
+    - assert:
+        that: "{{ rendered | symmetric_difference(result['rendered'])\
+          \ |length==0 }}"
+
+    - name: Gather bfd_interfaces facts from the device and assert that its empty
+      register: result
+      cisco.nxos.nxos_bfd_interfaces:
+        state: gathered
+
+    - name: Make sure that rendered task actually did not make any changes to the
+        device
+      assert:
+        that: "{{ result['gathered'] == [] }}"
+  always:
+
+    - include_tasks: _remove_config.yaml
+
+- debug:
+    msg: END nxos_bfd_interfaces rendered integration tests on connection={{ ansible_connection
+      }}

--- a/tests/integration/targets/nxos_bfd_interfaces/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tests/common/replaced.yaml
@@ -11,14 +11,19 @@
   when: platform is not search('N5K|N6K')
 
 - name: setup1
-  ansible.netcommon.cli_config: &id002
-    config: "no feature bfd\ndefault interface {{ test_int1 }}\n"
+  cisco.nxos.nxos_config: &id002
+    lines: 
+      - "no feature bfd"
+      - "default interface {{ test_int1 }}"
 
 - block:
 
     - name: setup2
-      ansible.netcommon.cli_config:
-        config: "feature bfd\ninterface {{ test_int1 }}\n  no switchport\n"
+      cisco.nxos.nxos_config:
+        lines:
+          - "feature bfd"
+          - "interface {{ test_int1 }}"
+          - "  no switchport"
 
     - name: setup initial bfd state
       cisco.nxos.nxos_bfd_interfaces:
@@ -62,4 +67,4 @@
   always:
 
     - name: teardown
-      ansible.netcommon.cli_config: *id002
+      cisco.nxos.nxos_config: *id002

--- a/tests/integration/targets/nxos_bfd_interfaces/vars/main.yml
+++ b/tests/integration/targets/nxos_bfd_interfaces/vars/main.yml
@@ -1,0 +1,32 @@
+gathered:
+  - name: "{{ nxos_int1 }}"
+    bfd: disable
+    echo: enable
+  - name: "{{ nxos_int2 }}"
+    echo: disable
+    bfd: enable
+  - name: "{{ nxos_int3 }}"
+    bfd: enable
+    echo: enable
+
+parsed:
+  - bfd: disable
+    echo: disable
+    name: Ethernet1/800
+  - bfd: disable
+    echo: enable
+    name: Ethernet1/801
+  - bfd: enable
+    echo: disable
+    name: Ethernet1/802
+  - bfd: enable
+    echo: enable
+    name: mgmt0
+
+rendered:
+  - "interface Ethernet1/800"
+  - "bfd"
+  - "bfd echo"
+  - "interface Ethernet1/801"
+  - "no bfd"
+  - "no bfd echo"


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
Related to #36 

This also fixes an issue in config code. Since gather_subset was hardcoded to be ['!all', '!min], the platform version returned would always be empty. This patch changes it to ["min"] by default and for non-action states + gathered, it'd be ['!all', '!min'].

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
nxos_bfd_interfaces.py