### PR TITLE
Fix vlan config diff to remove default states

### DIFF
--- a/changelogs/fragments/fix_vlan_diff.yaml
+++ b/changelogs/fragments/fix_vlan_diff.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Vlan config diff was not removing default values

--- a/plugins/module_utils/network/nxos/config/vlans/vlans.py
+++ b/plugins/module_utils/network/nxos/config/vlans/vlans.py
@@ -189,8 +189,7 @@ class Vlans(ConfigBase):
         """
         obj_in_have = search_obj_in_list(want["vlan_id"], have, "vlan_id")
         if obj_in_have:
-            # ignore states that are already reset, then diff what's left
-            obj_in_have = self.remove_default_states(obj_in_have)
+            # Diff the want and have
             diff = dict_diff(want, obj_in_have)
             # Remove merge items from diff; what's left will be used to
             # remove states not specified in the playbook
@@ -198,6 +197,9 @@ class Vlans(ConfigBase):
                 diff.pop(k, None)
         else:
             diff = want
+
+        # Remove default states from resulting diff
+        diff = self.remove_default_states(diff)
 
         # merged_cmds: 'want' cmds to update 'have' states that don't match
         # replaced_cmds: remaining 'have' cmds that need to be reset to default

--- a/tests/unit/modules/network/nxos/test_nxos_vlans.py
+++ b/tests/unit/modules/network/nxos/test_nxos_vlans.py
@@ -253,3 +253,31 @@ class TestNxosVlansModule(TestNxosModule):
         playbook["_ansible_check_mode"] = True
         set_module_args(playbook, ignore_provider_arg)
         self.execute_module(changed=True, commands=replaced)
+
+    def test_5(self):
+        """
+        Idempotency test
+        """
+
+        self.prepare()
+        # Misc tests to hit codepaths highlighted by code coverage tool as missed.
+        playbook = dict(config=[
+            dict(vlan_id=1, name='default', enabled=True),
+            dict(vlan_id=3, name='test-vlan3', enabled=True),
+            dict(vlan_id=4, enabled=True),
+            dict(vlan_id=5, name='test-changeme', mapped_vni=942, state='suspend', enabled=False),
+            dict(vlan_id=8, name='test-changeme-not', state='suspend', enabled=False),
+            ])
+
+        
+        playbook["state"] = "merged"
+        set_module_args(playbook, ignore_provider_arg)
+        r = self.execute_module(changed=False)
+
+        playbook["state"] = "overridden"
+        set_module_args(playbook, ignore_provider_arg)
+        r = self.execute_module(changed=False)
+
+        playbook["state"] = "replaced"
+        set_module_args(playbook, ignore_provider_arg)
+        r = self.execute_module(changed=False)

--- a/tests/unit/modules/network/nxos/test_nxos_vlans.py
+++ b/tests/unit/modules/network/nxos/test_nxos_vlans.py
@@ -260,15 +260,27 @@ class TestNxosVlansModule(TestNxosModule):
         """
 
         self.prepare()
-        playbook = dict(config=[
-            dict(vlan_id=1, name='default', enabled=True),
-            dict(vlan_id=3, name='test-vlan3', enabled=True),
-            dict(vlan_id=4, enabled=True),
-            dict(vlan_id=5, name='test-changeme', mapped_vni=942, state='suspend', enabled=False),
-            dict(vlan_id=8, name='test-changeme-not', state='suspend', enabled=False),
-            ])
+        playbook = dict(
+            config=[
+                dict(vlan_id=1, name="default", enabled=True),
+                dict(vlan_id=3, name="test-vlan3", enabled=True),
+                dict(vlan_id=4, enabled=True),
+                dict(
+                    vlan_id=5,
+                    name="test-changeme",
+                    mapped_vni=942,
+                    state="suspend",
+                    enabled=False,
+                ),
+                dict(
+                    vlan_id=8,
+                    name="test-changeme-not",
+                    state="suspend",
+                    enabled=False,
+                ),
+            ]
+        )
 
-        
         playbook["state"] = "merged"
         set_module_args(playbook, ignore_provider_arg)
         r = self.execute_module(changed=False)

--- a/tests/unit/modules/network/nxos/test_nxos_vlans.py
+++ b/tests/unit/modules/network/nxos/test_nxos_vlans.py
@@ -260,7 +260,6 @@ class TestNxosVlansModule(TestNxosModule):
         """
 
         self.prepare()
-        # Misc tests to hit codepaths highlighted by code coverage tool as missed.
         playbook = dict(config=[
             dict(vlan_id=1, name='default', enabled=True),
             dict(vlan_id=3, name='test-vlan3', enabled=True),


### PR DESCRIPTION
##### SUMMARY
Fixed an issue with the vlan config generation, where default values were not being properly removed. 

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
When making changes to vlan config default values remained in the commands list. The code removed default values from the existing config, but not from the resulting diff. 

Tested on Nexus 7K platform. 
