### PR TITLE
Don't rely on `safe_eval` being able to do math/concat

### DIFF
--- a/changelogs/fragments/315-safe-eval-no-concat.yml
+++ b/changelogs/fragments/315-safe-eval-no-concat.yml
@@ -1,3 +1,4 @@
+---
 trivial:
-- Don't rely on ``safe_eval`` being able to do math/concat
-  (https://github.com/ansible-collections/cisco.nxos/pull/315)
+  - Don't rely on ``safe_eval`` being able to do math/concat
+    (https://github.com/ansible-collections/cisco.nxos/pull/315)

--- a/changelogs/fragments/315-safe-eval-no-concat.yml
+++ b/changelogs/fragments/315-safe-eval-no-concat.yml
@@ -1,0 +1,3 @@
+trivial:
+- Don't rely on ``safe_eval`` being able to do math/concat
+  (https://github.com/ansible-collections/cisco.nxos/pull/315)

--- a/tests/integration/targets/nxos_aaa_server/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_aaa_server/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_aaa_server/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_aaa_server/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_aaa_server_host/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_aaa_server_host/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_aaa_server_host/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_aaa_server_host/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_acl/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_acl/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_acl/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_acl/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_acl_interface/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_acl_interface/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_acl_interface/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_acl_interface/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_acl_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_acl_interfaces/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_acl_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_acl_interfaces/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_acls/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_acls/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_acls/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_acls/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_banner/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_banner/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_banner/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_banner/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_bfd_global/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_bfd_global/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_bfd_global/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bfd_global/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_bfd_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tasks/cli.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_bfd_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tasks/nxapi.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_bgp/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_bgp/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_bgp/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bgp/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_bgp_address_family/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_bgp_address_family/tasks/cli.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_bgp_address_family/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bgp_address_family/tasks/nxapi.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_bgp_af/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_bgp_af/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_bgp_af/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bgp_af/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_bgp_global/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_bgp_global/tasks/cli.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_bgp_global/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bgp_global/tasks/nxapi.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_bgp_neighbor/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_bgp_neighbor/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_bgp_neighbor_address_family/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_address_family/tasks/cli.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_bgp_neighbor_address_family/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_address_family/tasks/nxapi.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_bgp_neighbor_af/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_af/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_bgp_neighbor_af/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_af/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_command/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_command/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_command/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_command/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_config/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_config/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_config/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_config/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_devicealias/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_devicealias/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_evpn_global/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_evpn_global/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_evpn_global/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_evpn_global/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_evpn_vni/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_evpn_vni/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_evpn_vni/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_evpn_vni/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_facts/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_facts/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_facts/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_facts/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_feature/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_feature/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_feature/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_feature/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_file_copy/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_file_copy/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_file_copy/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_file_copy/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_gir/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_gir/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_gir/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_gir/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_gir_profile_management/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_gir_profile_management/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_gir_profile_management/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_gir_profile_management/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_hsrp/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_hsrp/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_hsrp/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_hsrp/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_hsrp_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_hsrp_interfaces/tasks/cli.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_hsrp_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_hsrp_interfaces/tasks/nxapi.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_igmp/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_igmp/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_igmp/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_igmp/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_igmp_interface/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_igmp_interface/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_igmp_interface/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_igmp_interface/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_igmp_snooping/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_igmp_snooping/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_igmp_snooping/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_igmp_snooping/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_interface/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_interface/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_interface/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_interface/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_interface_ospf/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_interface_ospf/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_interface_ospf/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_interface_ospf/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_interfaces/tasks/cli.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_interfaces/tasks/nxapi.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_l2_interface/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_l2_interface/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_l2_interface/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_l2_interface/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_l2_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tasks/cli.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_l2_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tasks/nxapi.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_l3_interface/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_l3_interface/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_l3_interface/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_l3_interface/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_l3_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tasks/cli.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_l3_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tasks/nxapi.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_lacp/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_lacp/tasks/cli.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_lacp/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_lacp/tasks/nxapi.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_lacp_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_lacp_interfaces/tasks/cli.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_lacp_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_lacp_interfaces/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_lag_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_lag_interfaces/tasks/cli.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_lag_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_lag_interfaces/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_linkagg/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_linkagg/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_linkagg/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_linkagg/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_lldp/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_lldp/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_lldp/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_lldp/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_lldp_global/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_lldp_global/tasks/cli.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_lldp_global/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_lldp_global/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_lldp_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_lldp_interfaces/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_lldp_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_lldp_interfaces/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_logging/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_logging/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_logging/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_logging/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_ntp/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_ntp/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_ntp/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_ntp/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_ntp_auth/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_ntp_auth/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_ntp_auth/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_ntp_auth/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_ntp_options/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_ntp_options/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_ntp_options/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_ntp_options/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_nxapi/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_nxapi/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_nxapi/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_nxapi/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_ospf/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_ospf/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_ospf/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_ospf/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_ospf_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_ospf_interfaces/tasks/cli.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_ospf_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_ospf_interfaces/tasks/nxapi.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_ospf_vrf/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_ospf_vrf/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_ospf_vrf/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_ospf_vrf/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_ospfv2/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_ospfv2/tasks/cli.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_ospfv2/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_ospfv2/tasks/nxapi.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_ospfv3/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_ospfv3/tasks/cli.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_ospfv3/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_ospfv3/tasks/nxapi.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_overlay_global/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_overlay_global/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_overlay_global/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_overlay_global/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_pim/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_pim/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_pim/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_pim/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_pim_interface/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_pim_interface/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_pim_interface/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_pim_interface/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_pim_rp_address/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_pim_rp_address/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_pim_rp_address/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_pim_rp_address/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_prefix_lists/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_prefix_lists/tasks/cli.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_prefix_lists/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_prefix_lists/tasks/nxapi.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_reboot/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_reboot/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_reboot/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_reboot/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_rollback/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_rollback/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_rollback/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_rollback/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_route_maps/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_route_maps/tasks/cli.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_route_maps/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_route_maps/tasks/nxapi.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_rpm/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_rpm/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_rpm/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_rpm/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_smoke/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_smoke/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: "{{ test_cases.files }} + {{ cli_cases.files }}"
+      files: "{{ test_cases.files + cli_cases.files }}"
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_smoke/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_smoke/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: "{{ test_cases.files }} + {{ nxapi_cases.files }}"
+      files: "{{ test_cases.files + nxapi_cases.files }}"
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_snapshot/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_snapshot/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_snapshot/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_snapshot/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_snmp_community/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_snmp_community/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_snmp_community/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_snmp_community/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_snmp_contact/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_snmp_contact/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_snmp_contact/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_snmp_contact/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_snmp_host/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_snmp_host/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_snmp_host/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_snmp_host/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_snmp_location/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_snmp_location/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_snmp_location/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_snmp_location/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_snmp_traps/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_snmp_traps/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_snmp_traps/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_snmp_traps/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_snmp_user/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_snmp_user/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_snmp_user/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_snmp_user/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_static_route/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_static_route/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_static_route/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_static_route/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_static_routes/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_static_routes/tasks/cli.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: "{{ test_cases.files }} + {{ cli_cases.files }}"
+      files: "{{ test_cases.files + cli_cases.files }}"
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_system/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_system/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_system/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_system/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_telemetry/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_telemetry/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_telemetry/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_telemetry/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_udld/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_udld/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_udld/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_udld/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_udld_interface/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_udld_interface/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_udld_interface/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_udld_interface/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_user/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_user/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_user/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_user/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vlan/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vlan/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vlan/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vlan/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vlans/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vlans/tasks/cli.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vlans/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vlans/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vpc/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vpc/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vpc/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vpc/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vpc_interface/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vpc_interface/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vpc_interface/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vpc_interface/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vrf/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vrf/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vrf/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vrf/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vrf_af/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vrf_af/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vrf_af/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vrf_af/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vrf_interface/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vrf_interface/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vrf_interface/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vrf_interface/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vrrp/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vrrp/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vrrp/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vrrp/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vsan/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vsan/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vtp_domain/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vtp_domain/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vtp_domain/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vtp_domain/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vtp_password/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vtp_password/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vtp_password/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vtp_password/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vtp_version/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vtp_version/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vtp_version/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vtp_version/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vxlan_vtep/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vxlan_vtep/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vxlan_vtep_vni/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep_vni/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_vxlan_vtep_vni/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep_vni/tasks/nxapi.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ nxapi_cases.files }}'
+      files: '{{ test_cases.files + nxapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/nxos_zone_zoneset/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_zone_zoneset/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"


### PR DESCRIPTION
##### SUMMARY
Don't rely on `safe_eval` being able to do math/concat. This functionality will be removed in ansible-core 2.12, and has never worked with jinja2 native which we are working toward making the default in 2.12.

See https://github.com/ansible/ansible/pull/75068

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/integration/targets/

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
