### PR TITLE
Fix ansible-collections#166 - Support FEX Fabric mode on nxos_l2_interfaces

### DIFF
--- a/changelogs/fragments/add_fex_fabric_l2_inteerfaces.yaml
+++ b/changelogs/fragments/add_fex_fabric_l2_inteerfaces.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Allow `fex-fabric` option for mode key (https://github.com/ansible-collections/cisco.nxos/issues/166).

--- a/plugins/module_utils/network/nxos/argspec/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/argspec/l2_interfaces/l2_interfaces.py
@@ -45,7 +45,7 @@ class L2_interfacesArgs(object):  # pylint: disable=R0903
                     "options": {"vlan": {"type": "int"}},
                     "type": "dict",
                 },
-                "mode": {"type": "str", "choices": ["access", "trunk"]},
+                "mode": {"type": "str", "choices": ["access", "trunk", "fex-fabric"]},
                 "name": {"required": True, "type": "str"},
                 "trunk": {
                     "options": {

--- a/plugins/module_utils/network/nxos/argspec/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/argspec/l2_interfaces/l2_interfaces.py
@@ -45,7 +45,10 @@ class L2_interfacesArgs(object):  # pylint: disable=R0903
                     "options": {"vlan": {"type": "int"}},
                     "type": "dict",
                 },
-                "mode": {"type": "str", "choices": ["access", "trunk", "fex-fabric"]},
+                "mode": {
+                    "type": "str",
+                    "choices": ["access", "trunk", "fex-fabric"],
+                },
                 "name": {"required": True, "type": "str"},
                 "trunk": {
                     "options": {

--- a/plugins/modules/nxos_l2_interfaces.py
+++ b/plugins/modules/nxos_l2_interfaces.py
@@ -93,6 +93,7 @@ options:
         choices:
         - access
         - trunk
+        - fex-fabric
   state:
     description:
     - The state of the configuration after module completion.

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/parsed.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/parsed.yaml
@@ -14,6 +14,8 @@
             switchport trunk allowed vlan 210
           interface Ethernet1/801
             switchport trunk allowed vlan 2,4,15
+          interface Ethernet1/802
+            switchport mode fex-fabric
         state: parsed
 
     - assert:

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/rendered.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/rendered.yaml
@@ -25,6 +25,8 @@
             trunk:
               native_vlan: 20
               allowed_vlans: 5-10, 15
+          - name: Ethernet1/4
+            mode: fex-fabric
         state: rendered
         
     - assert:

--- a/tests/integration/targets/nxos_l2_interfaces/vars/main.yml
+++ b/tests/integration/targets/nxos_l2_interfaces/vars/main.yml
@@ -18,6 +18,8 @@ parsed:
   - name: Ethernet1/801
     trunk:
       allowed_vlans: "2,4,15"
+  - name: Ethernet1/802
+    mode: fex-fabric
 
 rendered:
   - "interface Ethernet1/1"
@@ -28,3 +30,5 @@ rendered:
   - "interface Ethernet1/3"
   - "switchport trunk allowed vlan 5,6,7,8,9,10,15"
   - "switchport trunk native vlan 20"
+  - "interface Ethernet1/4"
+  - "switchport mode fex-fabric"


### PR DESCRIPTION


##### SUMMARY

Allow for interface switchport mode to be fex-fabric, opening up
modification of other interfaces which are in trunk & access mode

Fixes #166 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_l2_interfaces
##### ADDITIONAL INFORMATION