### PR TITLE
Properly mask values of sensitive keys in module result

### DIFF
--- a/changelogs/fragments/no_log_fix.yaml
+++ b/changelogs/fragments/no_log_fix.yaml
@@ -1,0 +1,3 @@
+---
+security_fixes:
+  - Properly mask values of sensitive keys in module result.

--- a/plugins/module_utils/network/nxos/facts/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/nxos/facts/bgp_global/bgp_global.py
@@ -86,7 +86,9 @@ class Bgp_globalFacts(object):
 
         ansible_facts["ansible_network_resources"].pop("bgp_global", None)
         params = utils.remove_empties(
-            utils.validate_config(self.argument_spec, {"config": obj})
+            utils.validate_config(
+                self.argument_spec, {"config": obj}, self._module
+            )
         )
 
         facts["bgp_global"] = params.get("config", {})

--- a/plugins/module_utils/network/nxos/facts/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/nxos/facts/bgp_global/bgp_global.py
@@ -60,7 +60,9 @@ class Bgp_globalFacts(object):
         data = self._flatten_config(data)
 
         # parse native config using the Bgp_global template
-        bgp_global_parser = Bgp_globalTemplate(lines=data.splitlines())
+        bgp_global_parser = Bgp_globalTemplate(
+            lines=data.splitlines(), module=self._module
+        )
         obj = bgp_global_parser.parse()
 
         vrfs = obj.get("vrfs", {})
@@ -86,8 +88,8 @@ class Bgp_globalFacts(object):
 
         ansible_facts["ansible_network_resources"].pop("bgp_global", None)
         params = utils.remove_empties(
-            utils.validate_config(
-                self.argument_spec, {"config": obj}, self._module
+            bgp_global_parser.validate_config(
+                self.argument_spec, {"config": obj}, redact=True
             )
         )
 

--- a/plugins/module_utils/network/nxos/facts/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/nxos/facts/ospf_interfaces/ospf_interfaces.py
@@ -60,7 +60,7 @@ class Ospf_interfacesFacts(object):
 
         # parse native config using the Ospf_interfaces template
         ospf_interfaces_parser = Ospf_interfacesTemplate(
-            lines=data.splitlines()
+            lines=data.splitlines(), module=self._module
         )
         objs = list(ospf_interfaces_parser.parse().values())
         if objs:
@@ -75,8 +75,8 @@ class Ospf_interfacesFacts(object):
         ansible_facts["ansible_network_resources"].pop("ospf_interfaces", None)
 
         params = utils.remove_empties(
-            utils.validate_config(
-                self.argument_spec, {"config": objs}, self._module
+            ospf_interfaces_parser.validate_config(
+                self.argument_spec, {"config": objs}, redact=True
             )
         )
 

--- a/plugins/module_utils/network/nxos/facts/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/nxos/facts/ospf_interfaces/ospf_interfaces.py
@@ -75,7 +75,9 @@ class Ospf_interfacesFacts(object):
         ansible_facts["ansible_network_resources"].pop("ospf_interfaces", None)
 
         params = utils.remove_empties(
-            utils.validate_config(self.argument_spec, {"config": objs})
+            utils.validate_config(
+                self.argument_spec, {"config": objs}, self._module
+            )
         )
 
         facts["ospf_interfaces"] = params.get("config", [])

--- a/plugins/module_utils/network/nxos/rm_templates/bgp_global.py
+++ b/plugins/module_utils/network/nxos/rm_templates/bgp_global.py
@@ -55,8 +55,10 @@ def _tmplt_bfd(proc):
 
 
 class Bgp_globalTemplate(NetworkTemplate):
-    def __init__(self, lines=None):
-        super(Bgp_globalTemplate, self).__init__(lines=lines, tmplt=self)
+    def __init__(self, lines=None, module=None):
+        super(Bgp_globalTemplate, self).__init__(
+            lines=lines, tmplt=self, module=module
+        )
 
     # fmt: off
     PARSERS = [

--- a/plugins/module_utils/network/nxos/rm_templates/ospf_interfaces.py
+++ b/plugins/module_utils/network/nxos/rm_templates/ospf_interfaces.py
@@ -35,8 +35,10 @@ def _tmplt_authentication(data):
 
 
 class Ospf_interfacesTemplate(NetworkTemplate):
-    def __init__(self, lines=None):
-        super(Ospf_interfacesTemplate, self).__init__(lines=lines, tmplt=self)
+    def __init__(self, lines=None, module=None):
+        super(Ospf_interfacesTemplate, self).__init__(
+            lines=lines, tmplt=self, module=module
+        )
 
     # fmt: off
     PARSERS = [


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/ansible.netcommon/pull/246

##### SUMMARY
- Pass current module object to validate_config() in order to update no_log_values list for proper masking.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
facts/ospf_interfaces.py
facts/bgp_global.py
