### PR TITLE
Fix nxos_interfaces state overridden & replaced

### DIFF
--- a/changelogs/102-fix-nxos_interfaces-states.yaml
+++ b/changelogs/102-fix-nxos_interfaces-states.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix nxos_interfaces states replaced and overridden (https://github.com/ansible-collections/cisco.nxos/pull/102).

--- a/plugins/module_utils/network/nxos/config/interfaces/interfaces.py
+++ b/plugins/module_utils/network/nxos/config/interfaces/interfaces.py
@@ -231,32 +231,29 @@ class Interfaces(ConfigBase):
             diff = w
 
         merged_commands = self.set_commands(w, have)
-        if merged_commands:
-            # merged_commands:
-            #   - These commands are changes specified by the playbook.
-            #   - merged_commands apply to both existing and new objects
-            # replaced_commands:
-            #   - These are the unspecified commands, used to reset any params
-            #     that are not already set to default states
-            #   - replaced_commands should only be used on 'have' objects
-            #     (interfaces that already exist)
-            if obj_in_have:
-                if "name" not in diff:
-                    diff["name"] = name
-                wkeys = w.keys()
-                dkeys = diff.keys()
-                for k in wkeys:
-                    if k in self.exclude_params and k in dkeys:
-                        del diff[k]
-                replaced_commands = self.del_attribs(diff)
-                cmds = set(replaced_commands).intersection(
-                    set(merged_commands)
-                )
-                for cmd in cmds:
-                    merged_commands.remove(cmd)
-                commands.extend(replaced_commands)
+        # merged_commands:
+        #   - These commands are changes specified by the playbook.
+        #   - merged_commands apply to both existing and new objects
+        # replaced_commands:
+        #   - These are the unspecified commands, used to reset any params
+        #     that are not already set to default states
+        #   - replaced_commands should only be used on 'have' objects
+        #     (interfaces that already exist)
+        if obj_in_have:
+            if "name" not in diff:
+                diff["name"] = name
+            wkeys = w.keys()
+            dkeys = diff.keys()
+            for k in wkeys:
+                if k in self.exclude_params and k in dkeys:
+                    del diff[k]
+            replaced_commands = self.del_attribs(diff)
+            cmds = set(replaced_commands).intersection(set(merged_commands))
+            for cmd in cmds:
+                merged_commands.remove(cmd)
+            commands.extend(replaced_commands)
 
-            commands.extend(merged_commands)
+        commands.extend(merged_commands)
         return commands
 
     def _state_overridden(self, want, have):

--- a/tests/integration/targets/nxos_interfaces/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_interfaces/tests/common/replaced.yaml
@@ -4,6 +4,7 @@
 
 - set_fact:
     test_int1: "{{ nxos_int1 }}"
+    test_int2: "{{ nxos_int2 }}"
 
 - block:
 
@@ -61,6 +62,37 @@
             that:
               - result.changed == false
               - result.commands|length == 0
+
+        - name: Reset interfaces
+          cisco.nxos.nxos_config:
+            lines:
+              - "default interface {{ test_int1 }}"
+              - "default interface {{ test_int2 }}"
+              - "interface {{ test_int1 }}"
+              - "  description TEST-INTF-1"
+              - "  speed 1000"
+
+        - name: Replace (default existing and add new attributes)
+          cisco.nxos.nxos_interfaces:
+            config:
+              - name: "{{ test_int1 }}"
+                enabled: False
+              - name: "{{ test_int2 }}"
+                description: TEST-INTF-2
+                enabled: True
+            state: replaced
+          register: result
+
+        - assert:
+            that:
+              - "'interface {{ test_int1 }}' in result.commands"
+              - "'no description' in result.commands"
+              - "'no speed' in result.commands"
+              - "'interface {{ test_int2 }}' in result.commands"
+              - "'description TEST-INTF-2' in result.commands"
+              - "'no shutdown' in result.commands"
+              - result.commands|length == 6
+
       always:
 
         - name: teardown


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes #100 
- `state: replaced` was ignoring negate commands if no new attributes were being added for that interface in the task.
- Since `state: overridden` depends on `state: replaced` it is affected too.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_interfaces.py