### PR TITLE
Streamline l2_interfaces and l3_interfaces

### DIFF
--- a/plugins/module_utils/network/nxos/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/nxos/config/l3_interfaces/l3_interfaces.py
@@ -70,7 +70,7 @@ class L3_interfaces(ConfigBase):
         )
         self.platform = facts.get("ansible_net_platform", "")
 
-        return remove_rsvd_interfaces(l3_interfaces_facts)
+        return l3_interfaces_facts
 
     def edit_config(self, commands):
         return self._connection.edit_config(commands)
@@ -141,10 +141,6 @@ class L3_interfaces(ConfigBase):
         if config:
             for w in config:
                 w.update({"name": normalize_interface(w["name"])})
-                if get_interface_type(w["name"]) == "management":
-                    self._module.fail_json(
-                        msg="The 'management' interface is not allowed to be managed by this module"
-                    )
                 want.append(remove_empties(w))
         have = deepcopy(existing_l3_interfaces_facts)
         self.init_check_existing(have)
@@ -237,7 +233,6 @@ class L3_interfaces(ConfigBase):
         """
         # overridden behavior is the same as replaced except for scope.
         cmds = []
-        existing_vlans = []
         for i in have:
             obj_in_want = search_obj_in_list(i["name"], want, "name")
             if obj_in_want:

--- a/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
@@ -61,7 +61,7 @@ class L2_interfacesFacts(object):
             conf = conf.strip()
             if conf:
                 obj = self.render_config(self.generated_spec, conf)
-                if obj and len(obj.keys()) > 1:
+                if obj:
                     objs.append(obj)
 
         ansible_facts["ansible_network_resources"].pop("l2_interfaces", None)

--- a/plugins/module_utils/network/nxos/facts/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/nxos/facts/l3_interfaces/l3_interfaces.py
@@ -61,7 +61,7 @@ class L3_interfacesFacts(object):
             conf = conf.strip()
             if conf:
                 obj = self.render_config(self.generated_spec, conf)
-                if obj and len(obj.keys()) > 1:
+                if obj:
                     objs.append(obj)
 
         ansible_facts["ansible_network_resources"].pop("l3_interfaces", None)

--- a/plugins/modules/nxos_l3_interfaces.py
+++ b/plugins/modules/nxos_l3_interfaces.py
@@ -107,6 +107,10 @@ options:
   state:
     description:
     - The state of the configuration after module completion.
+    - The state I(overridden) would override the IP address configuration
+      of all interfaces on the device with the provided configuration in
+      the task. Use caution with this state as you may loose access to the
+      device.
     type: str
     choices:
     - merged
@@ -173,7 +177,8 @@ EXAMPLES = """
   cisco.nxos.nxos_l3_interfaces:
     config:
     - name: Ethernet1/6
-      ipv4: 192.168.22.3/24
+      ipv4:
+        - address: 192.168.22.3/24
     state: replaced
 
 # After state:

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/deleted.yaml
@@ -46,7 +46,6 @@
         that:
           - ansible_facts.network_resources.l2_interfaces|symmetric_difference(result.before)|length
             == 0
-          - result.after|length == 0
           - result.changed == true
           - "'interface {{ test_int1 }}' in result.commands"
           - "'no switchport trunk native vlan' in result.commands"

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/gathered.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/gathered.yaml
@@ -15,7 +15,7 @@
         state: gathered
 
     - assert:
-        that: "{{ result['gathered'] | symmetric_difference(gathered)\
+        that: "{{ result['gathered'][:2] | symmetric_difference(gathered)\
           \ |length == 0 }}"
   always:
 

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/merged.yaml
@@ -33,7 +33,6 @@
     - assert:
         that:
           - result.changed == true
-          - result.before|length == 0
           - "'interface {{ test_int1 }}' in result.commands"
           - "'switchport access vlan 6' in result.commands"
           - "'switchport trunk allowed vlan 200' in result.commands"

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/rendered.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/rendered.yaml
@@ -4,6 +4,11 @@
 
 - include_tasks: _remove_config.yaml
 
+- name: Gather pre-facts
+  cisco.nxos.nxos_facts:
+    gather_subset: ['!all', '!min']
+    gather_network_resources: l2_interfaces
+
 - block:
     - name: Use rendered state to convert task input to device specific commands
       register: result
@@ -34,7 +39,7 @@
     - name: Make sure that rendered task actually did not make any changes to the
         device
       assert:
-        that: "{{ result['gathered'] == [] }}"
+        that: "{{ result['gathered']|symmetric_difference(ansible_facts.network_resources.l2_interfaces) == [] }}"
   always:
 
     - include_tasks: _remove_config.yaml

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/rtt.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/rtt.yaml
@@ -1,0 +1,74 @@
+---
+- debug:
+    msg: START nxos_l2_interfaces round trip integration tests on connection={{ansible_connection }}
+
+- include_tasks: _remove_config.yaml
+
+- block:
+    - name: Prepare interfaces (switch to L2)
+      cisco.nxos.nxos_interfaces:
+        config:
+          - name: "{{ nxos_int1 }}"
+            mode: layer2
+          - name: "{{ nxos_int2 }}"
+            mode: layer2
+          - name: "{{ nxos_int3 }}"
+            mode: layer2
+        state: merged
+
+    - name: Apply the provided configuration (Base config)
+      register: base_config
+      cisco.nxos.nxos_l2_interfaces:
+        config:
+          - name: "{{ nxos_int1 }}"
+            trunk:
+              native_vlan: 10
+              allowed_vlans: 2,4,15
+          - name: "{{ nxos_int2 }}"
+            access:
+              vlan: 30
+        state: merged
+      tags: base_config
+
+    - name: Gather interfaces facts
+      cisco.nxos.nxos_facts:
+        gather_subset:
+          - '!all'
+          - '!min'
+        gather_network_resources:
+          - l2_interfaces
+
+    - name: Apply the provided configuration (config to be reverted)
+      register: result
+      cisco.nxos.nxos_l2_interfaces:
+        config:
+          - name: "{{ nxos_int1 }}"
+            trunk:
+              native_vlan: 20
+          - name: "{{ nxos_int2 }}"
+            access:
+              vlan: 31
+          - name: "{{ nxos_int3 }}"
+            trunk:
+              native_vlan: 20
+              allowed_vlans: 5-10, 15
+        state: overridden
+
+    - assert:
+        that:
+        - result.changed == true
+
+    - name: Revert back to base config using facts round trip
+      register: revert
+      cisco.nxos.nxos_l2_interfaces:
+        config: "{{ ansible_facts['network_resources']['l2_interfaces'] }}"
+        state: overridden
+
+    - assert:
+        that:
+          - "{{ base_config['after'] == revert['after'] }}"
+  always:
+    - include_tasks: _remove_config.yaml
+
+- debug:
+    msg: END nxos_l2_interfaces round trip integration tests on connection={{ansible_connection }}

--- a/tests/integration/targets/nxos_l3_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tasks/main.yaml
@@ -1,19 +1,11 @@
 ---
 - set_fact:
-    rsvd_intf_len: 1
+    rsvd_intf: "{{ rsvd_intf|default('mgmt0') }}"
 
 - block:
-
-    - set_fact:
-        mgmt: "{{ intdataraw|selectattr('interface', 'equalto', 'mgmt0')|list}}"
-
-    - set_fact:
-        rsvd_intf_len: "{{ 1 if (mgmt and 'ip_addr' in mgmt[0]) else 0}}"
-  when: prepare_nxos_tests_task | default(True) | bool
-
-- include: cli.yaml
-  tags:
-    - cli
-- include: nxapi.yaml
-  tags:
-    - nxapi
+  - include: cli.yaml
+    tags:
+      - cli
+  - include: nxapi.yaml
+    tags:
+      - nxapi

--- a/tests/integration/targets/nxos_l3_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tasks/nxapi.yaml
@@ -3,6 +3,7 @@
   find:
     paths: '{{ role_path }}/tests/common'
     patterns: '{{ testcase }}.yaml'
+    use_regex: True
   connection: local
   register: test_cases
 

--- a/tests/integration/targets/nxos_l3_interfaces/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tests/common/deleted.yaml
@@ -6,6 +6,8 @@
     test_int3: '{{ nxos_int3 }}'
     subint3: '{{ nxos_int3 }}.42'
 
+- include_tasks: _remove_config.yaml
+
 - name: setup1
   ignore_errors: true
   cisco.nxos.nxos_config:
@@ -14,10 +16,6 @@
       - "default interface {{ test_int3 }}"
       - "interface {{ test_int3 }}"
       - "  no switchport"
-
-- name: setup2 cleanup all L3 states on all interfaces
-  cisco.nxos.nxos_l3_interfaces:
-    state: deleted
 
 - block:
 
@@ -40,13 +38,13 @@
     - name: deleted
       register: result
       cisco.nxos.nxos_l3_interfaces: &id001
+        config:
+          - name: "{{ subint3 }}"
         state: deleted
 
     - assert:
         that:
-          - result.before|length == (ansible_facts.network_resources.l3_interfaces|length|int
-            - rsvd_intf_len|int)
-          - result.after|length == 0
+          - result.before|symmetric_difference(ansible_facts.network_resources.l3_interfaces) == []
           - result.changed == true
           - "'interface {{ subint3 }}' in result.commands"
           - "'no encapsulation dot1q' in result.commands"

--- a/tests/integration/targets/nxos_l3_interfaces/tests/common/gathered.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tests/common/gathered.yaml
@@ -14,7 +14,7 @@
         state: gathered
 
     - assert:
-        that: "{{ result['gathered'] | symmetric_difference(gathered)\
+        that: "{{ result['gathered'][:2] | symmetric_difference(gathered)\
           \ |length == 0 }}"
   
   always:

--- a/tests/integration/targets/nxos_l3_interfaces/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tests/common/merged.yaml
@@ -6,6 +6,8 @@
     test_int3: '{{ nxos_int3 }}'
     subint3: '{{ nxos_int3 }}.42'
 
+- include_tasks: _remove_config.yaml
+
 - name: setup1
   ignore_errors: true
   cisco.nxos.nxos_config:
@@ -14,10 +16,6 @@
       - "default interface {{ test_int3 }}"
       - "interface {{ test_int3 }}"
       - "  no switchport"
-
-- name: setup2 cleanup all L3 states on all interfaces
-  cisco.nxos.nxos_l3_interfaces:
-    state: deleted
 
 - block:
 
@@ -38,7 +36,6 @@
     - assert:
         that:
           - result.changed == true
-          - result.before|length == 0
           - "'interface {{ subint3 }}' in result.commands"
           - "'encapsulation dot1q 42' in result.commands"
           - "'no ip redirects' in result.commands"
@@ -55,8 +52,7 @@
 
     - assert:
         that:
-          - result.after|length == (ansible_facts.network_resources.l3_interfaces|length|int
-            - rsvd_intf_len|int)
+          - result.after|symmetric_difference(ansible_facts.network_resources.l3_interfaces) == []
 
     - name: Idempotence - Merged
       register: result
@@ -68,8 +64,11 @@
           - result.commands|length == 0
   always:
 
-    - name: teardown
+    - name: teardown sub-interface
       ignore_errors: true
       cisco.nxos.nxos_config:
         lines:
          - "no interface {{ subint3 }}"
+    
+    - include_tasks: _remove_config.yaml
+

--- a/tests/integration/targets/nxos_l3_interfaces/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tests/common/overridden.yaml
@@ -2,6 +2,8 @@
 - debug:
     msg: Start nxos_l3_interfaces overridden integration tests connection={{ ansible_connection }}
 
+- include_tasks: _remove_config.yaml
+
 - set_fact:
     test_int1: "{{ nxos_int1 }}"
     test_int2: "{{ nxos_int2 }}"
@@ -20,10 +22,6 @@
     - "{{ test_int2 }}"
     - "{{ test_int3 }}"
 
-- name: setup2 cleanup all L3 states on all interfaces
-  cisco.nxos.nxos_l3_interfaces:
-    state: deleted
-
 - block:
 
     - name: setup3
@@ -40,22 +38,24 @@
           - '!all'
           - '!min'
         gather_network_resources: l3_interfaces
+    
+    - name: Store reserved interface IP config
+      set_fact:
+        mgmt: "{{ ansible_facts.network_resources.l3_interfaces|selectattr('name', 'equalto', rsvd_intf)|list }}"
+        overriden_config:
+          - name: '{{ test_int3 }}'
+            ipv4:
+              - address: 10.1.1.3/24
 
     - name: Overridden
       register: result
       cisco.nxos.nxos_l3_interfaces: &id002
-        config:
-
-          - name: '{{ test_int3 }}'
-            ipv4:
-
-              - address: 10.1.1.3/24
+        config: "{{ overriden_config + mgmt }}"
         state: overridden
 
     - assert:
         that:
-          - result.before|length == (ansible_facts.network_resources.l3_interfaces|length|int
-            - rsvd_intf_len|int)
+          - result.before|symmetric_difference(ansible_facts.network_resources.l3_interfaces) == []
           - result.changed == true
           - "'interface {{ test_int1 }}' in result.commands"
           - "'no ip address' in result.commands"
@@ -70,8 +70,7 @@
 
     - assert:
         that:
-          - result.after|length == (ansible_facts.network_resources.l3_interfaces|length|int
-            - rsvd_intf_len|int)
+          - result.after|symmetric_difference(ansible_facts.network_resources.l3_interfaces) == []
 
     - name: Idempotence - Overridden
       register: result

--- a/tests/integration/targets/nxos_l3_interfaces/tests/common/parsed.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tests/common/parsed.yaml
@@ -1,6 +1,6 @@
 ---
 - debug:
-    msg: START nxo_l3_interfaces parsed integration tests on connection={{ ansible_connection
+    msg: START nxos_l3_interfaces parsed integration tests on connection={{ ansible_connection
       }}
 
 - block:

--- a/tests/integration/targets/nxos_l3_interfaces/tests/common/rendered.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tests/common/rendered.yaml
@@ -5,6 +5,12 @@
 
 - include_tasks: _remove_config.yaml
 
+
+- name: Gather pre-facts
+  cisco.nxos.nxos_facts:
+    gather_subset: ['!all', '!min']
+    gather_network_resources: l3_interfaces
+
 - block:
     # Interfaces used here doesn't actually exist on the device
     - name: Use rendered state to convert task input to device specific commands
@@ -33,13 +39,12 @@
       cisco.nxos.nxos_l3_interfaces:
         state: gathered
 
-    - name: Make sure that rendered 
+    - name: Make sure that rendered task actually did not make any changes to the device
       assert:
-        that: "{{ result['gathered'] == [] }}"
+        that: "{{ result['gathered']|symmetric_difference(ansible_facts.network_resources.l3_interfaces) == [] }}"
+  
   always:
-
     - include_tasks: _remove_config.yaml
 
 - debug:
-    msg: END nxos_l3_interfaces rendered integration tests on connection={{ ansible_connection
-      }}
+    msg: END nxos_l3_interfaces rendered integration tests on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_l3_interfaces/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tests/common/replaced.yaml
@@ -6,6 +6,8 @@
     test_int3: '{{ nxos_int3 }}'
     subint3: '{{ nxos_int3 }}.42'
 
+- include_tasks: _remove_config.yaml
+
 - name: setup1
   ignore_errors: true
   cisco.nxos.nxos_config:
@@ -14,10 +16,6 @@
       - "default interface {{ test_int3 }}"
       - "interface {{ test_int3 }}"
       - "  no switchport"
-
-- name: setup2 cleanup all L3 states on all interfaces
-  cisco.nxos.nxos_l3_interfaces:
-    state: deleted
 
 - block:
 
@@ -57,8 +55,7 @@
 
     - assert:
         that:
-          - result.before|length == (ansible_facts.network_resources.l3_interfaces|length|int
-            - rsvd_intf_len|int)
+          - result.before|symmetric_difference(ansible_facts.network_resources.l3_interfaces) == []
           - result.changed == true
           - "'interface {{ subint3 }}' in result.commands"
           - "'encapsulation dot1q 442' in result.commands"
@@ -72,8 +69,7 @@
 
     - assert:
         that:
-          - result.after|length == (ansible_facts.network_resources.l3_interfaces|length|int
-            - rsvd_intf_len|int)
+          - result.after|symmetric_difference(ansible_facts.network_resources.l3_interfaces) == []
 
     - name: Idempotence - Replaced
       register: result
@@ -114,8 +110,10 @@
           - result.commands|length == 0
   always:
 
-    - name: teardown
+    - name: teardown sub-interface
       ignore_errors: true
       cisco.nxos.nxos_config:
         lines:
          - "no interface {{ subint3 }}"
+
+    - include_tasks: _remove_config.yaml

--- a/tests/integration/targets/nxos_l3_interfaces/tests/common/rtt.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tests/common/rtt.yaml
@@ -1,0 +1,89 @@
+---
+- debug:
+    msg: START nxos_l3_interfaces round trip integration tests on connection={{ ansible_connection }}
+
+- include_tasks: _remove_config.yaml
+
+- block:
+    - name: Prepare interfaces (switch to L3)
+      cisco.nxos.nxos_interfaces:
+        config:
+          - name: "{{ nxos_int1 }}"
+            mode: layer3
+          - name: "{{ nxos_int2 }}"
+            mode: layer3
+          - name: "{{ nxos_int3 }}"
+            mode: layer3
+        state: merged
+
+    - name: Apply the provided configuration (Base config)
+      register: base_config
+      cisco.nxos.nxos_l3_interfaces:
+        config:
+          - name: "{{ nxos_int1 }}"
+            ipv4:
+              - address: 192.0.2.49/28
+                tag: 5
+              - address: 198.51.100.65/27
+                secondary: true
+                tag: 10
+            ipv6:
+              - address: 2001:db8:2000::1/32
+                tag: 6
+          - name: "{{ nxos_int2 }}"
+            ipv4: 
+              - address: 192.0.2.81/28
+        state: merged
+      tags: base_config
+
+    - name: Gather interfaces facts
+      cisco.nxos.nxos_facts:
+        gather_subset:
+          - '!all'
+          - '!min'
+        gather_network_resources:
+          - l3_interfaces
+    
+    - name: Set reserved interface IP config and config to revert
+      set_fact:
+        mgmt: "{{ ansible_facts.network_resources.l3_interfaces|selectattr('name', 'equalto', rsvd_intf)|list }}"
+        config_to_revert:
+          - name: "{{ nxos_int1 }}"
+            ipv4: 
+              - address: 203.0.113.67/26
+          - name: "{{ nxos_int2 }}"
+            ipv4:
+              - address: 198.51.100.10/24
+                tag: 7
+              - address: 198.51.100.130/25
+                secondary: true
+                tag: 11
+          - name: "{{ nxos_int3 }}"
+            ipv6:
+              - address: 2001:db8::20/32
+                tag: 6
+
+    - name: Apply the provided configuration (config to be reverted)
+      register: result
+      cisco.nxos.nxos_l3_interfaces:
+        config: "{{ config_to_revert + mgmt }}"
+        state: overridden
+
+    - assert:
+        that:
+        - result.changed == true
+
+    - name: Revert back to base config using facts round trip
+      register: revert
+      cisco.nxos.nxos_l3_interfaces:
+        config: "{{ ansible_facts['network_resources']['l3_interfaces'] }}"
+        state: overridden
+
+    - assert:
+        that:
+          - base_config['after'] == revert['after']
+  always:
+    - include_tasks: _remove_config.yaml
+
+- debug:
+    msg: END nxos_l3_interfaces round trip integration tests on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_l3_interfaces/vars/main.yml
+++ b/tests/integration/targets/nxos_l3_interfaces/vars/main.yml
@@ -31,3 +31,6 @@ parsed:
       - address: fd5d:12c9:2201:2::1/64
         tag: 6
     unreachables: True
+  - name: mgmt0
+    ipv4:
+      - address: dhcp


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY

* Both default and non-default interfaces are returned now.

* Removes check for reserved interfaces to ensure 100% round-trip
  with facts.

* Adds round-trip tests.

* A minor documentation fix.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_l2_interfaces.py
nxos_l3_interfaces.py