### PR TITLE
Support vlan interface in static routes.

### DIFF
--- a/changelogs/fragments/205-support-vlan-interface-in-static-routes.yaml
+++ b/changelogs/fragments/205-support-vlan-interface-in-static-routes.yaml
@@ -1,0 +1,3 @@
+---
+doc_changes:
+  - Fix static_routes module skip vlan interface bug.

--- a/plugins/module_utils/network/nxos/facts/static_routes/static_routes.py
+++ b/plugins/module_utils/network/nxos/facts/static_routes/static_routes.py
@@ -122,9 +122,9 @@ class Static_routesFacts(object):
 
         # ethernet1/2/23
         iface = re.match(
-            r".* (Ethernet|loopback|mgmt|port\-channel)(\S*) .*", conf
+            r".* (Ethernet|Vlan|loopback|mgmt|port\-channel)(\S*) .*", conf
         )
-        i = ["Ethernet", "loopback", "mgmt", "port-channel"]
+        i = ["Ethernet", "Vlan", "loopback", "mgmt", "port-channel"]
         if iface and iface.group(1) in i:
             inner_dict["interface"] = (iface.group(1)) + (iface.group(2))
             conf = re.sub(inner_dict["interface"], "", conf)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Support vlan interface in static routes like below:
```
ip route 0.0.0.0/0 Vlan10 xxx
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
static_routes

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Currently the static_routes module would skip Vlan interface in static routes, so every time we run the commands in this case, it would generate diff and re add the routes even the before and after is same.
```
