### PR TITLE
Fix ospf interface do not come up with diff when do not configure secondary

### DIFF
--- a/changelogs/fragments/205-fix-ospf-interface-jinjia2-bug.yaml
+++ b/changelogs/fragments/205-fix-ospf-interface-jinjia2-bug.yaml
@@ -1,0 +1,2 @@
+doc_changes:
+  - Fix ospf interface never come up with diff when configure area without secondaries bug.

--- a/plugins/module_utils/network/nxos/rm_templates/ospf_interfaces.py
+++ b/plugins/module_utils/network/nxos/rm_templates/ospf_interfaces.py
@@ -67,7 +67,7 @@ class Ospf_interfacesTemplate(NetworkTemplate):
             ),
             "setval": "{{ 'ip' if afi == 'ipv4' else 'ipv6' }} "
                       "router {{ 'ospf' if afi == 'ipv4' else 'ospfv3' }} "
-                      "{{ process_id }} area {{ area.area_id }}{{ ' secondaries none' if area.secondaries|default('True') == False}}",
+                      "{{ process_id }} area {{ area.area_id }}{{ ' secondaries none' if area.secondaries|default('True') == False else '' }}",
             "result": {
                 "{{ name }}": {
                     "address_family": {


### PR DESCRIPTION
…ondaries.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ospf_interface

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
If the ospf interface do not configure secondary, it would through out the exception below.
```
"/tmp/ansible_cisco.nxos.nxos_ospf_interfaces_payload_5yx4i9ud/ansible_cisco.nxos.nxos_ospf_interfaces_payload.zip/ansible_collections/ansible/netcommon/plugins/module_utils/network/common/utils.py", line 740, in __call__
      File "/usr/local/lib/python3.5/dist-packages/jinja2/environment.py", line 1008, in render
        return self.environment.handle_exception(exc_info, True)
      File "/usr/local/lib/python3.5/dist-packages/jinja2/environment.py", line 780, in handle_exception
        reraise(exc_type, exc_value, tb)
      File "/usr/local/lib/python3.5/dist-packages/jinja2/_compat.py", line 37, in reraise
        raise value.with_traceback(tb)
      File "<template>", line 1, in top-level template code
    jinja2.exceptions.UndefinedError: the inline if-expression on line 1 evaluated to false and no else section was defined.

```
