### PR TITLE
Updated nxos.py terminal plugin on_become

### DIFF
--- a/plugins/terminal/nxos.py
+++ b/plugins/terminal/nxos.py
@@ -67,7 +67,7 @@ class TerminalModule(TerminalBase):
     ]
 
     def on_become(self, passwd=None):
-        if self._get_prompt().endswith(b"enable#"):
+        if self._get_prompt().strip().endswith(b"enable#"):
             return
 
         out = self._exec_cli_command("show privilege")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updated on_become to consistentsly strip whitespace before checking to see if prompt ends with "enable#".
Before, it ran 1 check without strip and 1 check with strip.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/terminal/nxos.py

