### PR TITLE
Fix regex in nxos_lag_interfaces

### DIFF
--- a/changelogs/fragments/fix_nxos_lag_interfaces.yaml
+++ b/changelogs/fragments/fix_nxos_lag_interfaces.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix regex for parsing configuration in nxos_lag_interfaces.

--- a/plugins/module_utils/network/nxos/facts/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/nxos/facts/lag_interfaces/lag_interfaces.py
@@ -95,7 +95,7 @@ class Lag_interfacesFacts(object):
                 member["member"] = match_intf.group(0)
 
             match_line = re.search(
-                r"channel-group (?P<port_channel>\d+)\s*(?:mode)*\s*(?P<mode>\S+)*",
+                r"channel-group\s(?P<port_channel>\d+)(\smode\s(?P<mode>on|active|passive))?",
                 intf,
             )
             if match_line:

--- a/tests/integration/targets/nxos_lag_interfaces/tests/common/parsed.yaml
+++ b/tests/integration/targets/nxos_lag_interfaces/tests/common/parsed.yaml
@@ -14,6 +14,7 @@
           interface port-channel12
           interface Ethernet1/800
             channel-group 10 mode active
+            no shutdown
           interface Ethernet1/801
             channel-group 10 mode active
           interface Ethernet1/802

--- a/tests/integration/targets/nxos_lag_interfaces/tests/common/parsed.yaml
+++ b/tests/integration/targets/nxos_lag_interfaces/tests/common/parsed.yaml
@@ -13,7 +13,7 @@
           interface port-channel11
           interface port-channel12
           interface Ethernet1/800
-            channel-group 10 mode active
+            channel-group 10
             no shutdown
           interface Ethernet1/801
             channel-group 10 mode active

--- a/tests/integration/targets/nxos_lag_interfaces/vars/main.yml
+++ b/tests/integration/targets/nxos_lag_interfaces/vars/main.yml
@@ -19,7 +19,6 @@ rendered:
 parsed:
   - members:
       - member: Ethernet1/800
-        mode: active
       - member: Ethernet1/801
         mode: active
     name: port-channel10


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes #147 
- The regex in facts code was incorrectly parsing the config line that followed "channel-group <group-number> mode <on|active|passive>".

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
facts/lag_interfaces.py