### PR TITLE
Drop ansible in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-ansible
 paramiko
 scp


### PR DESCRIPTION
Due to how ansible / ansible-base works we need to remove ansible here.
Otherwise, our devel jobs are testing 2.10.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>