### PR TITLE
nxos_config: let device to throw an error if config replace is not supported

### DIFF
--- a/changelogs/fragments/nxos_config_replace.yaml
+++ b/changelogs/fragments/nxos_config_replace.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - `config replace` is actually supported for devices other than N9K and hence we shouldn't fail, and instead let the device handle it (https://github.com/ansible-collections/cisco.nxos/issues/215).
+  - "'config replace' is actually supported for devices other than N9K and hence we shouldn't fail, and instead let the device handle it (https://github.com/ansible-collections/cisco.nxos/issues/215)."

--- a/changelogs/fragments/nxos_config_replace.yaml
+++ b/changelogs/fragments/nxos_config_replace.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - `config replace` is actually supported for devices other than N9K and hence we shouldn't fail, and instead let the device handle it (https://github.com/ansible-collections/cisco.nxos/issues/215).

--- a/docs/cisco.nxos.nxos_config_module.rst
+++ b/docs/cisco.nxos.nxos_config_module.rst
@@ -510,7 +510,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>Instructs the module on the way to perform the configuration on the device.  If the replace argument is set to <em>line</em> then the modified lines are pushed to the device in configuration mode.  If the replace argument is set to <em>block</em> then the entire command block is pushed to the device in configuration mode if any line is not correct. replace <em>config</em> is supported only on Nexus 9K device.</div>
+                        <div>Instructs the module on the way to perform the configuration on the device.  If the replace argument is set to <em>line</em> then the modified lines are pushed to the device in configuration mode.  If the replace argument is set to <em>block</em> then the entire command block is pushed to the device in configuration mode if any line is not correct. replace <em>config</em> will only work for NX-OS versions that support `config replace`.</div>
                 </td>
             </tr>
             <tr>
@@ -525,7 +525,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>The <em>replace_src</em> argument provides path to the configuration file to load into the remote system. This argument is used to replace the entire config with a flat-file. This is used with argument <em>replace</em> with value <em>config</em>. This is mutually exclusive with the <em>lines</em> and <em>src</em> arguments. This argument is supported on Nexus 9K device. Use <em>nxos_file_copy</em> module to copy the flat file to remote device and then use the path with this argument.</div>
+                        <div>The <em>replace_src</em> argument provides path to the configuration file to load into the remote system. This argument is used to replace the entire config with a flat-file. This is used with argument <em>replace</em> with value <em>config</em>. This is mutually exclusive with the <em>lines</em> and <em>src</em> arguments. This argument will only work for NX-OS versions that support `config replace`. Use <em>nxos_file_copy</em> module to copy the flat file to remote device and then use the path with this argument.</div>
                 </td>
             </tr>
             <tr>

--- a/plugins/cliconf/nxos.py
+++ b/plugins/cliconf/nxos.py
@@ -228,10 +228,8 @@ class Cliconf(CliconfBase):
 
         if replace:
             device_info = self.get_device_info()
-            if "9K" not in device_info.get("network_os_platform", ""):
-                raise ConnectionError(
-                    message=u"replace is supported only on Nexus 9K devices"
-                )
+            # not all NX-OS versions support `config replace`
+            # we let the device throw the invalid command error
             candidate = "config replace {0}".format(replace)
 
         if commit:

--- a/plugins/modules/nxos_config.py
+++ b/plugins/modules/nxos_config.py
@@ -63,8 +63,8 @@ options:
       into the remote system. This argument is used to replace the entire config with
       a flat-file. This is used with argument I(replace) with value I(config). This
       is mutually exclusive with the I(lines) and I(src) arguments. This argument
-      is supported on Nexus 9K device. Use I(nxos_file_copy) module to copy the flat
-      file to remote device and then use the path with this argument.
+      will only work for NX-OS versions that support `config replace`. Use I(nxos_file_copy)
+      module to copy the flat file to remote device and then use the path with this argument.
     type: str
   before:
     description:
@@ -103,8 +103,8 @@ options:
       the replace argument is set to I(line) then the modified lines are pushed to
       the device in configuration mode.  If the replace argument is set to I(block)
       then the entire command block is pushed to the device in configuration mode
-      if any line is not correct. replace I(config) is supported only on Nexus 9K
-      device.
+      if any line is not correct. replace I(config) will only work for NX-OS versions
+      that support `config replace`.
     default: line
     choices:
     - line


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes #215 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_config.py