### PR TITLE
Add "fabricpath" to mode choices for l2 interfaces ( FIX for issue #220)

### DIFF
--- a/changelogs/fragments/fix_l2_interfaces_mode_fabricpath
+++ b/changelogs/fragments/fix_l2_interfaces_mode_fabricpath
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Add support for interfaces in mode 'fabricpath' to l2_interfaces (https://github.com/ansible-collections/cisco.nxos/issues/220).

--- a/plugins/module_utils/network/nxos/argspec/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/argspec/l2_interfaces/l2_interfaces.py
@@ -47,7 +47,7 @@ class L2_interfacesArgs(object):  # pylint: disable=R0903
                 },
                 "mode": {
                     "type": "str",
-                    "choices": ["access", "trunk", "fex-fabric"],
+                    "choices": ["access", "trunk", "fex-fabric", "fabricpath"],
                 },
                 "name": {"required": True, "type": "str"},
                 "trunk": {

--- a/plugins/modules/nxos_l2_interfaces.py
+++ b/plugins/modules/nxos_l2_interfaces.py
@@ -94,6 +94,7 @@ options:
         - access
         - trunk
         - fex-fabric
+        - fabricpath
   state:
     description:
     - The state of the configuration after module completion.

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/parsed.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/parsed.yaml
@@ -21,6 +21,8 @@
             switchport trunk allowed vlan 2,4,15
           interface Ethernet1/802
             switchport mode fex-fabric
+          interface Ethernet1/803
+            switchport mode fabricpath
           interface loopback1
         state: parsed
 

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/rendered.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/rendered.yaml
@@ -27,6 +27,8 @@
               allowed_vlans: 5-10, 15
           - name: Ethernet1/4
             mode: fex-fabric
+          - name: Ethernet1/5
+            mode: fabricpath
         state: rendered
         
     - assert:

--- a/tests/integration/targets/nxos_l2_interfaces/vars/main.yml
+++ b/tests/integration/targets/nxos_l2_interfaces/vars/main.yml
@@ -21,6 +21,8 @@ parsed:
       allowed_vlans: "2,4,15"
   - name: Ethernet1/802
     mode: fex-fabric
+  - name: Ethernet1/803
+    mode: fabricpath
   - name: loopback1
 
 rendered:
@@ -34,3 +36,5 @@ rendered:
   - "switchport trunk native vlan 20"
   - "interface Ethernet1/4"
   - "switchport mode fex-fabric"
+  - "interface Ethernet1/5"
+  - "switchport mode fabricpath"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #220

Add "fabricpath" as additional mode choice in:
cisco.nxos/plugins/module_utils/network/nxos/argspec/l2_interfaces/l2_interfaces.py

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
cisco.nxos/plugins/module_utils/network/nxos/argspec/l2_interfaces/l2_interfaces.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
nxos_facts experiences fatal error when it discovers an interface in mode "fabricpath".  Changing choices from 'access', 'trunk', 'fex-fabric' to include 'fabricpath'
```
