### PR TITLE
Fix nxos_lag_interfaces error when no port-channel members exist

### DIFF
--- a/changelogs/fragments/fix_nxos_lag_interfaces.yaml
+++ b/changelogs/fragments/fix_nxos_lag_interfaces.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix for nxos_lag_interfaces issue (https://github.com/ansible-collections/cisco.nxos/pull/194).

--- a/plugins/module_utils/network/nxos/config/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/nxos/config/lag_interfaces/lag_interfaces.py
@@ -304,6 +304,8 @@ class Lag_interfaces(ConfigBase):
         if not obj_in_have:
             commands = self.add_commands(w["members"], w["name"])
         else:
+            if 'members' not in obj_in_have:
+                obj_in_have["members"] = None
             diff = self.diff_list_of_dicts(
                 w["members"], obj_in_have["members"]
             )

--- a/plugins/module_utils/network/nxos/config/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/nxos/config/lag_interfaces/lag_interfaces.py
@@ -304,7 +304,7 @@ class Lag_interfaces(ConfigBase):
         if not obj_in_have:
             commands = self.add_commands(w["members"], w["name"])
         else:
-            if 'members' not in obj_in_have:
+            if "members" not in obj_in_have:
                 obj_in_have["members"] = None
             diff = self.diff_list_of_dicts(
                 w["members"], obj_in_have["members"]

--- a/tests/integration/targets/nxos_lag_interfaces/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_lag_interfaces/tests/common/merged.yaml
@@ -63,6 +63,39 @@
     - assert:
         that:
           - result.changed == false
+
+    - name: Add new port-channel with no members
+      ignore_errors: true
+      cisco.nxos.nxos_config:
+        lines:
+          - interface port-channel 11
+
+    - name: Merged - No Members
+      register: result
+      cisco.nxos.nxos_lag_interfaces: &id003
+        config:
+
+          - name: port-channel11
+            members:
+
+              - member: '{{ test_int1 }}'
+
+              - member: '{{ test_int2 }}'
+                mode: true
+        state: merged
+
+    - assert:
+        that:
+          - result.changed == true
+
+    - name: Idempotence - Merged - No Members
+      register: result
+      cisco.nxos.nxos_lag_interfaces: *id003
+
+    - assert:
+        that:
+          - result.changed == false
+
   always:
 
     - name: Teardown


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/cisco.nxos/issues/193

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_lag_interfaces

Integration test step added to defend against this.