### PR TITLE
netconf: change device handler to nexus 

### DIFF
--- a/2
+++ b/2
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Device handler should be nexus.

--- a/changelogs/fragments/netconf_fix.yaml
+++ b/changelogs/fragments/netconf_fix.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Device handler should be nexus.

--- a/docs/cisco.nxos.nxos_netconf.rst
+++ b/docs/cisco.nxos.nxos_netconf.rst
@@ -44,7 +44,7 @@ Parameters
                     </div>
                 </td>
                 <td>
-                        <b>Default:</b><br/><div style="color: blue">"nxos"</div>
+                        <b>Default:</b><br/><div style="color: blue">"nexus"</div>
                 </td>
                     <td>
                     </td>

--- a/docs/cisco.nxos.nxos_route_maps_module.rst
+++ b/docs/cisco.nxos.nxos_route_maps_module.rst
@@ -2438,7 +2438,6 @@ Parameters
                 </td>
                 <td>
                         <div>The state the configuration should be left in.</div>
-                        <div>Refer to examples for more details.</div>
                         <div>With state <em>replaced</em>, for the listed route-maps, sequences that are in running-config but not in the task are negated.</div>
                         <div>With state <em>overridden</em>, all route-maps that are in running-config but not in the task are negated.</div>
                         <div>Please refer to examples for more details.</div>

--- a/plugins/netconf/nxos.py
+++ b/plugins/netconf/nxos.py
@@ -31,7 +31,7 @@ version_added: 2.3.0
 options:
   ncclient_device_handler:
     type: str
-    default: nxos
+    default: nexus
     description:
     - Specifies the ncclient device handler name for Cisco NX-OS network os. To
       identify the ncclient device handler name refer ncclient library documentation.


### PR DESCRIPTION
##### SUMMARY
- Fixing the incorrect device handler name that went in with https://github.com/ansible-collections/cisco.nxos/pull/298.