### PR TITLE
Add hello_interval_ms option in nxos_pim_interface

### DIFF
--- a/changelogs/fragments/fix_hello_interval.yaml
+++ b/changelogs/fragments/fix_hello_interval.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Add hello_interval_ms option in nxos_pim_interface module to support sub-second intervals (https://github.com/ansible-collections/cisco.nxos/issues/226).

--- a/plugins/modules/nxos_pim_interface.py
+++ b/plugins/modules/nxos_pim_interface.py
@@ -60,8 +60,14 @@ options:
     type: str
   hello_interval:
     description:
-    - Hello interval in milliseconds for this interface.
+    - Hello interval in milliseconds or seconds for this interface.
+    - Use the option I(hello_interval_ms) to specify if the given value is in
+      milliseconds or seconds. The default is seconds.
     type: int
+  hello_interval_ms:
+    description:
+    - Specifies that the hello_interval is in milliseconds.
+    type: bool
   jp_policy_out:
     description:
     - Policy for join-prune messages (outbound).
@@ -511,13 +517,16 @@ def config_pim_interface_defaults(existing, jp_bidir, isauth):
     return command
 
 
-def normalize_proposed_values(proposed):
+def normalize_proposed_values(proposed, module):
     keys = proposed.keys()
     if "bfd" in keys:
         # bfd is a tri-state string: enable, disable, default
         proposed["bfd"] = proposed["bfd"].lower()
     if "hello_interval" in keys:
-        proposed["hello_interval"] = str(proposed["hello_interval"] * 1000)
+        hello_interval = proposed["hello_interval"]
+        if not module.params["hello_interval_ms"]:
+            hello_interval = hello_interval * 1000
+        proposed["hello_interval"] = str(hello_interval)
 
 
 def main():
@@ -527,6 +536,7 @@ def main():
         dr_prio=dict(type="str"),
         hello_auth_key=dict(type="str", no_log=True),
         hello_interval=dict(type="int"),
+        hello_interval_ms=dict(type="bool"),
         jp_policy_out=dict(type="str"),
         jp_policy_in=dict(type="str"),
         jp_type_out=dict(type="str", choices=["prefix", "routemap"]),
@@ -543,8 +553,11 @@ def main():
     )
     argument_spec.update(nxos_argument_spec)
 
+    required_by = {"hello_interval_ms": "hello_interval"}
     module = AnsibleModule(
-        argument_spec=argument_spec, supports_check_mode=True
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_by=required_by,
     )
 
     warnings = list()
@@ -586,7 +599,7 @@ def main():
     proposed = dict(
         (k, v) for k, v in module.params.items() if v is not None and k in args
     )
-    normalize_proposed_values(proposed)
+    normalize_proposed_values(proposed, module)
 
     delta = dict(set(proposed.items()).difference(existing.items()))
 

--- a/plugins/modules/nxos_pim_interface.py
+++ b/plugins/modules/nxos_pim_interface.py
@@ -67,6 +67,8 @@ options:
   hello_interval_ms:
     description:
     - Specifies that the hello_interval is in milliseconds.
+    - When set to True, this indicates that the user is providing the
+      hello_interval in milliseconds and hence, no conversion is required.
     type: bool
   jp_policy_out:
     description:

--- a/tests/unit/modules/network/nxos/test_nxos_pim_interface.py
+++ b/tests/unit/modules/network/nxos/test_nxos_pim_interface.py
@@ -263,3 +263,42 @@ class TestNxosPimInterfaceBfdModule(TestNxosModule):
             changed=True,
             commands=["interface Ethernet9/3", "no ip pim bfd-instance"],
         )
+
+    def test_bfd_4(self):
+        self.get_config.return_value = """
+            interface Ethernet9/2
+              ip pim hello-interval 1000
+        """
+        # update hello-interval (as milliseconds)
+        set_module_args(
+            dict(
+                interface="Ethernet9/2",
+                hello_interval=1,
+                hello_interval_ms=True,
+            )
+        )
+        self.execute_module(
+            changed=True,
+            commands=["interface Ethernet9/2", "ip pim hello-interval 1"],
+        )
+
+        # idempotent (as milliseconds)
+        set_module_args(
+            dict(
+                interface="Ethernet9/2",
+                hello_interval=1000,
+                hello_interval_ms=True,
+            )
+        )
+        self.execute_module(changed=False, commands=[])
+
+        # update hello-interval (default seconds)
+        set_module_args(dict(interface="Ethernet9/2", hello_interval=2))
+        self.execute_module(
+            changed=True,
+            commands=["interface Ethernet9/2", "ip pim hello-interval 2000"],
+        )
+
+        # idempotent (default seconds)
+        set_module_args(dict(interface="Ethernet9/2", hello_interval=1))
+        self.execute_module(changed=False, commands=[])


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes #226 
- The `hello_interval` value was incorrectly being multiplied by 1000. This prevents sub second intervals or interval greater than 18724 from being configured. Both of which are valid values.
- Since updating the behaviour would be a breaking change, a new option `hello_interval_ms` was added, which when set to True, prevents the `hello_interval` from being converted into milliseconds. When set to False on kept unset, the module behaves as before.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
nxos_pim_interface.py