### PR TITLE
Allow other transfer protocols than scp in nxos_file_copy module.

### DIFF
--- a/changelogs/fragments/161-transfer_protocol_file_copy.yaml
+++ b/changelogs/fragments/161-transfer_protocol_file_copy.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Allow other transfer protocols than scp to pull files from a NXOS device in nxos_file_copy module. sftp, http, https, tftp and ftp can be choosen as a transfer protocol, when the file_pull parameter is true..

--- a/plugins/action/nxos_file_copy.py
+++ b/plugins/action/nxos_file_copy.py
@@ -59,6 +59,7 @@ class ActionModule(ActionBase):
             file_system=dict(type="str", default="bootflash:"),
             file_pull=dict(type="bool", default=False),
             file_pull_timeout=dict(type="int", default=300),
+            file_pull_protocol=dict(type="str", default="scp", choices=['scp', 'sftp', 'http', 'https', 'tftp', 'ftp']),
             file_pull_compact=dict(type="bool", default=False),
             file_pull_kstack=dict(type="bool", default=False),
             local_file=dict(type="path"),
@@ -99,6 +100,13 @@ class ActionModule(ActionBase):
                 raise AnsibleError(
                     "argument %s is of type %s and we were unable to convert to %s: %s"
                     % (key, type(playvals[key]), option_type, to_native(e))
+                )
+
+            if "choices" in argument_spec[key] and playvals[key] not in argument_spec[key].get("choices"):
+                raise AnsibleError(
+                    "argument {0} with value {1} is not valid. Allowed values are {2}". format(
+                        key, playvals[key], ", ".join(argument_spec[key].get("choices"))
+                    )
                 )
 
         # Validate playbook dependencies
@@ -280,7 +288,7 @@ class ActionModule(ActionBase):
         port = self.playvals["connect_ssh_port"]
 
         # Build copy command components that will be used to initiate copy from the nxos device.
-        cmdroot = "copy scp://"
+        cmdroot = "copy " +  self.playvals["file_pull_protocol"] + "://"
         ruser = self.playvals["remote_scp_server_user"] + "@"
         rserver = self.playvals["remote_scp_server"]
         rfile = self.playvals["remote_file"] + " "

--- a/plugins/action/nxos_file_copy.py
+++ b/plugins/action/nxos_file_copy.py
@@ -62,7 +62,7 @@ class ActionModule(ActionBase):
             file_pull_protocol=dict(
                 type="str",
                 default="scp",
-                choices=['scp', 'sftp', 'http', 'https', 'tftp', 'ftp'],
+                choices=["scp", "sftp", "http", "https", "tftp", "ftp"],
             ),
             file_pull_compact=dict(type="bool", default=False),
             file_pull_kstack=dict(type="bool", default=False),
@@ -110,7 +110,7 @@ class ActionModule(ActionBase):
                 key
             ] not in argument_spec[key].get("choices"):
                 raise AnsibleError(
-                    "argument {0} with value {1} is not valid. Allowed values are {2}". format(
+                    "argument {0} with value {1} is not valid. Allowed values are {2}".format(
                         key,
                         playvals[key],
                         ", ".join(argument_spec[key].get("choices")),

--- a/plugins/action/nxos_file_copy.py
+++ b/plugins/action/nxos_file_copy.py
@@ -59,7 +59,11 @@ class ActionModule(ActionBase):
             file_system=dict(type="str", default="bootflash:"),
             file_pull=dict(type="bool", default=False),
             file_pull_timeout=dict(type="int", default=300),
-            file_pull_protocol=dict(type="str", default="scp", choices=['scp', 'sftp', 'http', 'https', 'tftp', 'ftp']),
+            file_pull_protocol=dict(
+                type="str",
+                default="scp",
+                choices=['scp', 'sftp', 'http', 'https', 'tftp', 'ftp'],
+            ),
             file_pull_compact=dict(type="bool", default=False),
             file_pull_kstack=dict(type="bool", default=False),
             local_file=dict(type="path"),
@@ -102,10 +106,14 @@ class ActionModule(ActionBase):
                     % (key, type(playvals[key]), option_type, to_native(e))
                 )
 
-            if "choices" in argument_spec[key] and playvals[key] not in argument_spec[key].get("choices"):
+            if "choices" in argument_spec[key] and playvals[
+                key
+            ] not in argument_spec[key].get("choices"):
                 raise AnsibleError(
                     "argument {0} with value {1} is not valid. Allowed values are {2}". format(
-                        key, playvals[key], ", ".join(argument_spec[key].get("choices"))
+                        key,
+                        playvals[key],
+                        ", ".join(argument_spec[key].get("choices")),
                     )
                 )
 
@@ -288,7 +296,7 @@ class ActionModule(ActionBase):
         port = self.playvals["connect_ssh_port"]
 
         # Build copy command components that will be used to initiate copy from the nxos device.
-        cmdroot = "copy " +  self.playvals["file_pull_protocol"] + "://"
+        cmdroot = "copy " + self.playvals["file_pull_protocol"] + "://"
         ruser = self.playvals["remote_scp_server_user"] + "@"
         rserver = self.playvals["remote_scp_server"]
         rfile = self.playvals["remote_file"] + " "

--- a/plugins/modules/nxos_file_copy.py
+++ b/plugins/modules/nxos_file_copy.py
@@ -78,6 +78,20 @@ options:
       the operation is NOT idempotent.
     type: bool
     default: false
+  file_pull_protocol:
+    description:
+    - When file_pull is True, this can be used to define the transfer protocol for
+      copying file from remote to the NXOS device.
+    - When (file_pull is False), this is not used.
+    default: 'scp'
+    choices:
+    - scp
+    - sftp
+    - ftp
+    - http
+    - https
+    - tftp
+    type: str
   file_pull_compact:
     description:
     - When file_pull is True, this is used to compact nxos image files. This option
@@ -138,6 +152,19 @@ EXAMPLES = """
     file_pull: true
     local_file: xyz
     local_file_directory: dir1/dir2/dir3
+    remote_file: /mydir/abc
+    remote_scp_server: 192.168.0.1
+    remote_scp_server_user: myUser
+    remote_scp_server_password: myPassword
+    vrf: management
+
+# Initiate file copy from the nxos device to transfer file from a ftp server back to the nxos device.
+# remote_scp_server_user and remote_scp_server_password are used to login to the FTP server.
+- name: initiate file copy from device
+  cisco.nxos.nxos_file_copy:
+    file_pull: true
+    file_pull_protocol: ftp
+    local_file: xyz
     remote_file: /mydir/abc
     remote_scp_server: 192.168.0.1
     remote_scp_server_user: myUser

--- a/tests/integration/targets/nxos_file_copy/meta/main.yml
+++ b/tests/integration/targets/nxos_file_copy/meta/main.yml
@@ -1,2 +1,3 @@
 ---
 dependencies:
+  - prepare_nxos_tests

--- a/tests/integration/targets/nxos_file_copy/tests/cli/input_validation.yaml
+++ b/tests/integration/targets/nxos_file_copy/tests/cli/input_validation.yaml
@@ -68,4 +68,19 @@
       - result is search('Playbook parameters <remote_scp_server>, <remote_scp_server_user>
         must be set together')
 
+- name: Input Validation - param <file_pull_protocol> should only accept strings, which are included in choices
+  register: result
+  ignore_errors: true
+  cisco.nxos.nxos_file_copy:
+    file_pull: true
+    file_pull_protocol: foobar
+    remote_file: /network-integration.cfg
+    remote_scp_server: foobar
+    remote_scp_server_user: foobar
+
+- assert:
+    that:
+      - result is search("argument file_pull_protocol with value foobar is not valid.
+        Allowed values are scp, sftp, http, https, tftp, ftp")
+
 - debug: msg="END nxos_file_copy input_validation test"

--- a/tests/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
+++ b/tests/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
@@ -5,6 +5,9 @@
     test_source_file: "data.cfg"
     test_destination_file: "test_destination_file"
 
+- set_fact:
+    sftp_root_dir: "{% if major_version is version('9.2', 'ge') %}/bootflash{% else %}/{% endif %}"
+
 - name: Setup - Remove existing file
   ignore_errors: true
   cisco.nxos.nxos_command: &id002
@@ -150,7 +153,7 @@
         file_pull: true
         file_pull_protocol: sftp
         file_pull_timeout: 30
-        remote_file: /bootflash/{{ test_destination_file }}
+        remote_file: "{{ sftp_root_dir }}/{{ test_destination_file }}"
         local_file: '{{ test_destination_file }}_another_copy'
         local_file_directory: dir1/dir2/dir3
         remote_scp_server: '{{ mgmt0_ip }}'
@@ -164,7 +167,7 @@
           - "'copy sftp:' in result.copy_cmd"
           - "'bootflash:' in result.file_system"
           - "'bootflash:dir1/dir2/dir3/{{ test_destination_file }}_another_copy' in result.local_file"
-          - "'/bootflash/{{ test_destination_file }}' in result.remote_file"
+          - "'{{ sftp_root_dir }}/{{ test_destination_file }}' in result.remote_file"
 
           - "'Received: File copied/pulled to nxos device from remote scp server.'\
             \ in result.transfer_status"

--- a/tests/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
+++ b/tests/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
@@ -30,17 +30,19 @@
     feature: sftp-server
     state: enabled
 
-- name: Setup - Backup admin password
+- name: Setup - Backup admin password if ansible_user is not admin
   cisco.nxos.nxos_command:
     commands:
       - command: show running-config | include "username admin password"
   register: nxos_admin_password
   no_log: true
+  when: ansible_user != "admin"
 
-- name: Setup - Change admin password
+- name: Setup - Change admin password if ansible_user is not admin
   cisco.nxos.nxos_user:
     name: admin
     configured_password: "{{ temp_passwd }}"
+  when: ansible_user != "admin"
 
 - block:
 
@@ -158,7 +160,7 @@
         local_file_directory: dir1/dir2/dir3
         remote_scp_server: '{{ mgmt0_ip }}'
         remote_scp_server_user: admin
-        remote_scp_server_password: "{{ temp_passwd }}"
+        remote_scp_server_password: "{% if ansible_user == 'admin' %}{{ ansible_password }}{% else %}{{ temp_passwd }}{% endif %}"
         connect_ssh_port: '{{ ansible_ssh_port }}'
 
     - assert:
@@ -179,11 +181,12 @@
       cisco.nxos.nxos_command: *id002
 
 
-    - name: Recover the admin password
+    - name: Recover the admin password if ansible_user is not admin
       cisco.nxos.nxos_config:
         lines:
           - "{{ nxos_admin_password['stdout_lines'][0][0] }}"
       no_log: true
+      when: ansible_user != "admin"
 
     - name: Turn off feature scp-server
       cisco.nxos.nxos_feature:

--- a/tests/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
+++ b/tests/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
@@ -22,6 +22,23 @@
     feature: scp-server
     state: enabled
 
+- name: Setup - Turn on feature sftp-server
+  cisco.nxos.nxos_feature:
+    feature: sftp-server
+    state: enabled
+
+- name: Setup - Backup admin password
+  cisco.nxos.nxos_command:
+    commands:
+      - command: show running-config | include "username admin password"
+  register: nxos_admin_password
+  no_log: true
+
+- name: Setup - Change admin password
+  cisco.nxos.nxos_user:
+    name: admin
+    configured_password: "{{ temp_passwd }}"
+
 - block:
 
     - name: Copy {{ test_source_file }} file from Ansible controller to bootflash
@@ -125,15 +142,54 @@
       cisco.nxos.nxos_file_copy: *id005
 
     - assert: *id006
+
+    - name: Initiate copy with sftp from nxos device to copy /bootflash/{{ test_destination_file }} to
+        bootflash:dir2/dir2/dir3/{{ test_destination_file }}_another_copy
+      register: result
+      cisco.nxos.nxos_file_copy:
+        file_pull: true
+        file_pull_protocol: sftp
+        file_pull_timeout: 30
+        remote_file: /bootflash/{{ test_destination_file }}
+        local_file: '{{ test_destination_file }}_another_copy'
+        local_file_directory: dir1/dir2/dir3
+        remote_scp_server: '{{ mgmt0_ip }}'
+        remote_scp_server_user: admin
+        remote_scp_server_password: "{{ temp_passwd }}"
+        connect_ssh_port: '{{ ansible_ssh_port }}'
+
+    - assert:
+        that:
+          - result.changed == true
+          - "'copy sftp:' in result.copy_cmd"
+          - "'bootflash:' in result.file_system"
+          - "'bootflash:dir1/dir2/dir3/{{ test_destination_file }}_another_copy' in result.local_file"
+          - "'/bootflash/{{ test_destination_file }}' in result.remote_file"
+
+          - "'Received: File copied/pulled to nxos device from remote scp server.'\
+            \ in result.transfer_status"
+          - "'{{ mgmt0_ip }}' in result.remote_scp_server"
   
   always:
     - name: Remove file
       ignore_errors: true
       cisco.nxos.nxos_command: *id002
 
+
+    - name: Recover the admin password
+      cisco.nxos.nxos_config:
+        lines:
+          - "{{ nxos_admin_password['stdout_lines'][0][0] }}"
+      no_log: true
+
     - name: Turn off feature scp-server
       cisco.nxos.nxos_feature:
         feature: scp-server
+        state: disabled
+
+    - name: Turn off feature sftp-server
+      cisco.nxos.nxos_feature:
+        feature: sftp-server
         state: disabled
 
     - debug: msg="END connection={{ ansible_connection }} nxos_file_copy sanity


### PR DESCRIPTION
##### SUMMARY
At the moment only scp can be used as a transfer protocol to pull files from a NXOS device in the nxos_file_copy module. Instead of hardcoding the protocol in the copy command, this PR will allow additional set of transfer protocols to be used. For this purpose I have introduced a new module parameter file_pull_protocol.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
nxos_file_copy

##### ADDITIONAL INFORMATION
I have tested the functionality after my code change with sftp, ftp and http protocols on a NXOS device with version 9.3(4) and 7.0.(3).I(7). Furthermore I have implemented two additional integration test cases to test the module with the new parameter. 

The sanity integration test will change temporarily the admin password of the NXOS device to be able to use sftp. The password of the admin user will be recovered at the end of the sanity test. It is a restriction by NXOS that only the admin user can access the switch with sftp.
