### PR TITLE
httpapi enable issue

### DIFF
--- a/plugins/httpapi/nxos.py
+++ b/plugins/httpapi/nxos.py
@@ -117,7 +117,9 @@ class HttpApi(HttpApiBase):
         device_info = {}
 
         device_info["network_os"] = "nxos"
-        reply, platform_reply = self.send_request(["show version", "show inventory"])
+        reply, platform_reply = self.send_request(
+            ["show version", "show inventory"]
+        )
 
         find_os_version = [
             r"\s+system:\s+version\s*(\S+)",

--- a/plugins/httpapi/nxos.py
+++ b/plugins/httpapi/nxos.py
@@ -108,9 +108,6 @@ class HttpApi(HttpApiBase):
             )
 
         results = handle_response(response_data)
-
-        if self._become:
-            results = results[1:]
         return results
 
     def get_device_info(self):
@@ -221,6 +218,8 @@ def handle_response(response):
                     "%s: %s: %s" % (input_data, msg, clierror),
                     code=output["code"],
                 )
+            elif output.get("input") == "enable":
+                continue
             elif "body" in output:
                 result = output["body"]
                 if isinstance(result, dict):

--- a/plugins/httpapi/nxos.py
+++ b/plugins/httpapi/nxos.py
@@ -117,8 +117,7 @@ class HttpApi(HttpApiBase):
         device_info = {}
 
         device_info["network_os"] = "nxos"
-        reply = self.send_request("show version")
-        platform_reply = self.send_request("show inventory")
+        reply, platform_reply = self.send_request(["show version", "show inventory"])
 
         find_os_version = [
             r"\s+system:\s+version\s*(\S+)",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
With delayed connection start, `self._become` _can_ change from the before the request to after. Rather than blindly stripping responses, from the output, decline to include responses whose input was enable.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/httpapi/nxos