### PR TITLE
nxos_user: Do not fail when a custom role is used

### DIFF
--- a/changelogs/fragments/fix_nxos_user_role.yaml
+++ b/changelogs/fragments/fix_nxos_user_role.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - nxos_user - do not fail when a custom role is used (https://github.com/ansible-collections/cisco.nxos/pull/130)

--- a/plugins/modules/nxos_user.py
+++ b/plugins/modules/nxos_user.py
@@ -226,8 +226,9 @@ def get_custom_roles(module):
 
 
 def validate_roles(value, module):
+    valid_roles = BUILTIN_ROLES + get_custom_roles(module)
     for item in value:
-        if item not in BUILTIN_ROLES + get_custom_roles(module):
+        if item not in valid_roles:
             module.fail_json(msg="invalid role specified")
 
 

--- a/plugins/modules/nxos_user.py
+++ b/plugins/modules/nxos_user.py
@@ -173,12 +173,15 @@ commands:
     - name ansible
     - name ansible password password
 """
+import re
+
 from copy import deepcopy
 from functools import partial
 
 from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.nxos import (
     run_commands,
     load_config,
+    get_config,
 )
 from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.nxos import (
     nxos_argument_spec,
@@ -190,7 +193,7 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.u
     to_list,
 )
 
-VALID_ROLES = [
+BUILTIN_ROLES = [
     "network-admin",
     "network-operator",
     "vdc-admin",
@@ -214,9 +217,17 @@ VALID_ROLES = [
 ]
 
 
+def get_custom_roles(module):
+    return re.findall(
+        r"^role name (\S+)",
+        get_config(module, flags=["| include '^role name'"]),
+        re.M,
+    )
+
+
 def validate_roles(value, module):
     for item in value:
-        if item not in VALID_ROLES:
+        if item not in BUILTIN_ROLES + get_custom_roles(module):
             module.fail_json(msg="invalid role specified")
 
 

--- a/tests/integration/targets/nxos_user/tests/common/basic.yaml
+++ b/tests/integration/targets/nxos_user/tests/common/basic.yaml
@@ -14,6 +14,8 @@
       - name: ansibletest_failed
 
       - name: ansibletest_warn
+
+      - name: ansibletest_role
     state: absent
 
 - name: Create user
@@ -93,6 +95,37 @@
   cisco.nxos.nxos_config: *enable
   when: pwdchck
 
+- name: Create a custom role
+  cisco.nxos.nxos_config:
+    lines:
+      - role name customrole
+
+- name: Attempt to create a user with a valid custom role
+  cisco.nxos.nxos_user:
+    name: ansibletest_role
+    role: customrole
+    state: present
+  register: result
+
+- assert:
+    that:
+      - result.changed == True
+      - result.failed == False
+      - '"username ansibletest_role role customrole" in result.commands'
+
+- name: Attempt to create user with invalid role (should fail)
+  cisco.nxos.nxos_user:
+    name: ansibletest_role
+    role: invalid_role
+    state: present
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.failed == True
+      - '"invalid role specified" in result.msg'
+
 - name: tearDown
   register: result
   cisco.nxos.nxos_user: *rem
@@ -101,5 +134,10 @@
     that:
       - result.changed == true
       - '"no username" in result.commands[0]'
+
+- name: Delete custom role
+  cisco.nxos.nxos_config:
+    lines:
+      - no role name customrole
 
 - debug: msg="END connection={{ ansible_connection }} nxos_user basic test"


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes #123 
- The nxos_user module validates the role passed in the task with a predefined list of built-in roles, which becomes a problem when a custom role is used.
- This fix dynamically fetches the list of custom roles from the device and appends it to the predefined list.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_user.py