### PR TITLE
[ospf_interfaces] Fix rendering of interface names

### DIFF
--- a/changelogs/fragments/fix_ospf_interfaces.yaml
+++ b/changelogs/fragments/fix_ospf_interfaces.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "`nxos_ospf_interfaces` - Correctly sort interface names before rendering."

--- a/plugins/module_utils/network/nxos/facts/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/nxos/facts/ospf_interfaces/ospf_interfaces.py
@@ -76,7 +76,12 @@ class Ospf_interfacesFacts(object):
                         item["address_family"], key=lambda i: i["afi"]
                     )
 
-            objs = sorted(objs, key=lambda i: i["name"])
+            objs = sorted(
+                objs,
+                key=lambda i: [
+                    int(k) if k.isdigit() else k for k in i["name"].split("/")
+                ],
+            )
 
         ansible_facts["ansible_network_resources"].pop("ospf_interfaces", None)
 


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Sorting the interfaces with names results in the following:
```
after:
   - name: Ethernet1/1
   - name: Ethernet1/10
   - name: Ethernet1/11
   - name: Ethernet1/12
   - name: Ethernet1/13
   - name: Ethernet1/14
   - name: Ethernet1/2
   - name: Ethernet1/3
   - name: Ethernet1/4
```

- This patch makes it render in the natural order.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_ospf_interfaces.py