### PR TITLE
Make OSPF modules work properly when process_id is a string

### DIFF
--- a/changelogs/fragments/fix_ospf_process_id.yaml
+++ b/changelogs/fragments/fix_ospf_process_id.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Make sure that the OSPF modules work properly when process_id is a string (https://github.com/ansible-collections/cisco.nxos/issues/198).

--- a/plugins/module_utils/network/nxos/rm_templates/ospfv2.py
+++ b/plugins/module_utils/network/nxos/rm_templates/ospfv2.py
@@ -253,7 +253,7 @@ class Ospfv2Template(NetworkTemplate):
             ),
             "setval": "router ospf {{ process_id }}",
             "result": {
-                "process_id": "{{ process_id|int }}",
+                "process_id": "{{ process_id }}",
             },
             "shared": True,
         },

--- a/plugins/module_utils/network/nxos/rm_templates/ospfv3.py
+++ b/plugins/module_utils/network/nxos/rm_templates/ospfv3.py
@@ -203,7 +203,7 @@ class Ospfv3Template(NetworkTemplate):
             ),
             "setval": "router ospfv3 {{ process_id }}",
             "result": {
-                "process_id": "{{ process_id|int }}",
+                "process_id": "{{ process_id }}",
             },
             "shared": True,
         },

--- a/tests/unit/modules/network/nxos/test_nxos_ospfv2.py
+++ b/tests/unit/modules/network/nxos/test_nxos_ospfv2.py
@@ -558,3 +558,31 @@ class TestNxosOspfv2Module(TestNxosModule):
 
         result = self.execute_module(changed=True)
         self.assertEqual(set(result["commands"]), set(commands))
+
+    def test_nxos_ospfv2_process_id_word(self):
+        self.get_config.return_value = dedent(
+            """\
+            router ospf 100
+              router-id 203.0.113.20
+            router ospf TEST-1
+              router-id 198.51.100.1
+            """
+        )
+        set_module_args(
+            dict(
+                config=dict(
+                    processes=[
+                        dict(process_id="100", router_id="203.0.113.20"),
+                        dict(process_id="TEST-1", router_id="198.51.100.1"),
+                        dict(process_id="TEST-2", router_id="198.52.200.1"),
+                    ]
+                ),
+                state="merged",
+            ),
+            ignore_provider_arg,
+        )
+
+        commands = ["router ospf TEST-2", "router-id 198.52.200.1"]
+
+        result = self.execute_module(changed=True)
+        self.assertEqual(set(result["commands"]), set(commands))

--- a/tests/unit/modules/network/nxos/test_nxos_ospfv3.py
+++ b/tests/unit/modules/network/nxos/test_nxos_ospfv3.py
@@ -2230,3 +2230,31 @@ class TestNxosOspfv3Module(TestNxosModule):
         }
         result = self.execute_module(changed=False)
         self.assertEqual(set(result["gathered"]), set(gathered))
+
+    def test_nxos_ospfv3_process_id_word(self):
+        self.get_config.return_value = dedent(
+            """\
+            router ospfv3 100
+              router-id 203.0.113.20
+            router ospfv3 TEST-1
+              router-id 198.51.100.1
+            """
+        )
+        set_module_args(
+            dict(
+                config=dict(
+                    processes=[
+                        dict(process_id="100", router_id="203.0.113.20"),
+                        dict(process_id="TEST-1", router_id="198.51.100.1"),
+                        dict(process_id="TEST-2", router_id="198.52.200.1"),
+                    ]
+                ),
+                state="merged",
+            ),
+            ignore_provider_arg,
+        )
+
+        commands = ["router ospfv3 TEST-2", "router-id 198.52.200.1"]
+
+        result = self.execute_module(changed=True)
+        self.assertEqual(set(result["commands"]), set(commands))


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes #198 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
rm_templates/ospfv2.py
rm_templates/ospfv3.py

