### PR TITLE
Fix system default generation

### DIFF
--- a/plugins/module_utils/network/nxos/facts/interfaces/interfaces.py
+++ b/plugins/module_utils/network/nxos/facts/interfaces/interfaces.py
@@ -60,7 +60,9 @@ class InterfacesFacts(object):
             data = connection.get(
                 "show running-config all | incl 'system default switchport'"
             )
-            data += connection.get("show running-config | section ^interface")
+            data += "\n" + connection.get(
+                "show running-config | section ^interface"
+            )
 
         # Collect device defaults & per-intf defaults
         self.render_system_defaults(data)

--- a/tests/integration/targets/nxos_interfaces/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_interfaces/tests/common/merged.yaml
@@ -4,6 +4,7 @@
 
 - set_fact:
     test_int1: "{{ nxos_int1 }}"
+    test_int2: "{{ nxos_int2 }}"
 
 - set_fact: enabled=true
   when: platform is not search('N3[5KL]|N[56]K|titanium')
@@ -12,7 +13,9 @@
 
     - name: setup
       cisco.nxos.nxos_config: &id002
-        lines: "default interface {{ test_int1 }}"
+        lines: 
+          - "default interface {{ test_int1 }}"
+          - "default interface {{ test_int2 }}"
 
     - name: Merged
       register: result
@@ -55,7 +58,32 @@
         that:
           - result.changed == false
           - result.commands|length == 0
-  always:
 
+    - name: "Populate {{ test_int2 }}"
+      cisco.nxos.nxos_config:
+        lines:
+          - "description Test"
+          - "switchport"
+          - "no shutdown"
+        parents: "interface {{ test_int2 }}"
+
+    - name: Update interface state
+      cisco.nxos.nxos_interfaces:
+        config:
+          - name: "{{ test_int2 }}"
+            enabled: False
+            mode: layer2
+            description: Test
+        state: merged
+      register: result
+
+    - assert:
+        that:
+          - "'interface {{ test_int2 }}' in result.commands"
+          - "'shutdown' in result.commands"
+          - result.changed == True
+          - result.commands|length == 2
+
+  always:
     - name: teardown
       cisco.nxos.nxos_config: *id002


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- #20 
- Concatenating defaults and interface data without a delimiter causes regexes in render_system_defaults() to not work properly.
- For example, the data passed to render_system_defaults() looks something like:
```
no system default switchport
no system default switchport fabricpath
no system default switchport shutdowninterface Ethernet1/1
  description TEST
  switchport
interface Ethernet1/2
interface Ethernet1/3
interface mgmt0
  ip address dhcp
  vrf member management
interface loopback8
```
As a result, [this](https://github.com/ansible-collections/cisco.nxos/blob/master/plugins/module_utils/network/nxos/facts/interfaces/interfaces.py#L124) doesn't work as expected. We could have modified the regex as well, but that didn't seem right and this patch looks way more cleaner to me.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_interfaces.py