### PR TITLE
Check feature privilege status only if priv escalation is required

### DIFF
--- a/plugins/terminal/nxos.py
+++ b/plugins/terminal/nxos.py
@@ -72,8 +72,6 @@ class TerminalModule(TerminalBase):
 
         out = self._exec_cli_command("show privilege")
         out = to_text(out, errors="surrogate_then_replace").strip()
-        if "Disabled" in out:
-            raise AnsibleConnectionFailure("Feature privilege is not enabled")
 
         # if already at privilege level 15 return
         if "15" in out:
@@ -81,6 +79,9 @@ class TerminalModule(TerminalBase):
 
         if self.validate_user_role():
             return
+
+        if "Disabled" in out:
+            raise AnsibleConnectionFailure("Feature privilege is not enabled")
 
         cmd = {u"command": u"enable"}
         if passwd:


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes #54 
- Currently, on_become() raises an exception if feature privilege is disabled even before checking the current privilege level or calling validate_user_role().
- As a result, a "show privilege" output like the following, with ansible_become set to True, results in the task failing. 
```
User name: test_user
Current privilege level: 15
Feature privilege: Disabled
```
- This patch moves this check to the correct place.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
terminal/nxos.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
