### PR TITLE
Allow integer values to be set for dscp key and correctly parse non rule entries

### DIFF
--- a/changelogs/fragments/fix_nxos_acls.yaml
+++ b/changelogs/fragments/fix_nxos_acls.yaml
@@ -1,3 +1,4 @@
 ---
 bugfixes:
   - Allow integer values to be set for dscp key (https://github.com/ansible-collections/cisco.nxos/issues/253).
+  - Do not fail when parsing non rule entries in access-list config (https://github.com/ansible-collections/cisco.nxos/issues/262).

--- a/changelogs/fragments/fix_nxos_acls.yaml
+++ b/changelogs/fragments/fix_nxos_acls.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Allow integer values to be set for dscp key (https://github.com/ansible-collections/cisco.nxos/issues/253).

--- a/plugins/module_utils/network/nxos/config/acls/acls.py
+++ b/plugins/module_utils/network/nxos/config/acls/acls.py
@@ -220,9 +220,10 @@ class Acls(ConfigBase):
                     if "aces" in acl.keys():
                         for ace in acl["aces"]:
                             if "dscp" in ace.keys():
-                                if ace["dscp"].isdigit():
+                                if ace["dscp"] in dscp:
                                     ace["dscp"] = dscp[int(ace["dscp"])]
-                                ace["dscp"] = ace["dscp"].lower()
+                                if not ace["dscp"].isdigit():
+                                    ace["dscp"] = ace["dscp"].lower()
                             if "precedence" in ace.keys():
                                 if ace["precedence"].isdigit():
                                     ace["precedence"] = precedence[

--- a/plugins/module_utils/network/nxos/facts/acls/acls.py
+++ b/plugins/module_utils/network/nxos/facts/acls/acls.py
@@ -222,20 +222,22 @@ class AclsFacts(object):
                 for ace in list(filter(None, acl[1:])):
                     if re.search(r"ip(.*)access-list.*", ace):
                         break
-                    entry = {}
                     ace = ace.strip()
-                    seq = re.match(r"(\d*)", ace).group(0)
-                    entry.update({"sequence": seq})
-                    ace = re.sub(seq, "", ace, 1)
-                    grant = ace.split()[0]
+                    seq = re.match(r"(\d+)", ace)
                     rem = ""
-                    if grant != "remark":
-                        entry.update({"grant": grant})
-                    else:
-                        rem = re.match(".*remark (.*)", ace).group(1)
-                        entry.update({"remark": rem})
+                    entry = {}
+                    if seq:
+                        seq = seq.group(0)
+                        entry.update({"sequence": seq})
+                        ace = re.sub(seq, "", ace, 1)
+                        grant = ace.split()[0]
+                        if grant != "remark":
+                            entry.update({"grant": grant})
+                        else:
+                            rem = re.match(".*remark (.*)", ace).group(1)
+                            entry.update({"remark": rem})
 
-                    if not rem:
+                    if not rem and seq:
                         ace = re.sub(grant, "", ace, 1)
                         pro = ace.split()[0]
                         entry.update({"protocol": pro})
@@ -278,6 +280,7 @@ class AclsFacts(object):
                                 pro_options.update({pro: options})
                             if pro_options:
                                 entry.update({"protocol_options": pro_options})
-                    acls["aces"].append(entry)
+                    if entry:
+                        acls["aces"].append(entry)
                 config["acls"].append(acls)
         return utils.remove_empties(config)

--- a/tests/unit/modules/network/nxos/test_nxos_acls.py
+++ b/tests/unit/modules/network/nxos/test_nxos_acls.py
@@ -16,6 +16,7 @@ from ansible_collections.cisco.nxos.tests.unit.modules.utils import (
     set_module_args,
 )
 from .nxos_module import TestNxosModule, load_fixture
+from textwrap import dedent
 
 
 class TestNxosAclsModule(TestNxosModule):
@@ -448,7 +449,14 @@ class TestNxosAclsModule(TestNxosModule):
     def test_nxos_acls_parsed(self):
         set_module_args(
             dict(
-                running_config="""\nip access-list ACL1v4\n 10 permit ip any any\n 20 deny udp any any dscp AF23 precedence critical""",
+                running_config=dedent(
+                    """
+                    ip access-list ACL1v4
+                      statistics per-entry
+                      10 permit ip any any
+                      20 deny udp any any dscp AF23 precedence critical
+                    """
+                ),
                 state="parsed",
             )
         )

--- a/tests/unit/modules/network/nxos/test_nxos_acls.py
+++ b/tests/unit/modules/network/nxos/test_nxos_acls.py
@@ -98,6 +98,20 @@ class TestNxosAclsModule(TestNxosModule):
                                         ),
                                     ),
                                     dict(
+                                        destination=dict(
+                                            address="1.2.2.2",
+                                            wildcard_bits="0.0.255.255",
+                                        ),
+                                        dscp="31",
+                                        grant="permit",
+                                        protocol="ip",
+                                        sequence="25",
+                                        source=dict(
+                                            address="1.1.1.1",
+                                            wildcard_bits="0.0.0.255",
+                                        ),
+                                    ),
+                                    dict(
                                         grant="deny",
                                         destination=dict(
                                             prefix="2002:2:2:2::/64"
@@ -121,6 +135,7 @@ class TestNxosAclsModule(TestNxosModule):
         commands = [
             "ip access-list ACL2v4",
             "20 deny tcp any any ack fragments",
+            "25 permit ip 1.1.1.1 0.0.0.255 1.2.2.2 0.0.255.255 dscp 31",
             "30 deny icmp 2002:1:1:1::/64 2002:2:2:2::/64 echo-request",
             "ipv6 access-list ACL2v6",
         ]


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes #253
- Fixes https://github.com/ansible-collections/cisco.nxos/issues/262
- Note: The doc changes here were made by the pre-commit hook and should no longer be a part of this PR once the depends on PR is merged.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
config/acls.py