### PR TITLE
Bump ansible.netcommon requirement to >=2.0.1

### DIFF
--- a/changelogs/fragments/update_requirement.yaml
+++ b/changelogs/fragments/update_requirement.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - For versions >=2.1.0, this collection requires ansible.netcommon >=2.0.1.
+  - Re-releasing this collection with ansible.netcommon dependency requirements updated.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 authors:
   - Ansible Network Community (ansible-network)
 dependencies:
-  "ansible.netcommon": ">=2.0.0"
+  "ansible.netcommon": ">=2.0.1"
 license_file: LICENSE
 name: nxos
 namespace: cisco


### PR DESCRIPTION
##### SUMMARY
- The changes introduced in #270 are dependent on ansible.netcommon:2.0.1. This was not updated in galaxy.yml causing affected modules fail in v2.1.0 fails if the netcommon installed is <2.0.1.
- This patch bumps the requirement in galaxy.yml.
- We will need a v2.1.1 release for this collection.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
galaxy.yml

