### PR TITLE
Fix nxos vrf changed commands

### DIFF
--- a/changelogs/fragments/docs_facts.yaml
+++ b/changelogs/fragments/docs_facts.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Update docs to include available_network_resources.

--- a/docs/cisco.nxos.nxos_facts_module.rst
+++ b/docs/cisco.nxos.nxos_facts_module.rst
@@ -36,6 +36,25 @@ Parameters
             <tr>
                 <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>available_network_resources</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                    <li>yes</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>When &#x27;True&#x27; a list of network resources for which resource modules are available will be provided.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>gather_network_resources</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/plugins/modules/nxos_vrf.py
+++ b/plugins/modules/nxos_vrf.py
@@ -627,11 +627,12 @@ def main():
     commands = map_obj_to_commands((want, have), module)
     result["commands"] = commands
 
-    if commands and not module.check_mode:
-        responses = load_config(
-            module, commands, opts={"catch_clierror": True}
-        )
-        vrf_error_check(module, commands, responses)
+    if commands:
+        if not module.check_mode:
+            responses = load_config(
+                module, commands, opts={"catch_clierror": True}
+            )
+            vrf_error_check(module, commands, responses)
         result["changed"] = True
 
     check_declarative_intent_params(want, module, element_spec, result)


### PR DESCRIPTION
Currently nxos_vrf could not correctly show the changed commands with highlighted message, which confuses people. This pr fixes the changed determination logic for nxos_vrf module.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
