### PR TITLE
nxos_snmp_community: properly handle partial matches in community string

### DIFF
--- a/changelogs/fragments/nxos_snmp_community.yaml
+++ b/changelogs/fragments/nxos_snmp_community.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Properly handle partial matches in community string (https://github.com/ansible-collections/cisco.nxos/issues/203).

--- a/plugins/modules/nxos_snmp_community.py
+++ b/plugins/modules/nxos_snmp_community.py
@@ -127,7 +127,7 @@ def get_snmp_groups(module):
 
 
 def get_snmp_community(module, name):
-    command = "show run snmp all | grep {0}".format(name)
+    command = "show run snmp all | grep word-exp {0}".format(name)
     data = execute_show_command(command, module)[0]
     community_dict = {}
 

--- a/tests/integration/targets/nxos_snmp_community/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_snmp_community/tests/common/sanity.yaml
@@ -136,9 +136,9 @@
     - name: Idempotence Check
       register: result
       cisco.nxos.nxos_snmp_community: *id009
-    
+
     - assert: *id004
-    
+
     - name: Add partial match community
       register: result
       cisco.nxos.nxos_snmp_community:
@@ -146,7 +146,7 @@
         access: rw
         acl: default
         state: present
-    
+
     - assert:
         that:
           - result.changed == True

--- a/tests/integration/targets/nxos_snmp_community/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_snmp_community/tests/common/sanity.yaml
@@ -2,10 +2,17 @@
 - debug: msg="START connection={{ ansible_connection }} nxos_snmp_community sanity
     test"
 
-- name: Setup - Remove snmp_community if configured
+- name: Setup - Remove snmp_community if configured - 1
   ignore_errors: true
   cisco.nxos.nxos_snmp_community: &id005
     community: TESTING7
+    group: network-operator
+    state: absent
+
+- name: Setup - Remove snmp_community if configured - 2
+  ignore_errors: true
+  cisco.nxos.nxos_snmp_community: &id010
+    community: TEST
     group: network-operator
     state: absent
 
@@ -129,12 +136,28 @@
     - name: Idempotence Check
       register: result
       cisco.nxos.nxos_snmp_community: *id009
-
+    
     - assert: *id004
+    
+    - name: Add partial match community
+      register: result
+      cisco.nxos.nxos_snmp_community:
+        community: TEST
+        access: rw
+        acl: default
+        state: present
+    
+    - assert:
+        that:
+          - result.changed == True
+          - "'snmp-server community TEST group network-admin' in result.commands"
   always:
 
     - name: Cleanup
       cisco.nxos.nxos_snmp_community: *id005
+    
+    - name: Cleanup
+      cisco.nxos.nxos_snmp_community: *id010
 
     - debug: msg="END connection={{ ansible_connection }} nxos_snmp_community sanity
         test"


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes https://github.com/ansible-collections/cisco.nxos/issues/203

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_snmp_community.py
