### PR TITLE
Enable no_log for sensitive parameters in argspec

### DIFF
--- a/changelogs/fragments/mask_sensitive_values.yaml
+++ b/changelogs/fragments/mask_sensitive_values.yaml
@@ -1,0 +1,3 @@
+---
+security_fixes:
+  - Enable no_log for sensitive parameters in argspec. 

--- a/plugins/modules/nxos_aaa_server.py
+++ b/plugins/modules/nxos_aaa_server.py
@@ -268,7 +268,7 @@ def main():
         server_type=dict(
             type="str", choices=["radius", "tacacs"], required=True
         ),
-        global_key=dict(type="str"),
+        global_key=dict(type="str", no_log=True),
         encrypt_type=dict(type="str", choices=["0", "7"]),
         deadtime=dict(type="str"),
         server_timeout=dict(type="str"),

--- a/plugins/modules/nxos_pim_interface.py
+++ b/plugins/modules/nxos_pim_interface.py
@@ -525,7 +525,7 @@ def main():
         interface=dict(type="str", required=True),
         sparse=dict(type="bool", default=False),
         dr_prio=dict(type="str"),
-        hello_auth_key=dict(type="str"),
+        hello_auth_key=dict(type="str", no_log=True),
         hello_interval=dict(type="int"),
         jp_policy_out=dict(type="str"),
         jp_policy_in=dict(type="str"),

--- a/plugins/modules/nxos_snmp_user.py
+++ b/plugins/modules/nxos_snmp_user.py
@@ -302,7 +302,7 @@ def main():
     argument_spec = dict(
         user=dict(required=True, type="str"),
         group=dict(type="str"),
-        pwd=dict(type="str"),
+        pwd=dict(type="str", no_log=True),
         privacy=dict(type="str"),
         authentication=dict(choices=["md5", "sha"]),
         encrypt=dict(type="bool"),

--- a/plugins/modules/nxos_vrrp.py
+++ b/plugins/modules/nxos_vrrp.py
@@ -349,7 +349,7 @@ def main():
             choices=["shutdown", "no shutdown", "default"],
             default="shutdown",
         ),
-        authentication=dict(required=False, type="str"),
+        authentication=dict(required=False, type="str", no_log=True),
         state=dict(
             choices=["absent", "present"], required=False, default="present"
         ),


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Enable no_log for sensitive parameters in argspec.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
nxos_aaa_server.py
nxos_pim_interface.py
nxos_snmp_user.py
nxos_vrrp.py