### PR TITLE
Update vlan fabricpath mode regex

### DIFF
--- a/changelogs/fragments/vlans-fabricpath-mode-regex.yaml
+++ b/changelogs/fragments/vlans-fabricpath-mode-regex.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Update regex to accept the platform "N77" as supporting fabricpath.

--- a/plugins/module_utils/network/nxos/config/vlans/vlans.py
+++ b/plugins/module_utils/network/nxos/config/vlans/vlans.py
@@ -329,7 +329,7 @@ class Vlans(ConfigBase):
     def _sanitize(self, vlans):
         sanitized_vlans = []
         for vlan in vlans:
-            if not re.search("N[567]K", self._platform):
+            if not re.search("N[567][7K]", self._platform):
                 if "mode" in vlan:
                     del vlan["mode"]
             sanitized_vlans.append(remove_empties(vlan))


### PR DESCRIPTION
##### SUMMARY
Update regex to accept the platform "N77" as supporting fabricpath.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
N/A

##### ADDITIONAL INFORMATION
Regex was failing for platforms such as "N77-C7706".
