### PR TITLE
Add netconf subplugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ Name | Description
 --- | ---
 [cisco.nxos.nxos](https://github.com/ansible-collections/nxos/blob/main/docs/cisco.nxos.nxos_httpapi.rst)|Use NX-API to run commands on Cisco NX-OS platform
 
+### Netconf plugins
+Name | Description
+--- | ---
+[cisco.nxos.nxos](https://github.com/ansible-collections/nxos/blob/main/docs/cisco.nxos.nxos_netconf.rst)|Use nxos netconf plugin to run netconf commands on Cisco NX-OS platform.
+
 ### Modules
 Name | Description
 --- | ---

--- a/changelogs/fragments/netconf.yaml
+++ b/changelogs/fragments/netconf.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Add a netconf subplugin to make netconf_* modules work with older NX-OS versions (https://github.com/ansible-collections/ansible.netcommon/issues/252).

--- a/docs/cisco.nxos.nxos_netconf.rst
+++ b/docs/cisco.nxos.nxos_netconf.rst
@@ -1,0 +1,76 @@
+.. _cisco.nxos.nxos_netconf:
+
+
+***************
+cisco.nxos.nxos
+***************
+
+**Use nxos netconf plugin to run netconf commands on Cisco NX-OS platform.**
+
+
+Version added: 2.3.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This nxos plugin provides low level abstraction apis for sending and receiving netconf commands from Cisco NX-OS network devices.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                <th>Configuration</th>
+            <th width="100%">Comments</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ncclient_device_handler</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">"nxos"</div>
+                </td>
+                    <td>
+                    </td>
+                <td>
+                        <div>Specifies the ncclient device handler name for Cisco NX-OS network os. To identify the ncclient device handler name refer ncclient library documentation.</div>
+                </td>
+            </tr>
+    </table>
+    <br/>
+
+
+
+
+
+
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Ansible Networking Team
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/plugins/netconf/nxos.py
+++ b/plugins/netconf/nxos.py
@@ -1,0 +1,44 @@
+#
+# (c) 2021 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+author: Ansible Networking Team
+netconf: nxos
+short_description: Use nxos netconf plugin to run netconf commands on Cisco NX-OS platform.
+description:
+- This nxos plugin provides low level abstraction apis for sending and receiving
+  netconf commands from Cisco NX-OS network devices.
+version_added: 2.3.0
+options:
+  ncclient_device_handler:
+    type: str
+    default: nxos
+    description:
+    - Specifies the ncclient device handler name for Cisco NX-OS network os. To
+      identify the ncclient device handler name refer ncclient library documentation.
+"""
+
+from ansible.plugins.netconf import NetconfBase
+
+
+class Netconf(NetconfBase):
+    pass


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Add a netconf subplugin to make netconf_* modules work with older NX-OS versions.
- Fixes https://github.com/ansible-collections/ansible.netcommon/issues/252

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
netconf/nxos.py