### PR TITLE
nxos_acls: Add echo_request option

### DIFF
--- a/changelogs/fragments/nxos_acls.yaml
+++ b/changelogs/fragments/nxos_acls.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Add `echo_request` option for ICMP.

--- a/docs/cisco.nxos.nxos_acls_module.rst
+++ b/docs/cisco.nxos.nxos_acls_module.rst
@@ -698,6 +698,30 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>echo_request</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li>yes</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Echo request (ping)</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>general_parameter_problem</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/plugins/module_utils/network/nxos/argspec/acls/acls.py
+++ b/plugins/module_utils/network/nxos/argspec/acls/acls.py
@@ -132,6 +132,9 @@ class AclsArgs(object):  # pylint: disable=R0903
                                                 },
                                                 "echo": {"type": "bool"},
                                                 "echo_reply": {"type": "bool"},
+                                                "echo_request": {
+                                                    "type": "bool"
+                                                },
                                                 "general_parameter_problem": {
                                                     "type": "bool"
                                                 },

--- a/plugins/module_utils/network/nxos/facts/acls/acls.py
+++ b/plugins/module_utils/network/nxos/facts/acls/acls.py
@@ -158,6 +158,7 @@ class AclsFacts(object):
                 "conversion_error",
                 "dod_host_prohibited",
                 "dod_net_prohibited",
+                "echo_request",
                 "echo",
                 "echo_reply",
                 "general_parameter_problem",
@@ -266,6 +267,11 @@ class AclsFacts(object):
                             for option in protocol_options[pro]:
                                 option = re.sub("_", "-", option)
                                 if option in ace:
+                                    if (
+                                        option == "echo"
+                                        and "echo_request" in options
+                                    ):
+                                        continue
                                     option = re.sub("-", "_", option)
                                     options.update({option: True})
                             if options:

--- a/plugins/modules/nxos_acls.py
+++ b/plugins/modules/nxos_acls.py
@@ -230,6 +230,9 @@ options:
                       echo_reply:
                         description: Echo reply
                         type: bool
+                      echo_request:
+                        description: Echo request (ping)
+                        type: bool
                       general_parameter_problem:
                         description: Parameter problem
                         type: bool

--- a/tests/unit/modules/network/nxos/test_nxos_acls.py
+++ b/tests/unit/modules/network/nxos/test_nxos_acls.py
@@ -96,7 +96,19 @@ class TestNxosAclsModule(TestNxosModule):
                                         protocol_options=dict(
                                             tcp=dict(ack=True)
                                         ),
-                                    )
+                                    ),
+                                    dict(
+                                        grant="deny",
+                                        destination=dict(
+                                            prefix="2002:2:2:2::/64"
+                                        ),
+                                        source=dict(prefix="2002:1:1:1::/64"),
+                                        sequence=30,
+                                        protocol="icmp",
+                                        protocol_options=dict(
+                                            icmp=dict(echo_request=True)
+                                        ),
+                                    ),
                                 ],
                             )
                         ],
@@ -109,6 +121,7 @@ class TestNxosAclsModule(TestNxosModule):
         commands = [
             "ip access-list ACL2v4",
             "20 deny tcp any any ack fragments",
+            "30 deny icmp 2002:1:1:1::/64 2002:2:2:2::/64 echo-request",
             "ipv6 access-list ACL2v6",
         ]
         self.execute_module(changed=True, commands=commands)


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- For IPv6 ACLs, `echo_request` is a valid option.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

