### PR TITLE
Fix rendering of log_adjacency_changes commands

### DIFF
--- a/changelogs/fragments/fix_nxos_ospfv2.yaml
+++ b/changelogs/fragments/fix_nxos_ospfv2.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix rendering of `log-adjacency-changes` commands.

--- a/plugins/module_utils/network/nxos/rm_templates/ospfv2.py
+++ b/plugins/module_utils/network/nxos/rm_templates/ospfv2.py
@@ -33,7 +33,7 @@ def _tmplt_default_information(proc):
 
 def _tmplt_log_adjacency_changes(proc):
     command = "log-adjacency-changes"
-    if proc.get("detail") is True:
+    if proc.get("log_adjacency_changes").get("detail", False) is True:
         command += " detail"
     return command
 

--- a/tests/unit/modules/network/nxos/test_nxos_ospfv2.py
+++ b/tests/unit/modules/network/nxos/test_nxos_ospfv2.py
@@ -76,7 +76,7 @@ class TestNxosOspfv2Module(TestNxosModule):
                                     route_map="direct-connect",
                                 ),
                             ],
-                            log_adjacency_changes=dict(detail=True)
+                            log_adjacency_changes=dict(detail=True),
                         ),
                         dict(
                             process_id="200",

--- a/tests/unit/modules/network/nxos/test_nxos_ospfv2.py
+++ b/tests/unit/modules/network/nxos/test_nxos_ospfv2.py
@@ -76,6 +76,7 @@ class TestNxosOspfv2Module(TestNxosModule):
                                     route_map="direct-connect",
                                 ),
                             ],
+                            log_adjacency_changes=dict(detail=True)
                         ),
                         dict(
                             process_id="200",
@@ -113,6 +114,7 @@ class TestNxosOspfv2Module(TestNxosModule):
             "router-id 203.0.113.20",
             "redistribute eigrp 100 route-map rmap_1",
             "redistribute direct route-map direct-connect",
+            "log-adjacency-changes detail",
             "router ospf 200",
             "router-id 198.51.100.1",
             "area 0.0.0.100 filter-list route-map rmap_1 in",


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes #151
- Fixes #152 
- Correctly process `log_adjacency_changes` dict while computing commands.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
rm_templates/ospfv2.py
