### PR TITLE
Fix nxos_acl_interfaces facts parsing

### DIFF
--- a/changelogs/fragments/fix_nxos_acl_interfaces.yaml
+++ b/changelogs/fragments/fix_nxos_acl_interfaces.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix regexes in nxos_acl_interfaces facts and some code cleanup (https://github.com/ansible-collections/cisco.nxos/issues/149).

--- a/tests/unit/modules/network/nxos/test_nxos_acl_interfaces.py
+++ b/tests/unit/modules/network/nxos/test_nxos_acl_interfaces.py
@@ -84,7 +84,7 @@ class TestNxosAclInterfacesModule(TestNxosModule):
                         access_groups=[
                             dict(
                                 afi="ipv4",
-                                acls=[dict(name="ACL1v4", direction="in")],
+                                acls=[dict(name="ACL1-v4", direction="in")],
                             )
                         ],
                     )
@@ -92,7 +92,7 @@ class TestNxosAclInterfacesModule(TestNxosModule):
                 state="merged",
             )
         )
-        commands = ["interface Ethernet1/3", "ip access-group ACL1v4 in"]
+        commands = ["interface Ethernet1/3", "ip access-group ACL1-v4 in"]
         self.execute_module(changed=True, commands=commands)
 
     def test_nxos_acl_interfaces_merged_idempotent(self):


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes #149 
- Existing regexes with "\w+" for parsing ACL names doesn't match all possible strings.
- Includes some overall cleanup of facts code.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_acl_interfaces.py