### PR TITLE
[acls] Fix parsing of remarks

### DIFF
--- a/changelogs/fragments/nxos_acls.yaml
+++ b/changelogs/fragments/nxos_acls.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "nxos_acls - Fix incorrect parsing of remarks if it has 'ip/ipv6 access-list' in it."

--- a/plugins/module_utils/network/nxos/facts/acls/acls.py
+++ b/plugins/module_utils/network/nxos/facts/acls/acls.py
@@ -220,7 +220,7 @@ class AclsFacts(object):
                 ).group(3)
                 acls["aces"] = []
                 for ace in list(filter(None, acl[1:])):
-                    if re.search(r"ip(.*)access-list.*", ace):
+                    if re.search(r"^ip(.*)access-list.*", ace):
                         break
                     ace = ace.strip()
                     seq = re.match(r"(\d+)", ace)


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- If the remark has "ip/ipv6 access-list" in it, it was not being parsed.
- This patch fixes it.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_acls.py
