### PR TITLE
Deprecate legacy BGP modules

### DIFF
--- a/changelogs/fragments/depr_bgp.yaml
+++ b/changelogs/fragments/depr_bgp.yaml
@@ -1,0 +1,3 @@
+---
+deprecated_features:
+  - Deprecated `nxos_bgp` and `nxos_bgp_neighbor` modules in favor of `nxos_bgp_global` resource module.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -401,10 +401,24 @@ plugin_routing:
       redirect: cisco.nxos.nxos_bfd_interfaces
     bgp:
       redirect: cisco.nxos.nxos_bgp
+      deprecation:
+        removal_date: '2023-01-27'
+        warning_text: See the plugin documentation for more details
+    nxos_bgp:
+      deprecation:
+        removal_date: '2023-01-27'
+        warning_text: See the plugin documentation for more details
     bgp_af:
       redirect: cisco.nxos.nxos_bgp_af
     bgp_neighbor:
       redirect: cisco.nxos.nxos_bgp_neighbor
+      deprecation:
+        removal_date: '2023-01-27'
+        warning_text: See the plugin documentation for more details
+    nxos_bgp_neighbor:
+      deprecation:
+        removal_date: '2023-01-27'
+        warning_text: See the plugin documentation for more details
     bgp_neighbor_af:
       redirect: cisco.nxos.nxos_bgp_neighbor_af
     command:

--- a/plugins/modules/nxos_bgp.py
+++ b/plugins/modules/nxos_bgp.py
@@ -24,13 +24,17 @@ DOCUMENTATION = """
 module: nxos_bgp
 extends_documentation_fragment:
 - cisco.nxos.nxos
-short_description: Manages BGP configuration.
+short_description: (deprecated, removed after 2023-01-27) Manages BGP configuration.
 description:
 - Manages BGP configurations on NX-OS switches.
 version_added: 1.0.0
 author:
 - Jason Edelman (@jedelman8)
 - Gabriele Gerbino (@GGabriele)
+deprecated:
+  alternative: nxos_bgp_global
+  why: Updated module released with more functionality.
+  removed_at_date: '2023-01-27'
 notes:
 - Tested against NXOSv 7.3.(0)D1(1) on VIRL
 - C(state=absent) removes the whole BGP ASN configuration when C(vrf=default) or the

--- a/plugins/modules/nxos_bgp_neighbor.py
+++ b/plugins/modules/nxos_bgp_neighbor.py
@@ -24,11 +24,15 @@ DOCUMENTATION = """
 module: nxos_bgp_neighbor
 extends_documentation_fragment:
 - cisco.nxos.nxos
-short_description: Manages BGP neighbors configurations.
+short_description: (deprecated, removed after 2023-01-27) Manages BGP neighbors configurations.
 description:
 - Manages BGP neighbors configurations on NX-OS switches.
 version_added: 1.0.0
 author: Gabriele Gerbino (@GGabriele)
+deprecated:
+  alternative: nxos_bgp_global
+  why: Updated module released with more functionality.
+  removed_at_date: '2023-01-27'
 notes:
 - Tested against NXOSv 7.3.(0)D1(1) on VIRL
 - C(state=absent) removes the whole BGP neighbor configuration.

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -25,3 +25,7 @@ plugins/modules/nxos_smu.py validate-modules:deprecation-mismatch # 2.9 expects 
 plugins/modules/nxos_smu.py validate-modules:invalid-documentation # removed_at_date not supported in `deprecated` dict
 plugins/modules/nxos_interface_ospf.py validate-modules:deprecation-mismatch # 2.9 expects METADATA
 plugins/modules/nxos_interface_ospf.py validate-modules:invalid-documentation # removed_at_date not supported in `deprecated` dict
+plugins/modules/nxos_bgp.py validate-modules:deprecation-mismatch # 2.9 expects METADATA
+plugins/modules/nxos_bgp.py validate-modules:invalid-documentation # removed_at_date not supported in `deprecated` dict
+plugins/modules/nxos_bgp_neighbor.py validate-modules:deprecation-mismatch # 2.9 expects METADATA
+plugins/modules/nxos_bgp_neighbor.py validate-modules:invalid-documentation # removed_at_date not supported in `deprecated` dict


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Deprecate nxos_bgp and nxos_bgp_neighbor in favor of nxos_bgp_global