### PR TITLE
Add support size and df_bit options for nxos_ping 

### DIFF
--- a/changelogs/fragments/237_nxos_ping_df_size.yaml
+++ b/changelogs/fragments/237_nxos_ping_df_size.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Add support df_bit and size option for nxos_ping (https://github.com/ansible-collections/cisco.nxos/pull/237).

--- a/plugins/modules/nxos_ping.py
+++ b/plugins/modules/nxos_ping.py
@@ -53,6 +53,15 @@ options:
     description:
     - Outgoing VRF.
     type: str
+  df_bit:
+    description:
+    - Set the DF bit.
+    default: false
+    type: bool
+  size:
+    description:
+    - Size of packets to send.
+    type: int
   state:
     description:
     - Determines if the expected result is success or fail.
@@ -83,6 +92,13 @@ EXAMPLES = """
   - 8.8.8.8
   - 4.4.4.4
   - 198.6.1.4
+
+- name: Test reachability to 8.8.8.8 using mgmt vrf, size and df-bit
+  cisco.nxos.nxos_ping:
+    dest: 8.8.8.8
+    df_bit: true
+    size: 1400
+    vrf: management
 """
 
 RETURN = """
@@ -172,6 +188,8 @@ def get_ping_results(command, module):
             destination=module.params["dest"],
             vrf=module.params["vrf"],
             source=module.params["source"],
+            size=module.params["size"],
+            df_bit=module.params["df_bit"],
         )
 
     elif "can't bind to address" in ping:
@@ -199,6 +217,8 @@ def main():
         count=dict(required=False, default=5, type="int"),
         vrf=dict(required=False),
         source=dict(required=False),
+        size=dict(required=False, type="int"),
+        df_bit=dict(required=False, default=False, type="bool"),
         state=dict(
             required=False, choices=["present", "absent"], default="present"
         ),
@@ -212,12 +232,20 @@ def main():
 
     destination = module.params["dest"]
     state = module.params["state"]
+    size = module.params["size"]
+    df_bit = module.params["df_bit"]
 
     ping_command = "ping {0}".format(destination)
     for command in ["count", "source", "vrf"]:
         arg = module.params[command]
         if arg:
             ping_command += " {0} {1}".format(command, arg)
+
+    if size:
+        ping_command += " packet-size {0}".format(size)
+
+    if df_bit:
+        ping_command += " df-bit"
 
     summary, rtt, ping_pass = get_ping_results(ping_command, module)
 

--- a/plugins/modules/nxos_ping.py
+++ b/plugins/modules/nxos_ping.py
@@ -85,13 +85,13 @@ EXAMPLES = """
 
 - name: Test reachability to a few different public IPs using mgmt vrf
   cisco.nxos.nxos_ping:
-    dest: nxos_ping
+    dest: "{{ item }}"
     vrf: management
     host: 68.170.147.165
   with_items:
-  - 8.8.8.8
-  - 4.4.4.4
-  - 198.6.1.4
+    - 8.8.8.8
+    - 4.4.4.4
+    - 198.6.1.4
 
 - name: Test reachability to 8.8.8.8 using mgmt vrf, size and df-bit
   cisco.nxos.nxos_ping:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add support size and df_bit options for `nxos_ping` module.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- `nxos_ping`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
- cisco.nxos.nxos_ping:
    dest: 8.8.8.8
    df_bit: true
    size: 1400
    vrf: management
```
executes  bellow comamnd.

```
ping 8.8.8.8 count 5 vrf management packet-size 1400 df-bit
```
