### PR TITLE
Prevent traceback when parsing unexpected line

### DIFF
--- a/changelogs/fragments/static_routes.yaml
+++ b/changelogs/fragments/static_routes.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Prevent traceback when parsing unexpected line in nxos_static_routes.

--- a/plugins/module_utils/network/nxos/facts/static_routes/static_routes.py
+++ b/plugins/module_utils/network/nxos/facts/static_routes/static_routes.py
@@ -229,12 +229,16 @@ class Static_routesFacts(object):
                     # considering from the second line as first line is 'vrf context..'
                     conf = conf[1:]
                     for c in conf:
-                        if "ip route" in c or "ipv6 route" in c:
+                        if (
+                            "ip route" in c or "ipv6 route" in c
+                        ) and "bfd" not in c:
                             self.get_command(c, afi_list, dest_list, af)
                             config_dict["address_families"] = af
                     config.append(config_dict)
                 else:
-                    if "ip route" in conf or "ipv6 route" in conf:
+                    if (
+                        "ip route" in conf or "ipv6 route" in conf
+                    ) and "bfd" not in conf:
                         self.get_command(
                             conf, global_afi_list, global_dest_list, global_af
                         )

--- a/tests/unit/modules/network/nxos/test_nxos_static_routes.py
+++ b/tests/unit/modules/network/nxos/test_nxos_static_routes.py
@@ -74,7 +74,7 @@ class TestNxosStaticRoutesModule(TestNxosModule):
                 "ip route 192.0.2.16/28 192.0.2.24 name initial_route"
             ]
             vrf_data = [
-                "vrf context test\n  ip route 192.0.2.96/28 192.0.2.122 vrf dest_vrf\n  ipv6 route 2001:db8:12::/32 2001:db8::1001 name ipv6_route 3\n"
+                "vrf context test\n  ip route 192.0.2.96/28 192.0.2.122 vrf dest_vrf\n  ip route static bfd Vlan100 192.168.1.100\n  ipv6 route 2001:db8:12::/32 2001:db8::1001 name ipv6_route 3\n"
             ]
 
             output = non_vrf_data + vrf_data

--- a/tests/unit/modules/network/nxos/test_nxos_static_routes.py
+++ b/tests/unit/modules/network/nxos/test_nxos_static_routes.py
@@ -74,7 +74,8 @@ class TestNxosStaticRoutesModule(TestNxosModule):
                 "ip route 192.0.2.16/28 192.0.2.24 name initial_route"
             ]
             vrf_data = [
-                "vrf context test\n  ip route 192.0.2.96/28 192.0.2.122 vrf dest_vrf\n  ip route static bfd Vlan100 192.168.1.100\n  ipv6 route 2001:db8:12::/32 2001:db8::1001 name ipv6_route 3\n"
+                "vrf context test\n  ip route 192.0.2.96/28 192.0.2.122 vrf dest_vrf"
+                "\n  ip route static bfd Vlan100 192.168.1.100\n  ipv6 route 2001:db8:12::/32 2001:db8::1001 name ipv6_route 3\n"
             ]
 
             output = non_vrf_data + vrf_data


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
Note: This is a temporary fix to let existing options provided by this module work. Adding `bfd` support requires considerable rework of the existing code and will be done in a later release.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_static_routes.py
