### PR TITLE
Update lag_interfaces.py

### DIFF
--- a/changelogs/fragments/111_update_lag_interfaces.yaml
+++ b/changelogs/fragments/111_update_lag_interfaces.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fixed force option in lag_interfaces.py (https://github.com/ansible-collections/cisco.nxos/pull/111).

--- a/plugins/module_utils/network/nxos/config/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/nxos/config/lag_interfaces/lag_interfaces.py
@@ -286,8 +286,8 @@ class Lag_interfaces(ConfigBase):
             commands.append("interface" + " " + d["member"])
             cmd = ""
             group_cmd = "channel-group {0}".format(name)
-            if "force" in d:
-                cmd = group_cmd + " force " + d["force"]
+            if "force" in d and d["force"]:
+                cmd = group_cmd + " force "
             if "mode" in d:
                 if cmd:
                     cmd = cmd + " mode " + d["mode"]

--- a/plugins/module_utils/network/nxos/config/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/nxos/config/lag_interfaces/lag_interfaces.py
@@ -286,7 +286,7 @@ class Lag_interfaces(ConfigBase):
             commands.append("interface" + " " + d["member"])
             cmd = ""
             group_cmd = "channel-group {0}".format(name)
-            if "force" in d and d["force"]:
+            if d.get("force"):
                 cmd = group_cmd + " force "
             if "mode" in d:
                 if cmd:


### PR DESCRIPTION
fix error appending boolean to string when force keyword is hitten

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix issue #110 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_lag_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
When used force keyword the code tried to append the boolean value of the "force" option in the string to be send to the device, instead the expected behavior is that, if force is true, only prepare che string "channel-group X force [mode X]"
