### PR TITLE
Fix for vdc with no interface in N7K

### DIFF
--- a/plugins/module_utils/network/nxos/facts/legacy/base.py
+++ b/plugins/module_utils/network/nxos/facts/legacy/base.py
@@ -260,7 +260,12 @@ class Interfaces(FactsBase):
 
     def populate_structured_interfaces(self, data):
         interfaces = dict()
-        for item in data["TABLE_interface"]["ROW_interface"]:
+        data = data["TABLE_interface"]["ROW_interface"]
+
+        if isinstance(data, dict):
+            data = [data]
+
+        for item in data:
             name = item["interface"]
 
             intf = dict()
@@ -644,8 +649,12 @@ class Legacy(FactsBase):
 
     def parse_structured_interfaces(self, data):
         objects = list()
-        for item in data["TABLE_interface"]["ROW_interface"]:
-            objects.append(item["interface"])
+        data = data["TABLE_interface"]["ROW_interface"]
+        if isinstance(data, dict):
+            objects.append(data["interface"])
+        elif isinstance(data, list):
+            for item in data:
+                objects.append(item["interface"])
         return objects
 
     def parse_structured_vlans(self, data):


### PR DESCRIPTION
SUMMARY
Fixes https://github.com/ansible/ansible/issues/68405
This is the fix for issue in https://github.com/ansible/ansible/issues/68405
The following is the list of changes included in this PR.

nxos/facts/legacy/base.py - While gathering facts, on parsing and populating the interfaces, the data from switch is always treated as list. Because of this in particular scenarios where-in there are no interface, a traceback is seen. The fix now checks if the data is a single interface instance or list and acts accordingly.


ISSUE TYPE
Bugfix Pull Request

COMPONENT NAME
nxos.facts

ADDITIONAL INFORMATION
This issue will be seen while gathering fact when there are no interfaces in default vdc in N7K

