### PR TITLE
Improve nxos_vxlan_vtep module documentation

### DIFF
--- a/changelogs/fragments/204-improve-nxos-vxlan-vtep-module-docs.yaml
+++ b/changelogs/fragments/204-improve-nxos-vxlan-vtep-module-docs.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix error in ``host_reachability`` parameter's example where a default value is used, which the ``host_reachability`` parameter does not support. Improve descriptions of some parameters to be more explicit. Correct spelling and grammar where errors were noticed.

--- a/changelogs/fragments/204-improve-nxos-vxlan-vtep-module-docs.yaml
+++ b/changelogs/fragments/204-improve-nxos-vxlan-vtep-module-docs.yaml
@@ -1,3 +1,3 @@
 ---
-bugfixes:
+doc_changes:
   - Fix error in ``host_reachability`` parameter's example where a default value is used, which the ``host_reachability`` parameter does not support. Improve descriptions of some parameters to be more explicit. Correct spelling and grammar where errors were noticed.

--- a/docs/cisco.nxos.nxos_vxlan_vtep_module.rst
+++ b/docs/cisco.nxos.nxos_vxlan_vtep_module.rst
@@ -132,7 +132,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>Specify mechanism for host reachability advertisement.</div>
+                        <div>Specify mechanism for host reachability advertisement. A Boolean value of 'true' indicates that BGP will be used for host reachability advertisement. A Boolean value of 'false' indicates that no protocol is used for host reachability advertisement. Other host reachability advertisement protocols (e.g. OpenFlow, controller, etc.) are not supported.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/cisco.nxos.nxos_vxlan_vtep_module.rst
+++ b/docs/cisco.nxos.nxos_vxlan_vtep_module.rst
@@ -495,7 +495,7 @@ Examples
     - cisco.nxos.nxos_vxlan_vtep:
         interface: nve1
         description: default
-        host_reachability: default
+        host_reachability: true
         source_interface: Loopback0
         source_interface_hold_down_time: 30
         shutdown: default

--- a/docs/cisco.nxos.nxos_vxlan_vtep_module.rst
+++ b/docs/cisco.nxos.nxos_vxlan_vtep_module.rst
@@ -64,7 +64,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>Configures ingress replication protocol as bgp for all VNIs This is available on NX-OS 9K series running 9.2.x or higher.</div>
+                        <div>Configures ingress replication protocol as bgp for all VNIs. This is available on Nexus 9000 series switches running NX-OS software release 9.2(x) or higher.</div>
                 </td>
             </tr>
             <tr>
@@ -79,7 +79,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Global multicast IP prefix for L2 VNIs or the keyword &#x27;default&#x27; This is available on NX-OS 9K series running 9.2.x or higher.</div>
+                        <div>Global multicast IP prefix for L2 VNIs or the keyword &#x27;default&#x27;. This is available on Nexus 9000 series switches running NX-OS software release 9.2(x) or higher.</div>
                 </td>
             </tr>
             <tr>
@@ -94,7 +94,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Global multicast IP prefix for L3 VNIs or the keyword &#x27;default&#x27; This is available on NX-OS 9K series running 9.2.x or higher.</div>
+                        <div>Global multicast IP prefix for L3 VNIs or the keyword &#x27;default&#x27;. This is available on Nexus 9000 series switches running NX-OS software release 9.2(x) or higher.</div>
                 </td>
             </tr>
             <tr>
@@ -113,7 +113,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>Enables ARP suppression for all VNIs This is available on NX-OS 9K series running 9.2.x or higher.</div>
+                        <div>Enables ARP suppression for all VNIs. This is available on Nexus 9000 series switches running NX-OS software release 9.2(x) or higher.</div>
                 </td>
             </tr>
             <tr>
@@ -164,7 +164,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Specify the loopback interface whose IP address should be used for the NVE Multisite Border-gateway Interface. This is available on selected NX-OS 9K series running 7.0(3)I7 or higher. Specify &quot;default&quot; to remove an exiting gateway config.</div>
+                        <div>Specify the loopback interface whose IP address should be used for the NVE Multisite Border-gateway Interface. This is available on specific Nexus 9000 series switches running NX-OS 7.0(3)I7(x) or higher. Specify &quot;default&quot; to remove an exiting gateway config.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/cisco.nxos.nxos_vxlan_vtep_module.rst
+++ b/docs/cisco.nxos.nxos_vxlan_vtep_module.rst
@@ -79,7 +79,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Global multicast ip prefix for L2 VNIs or the keyword &#x27;default&#x27; This is available on NX-OS 9K series running 9.2.x or higher.</div>
+                        <div>Global multicast IP prefix for L2 VNIs or the keyword &#x27;default&#x27; This is available on NX-OS 9K series running 9.2.x or higher.</div>
                 </td>
             </tr>
             <tr>
@@ -94,7 +94,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Global multicast ip prefix for L3 VNIs or the keyword &#x27;default&#x27; This is available on NX-OS 9K series running 9.2.x or higher.</div>
+                        <div>Global multicast IP prefix for L3 VNIs or the keyword &#x27;default&#x27; This is available on NX-OS 9K series running 9.2.x or higher.</div>
                 </td>
             </tr>
             <tr>

--- a/plugins/modules/nxos_vxlan_vtep.py
+++ b/plugins/modules/nxos_vxlan_vtep.py
@@ -48,7 +48,11 @@ options:
     type: str
   host_reachability:
     description:
-    - Specify mechanism for host reachability advertisement.
+    - Specify mechanism for host reachability advertisement.  A Boolean value of 'true'
+      indicates that BGP will be used for host reachability advertisement. A Boolean
+      value of 'false' indicates that no protocol is used for host reachability advertisement.
+      Other host reachability advertisement protocols (e.g. OpenFlow, controller, etc.) are not
+      supported.
     type: bool
   shutdown:
     description:
@@ -64,23 +68,23 @@ options:
     type: str
   global_mcast_group_L3:
     description:
-    - Global multicast ip prefix for L3 VNIs or the keyword 'default' This is available
-      on NX-OS 9K series running 9.2.x or higher.
+    - Global multicast IP prefix for L3 VNIs or the keyword 'default'. This is available on
+      Nexus 9000 series switches running NX-OS software release 9.2(x) or higher.
     type: str
   global_mcast_group_L2:
     description:
-    - Global multicast ip prefix for L2 VNIs or the keyword 'default' This is available
-      on NX-OS 9K series running 9.2.x or higher.
+    - Global multicast IP prefix for L2 VNIs or the keyword 'default'. This is available on
+      Nexus 9000 series switches running NX-OS software release 9.2(x) or higher.
     type: str
   global_suppress_arp:
     description:
-    - Enables ARP suppression for all VNIs This is available on NX-OS 9K series running
+    - Enables ARP suppression for all VNIs. This is available on NX-OS 9K series running
       9.2.x or higher.
     type: bool
   global_ingress_replication_bgp:
     description:
-    - Configures ingress replication protocol as bgp for all VNIs This is available
-      on NX-OS 9K series running 9.2.x or higher.
+    - Configures ingress replication protocol as bgp for all VNIs. This is available on Nexus
+      9000 series switches running NX-OS software release 9.2(x) or higher.
     type: bool
   state:
     description:
@@ -93,9 +97,9 @@ options:
   multisite_border_gateway_interface:
     description:
     - Specify the loopback interface whose IP address should be used for the NVE
-      Multisite Border-gateway Interface. This is available on selected NX-OS 9K
-      series running 7.0(3)I7 or higher. Specify "default" to remove an exiting
-      gateway config.
+      Multisite Border-gateway Interface. This is available on specific Nexus 9000
+      series switches running NX-OS 7.0(3)I7(x) or higher. Specify "default" to remove
+      an existing gateway config.
     type: str
     version_added: 1.1.0
 """
@@ -103,7 +107,7 @@ EXAMPLES = """
 - cisco.nxos.nxos_vxlan_vtep:
     interface: nve1
     description: default
-    host_reachability: default
+    host_reachability: true
     source_interface: Loopback0
     source_interface_hold_down_time: 30
     shutdown: default


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/cisco.nxos/pull/209

##### SUMMARY
This PR improves the documentation for the nxos_vxlan_vtep module. Specifically:

* Fix an error in the example where a value of `default` is used for the `host_reachability` parameter, even though the `default` value is not supported for this parameter.
* Improve the description of the `host_reachability` parameter.
* Improve the description of parameters that are applicable to specific series of switches and/or specific NX-OS software releases.
* Correct spelling/grammar where errors were noticed.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
nxos_vxlan_vtep
