### PR TITLE
[ntp_global] account for extra whitespace in source-interface line

### DIFF
--- a/changelogs/fragments/nxos_ntp.yaml
+++ b/changelogs/fragments/nxos_ntp.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "`nxos_ntp_global` - In some cases, there is an extra whitespace in the source-interface line. This patch accounts for this behaviour in config (https://github.com/ansible-collections/cisco.nxos/issues/399)."

--- a/plugins/module_utils/network/nxos/rm_templates/ntp_global.py
+++ b/plugins/module_utils/network/nxos/rm_templates/ntp_global.py
@@ -277,7 +277,7 @@ class Ntp_globalTemplate(NetworkTemplate):
             "name": "source_interface",
             "getval": re.compile(
                 r"""
-                ^ntp\ssource-interface\s(?P<source_interface>\S+)
+                ^ntp\ssource-interface(\s)+(?P<source_interface>\S+)
                 $""", re.VERBOSE),
             "setval": "ntp source-interface {{ source_interface }}",
             "result": {

--- a/tests/unit/modules/network/nxos/test_nxos_ntp_global.py
+++ b/tests/unit/modules/network/nxos/test_nxos_ntp_global.py
@@ -480,7 +480,7 @@ class TestNxosNtpGlobalModule(TestNxosModule):
                         dict(key_id=1002),
                         dict(key_id=1003),
                     ],
-                    source_interface="192.168.1.100",
+                    source_interface="Ethernet1/1",
                 ),
                 state="merged",
             ),
@@ -490,7 +490,7 @@ class TestNxosNtpGlobalModule(TestNxosModule):
             "ntp trusted-key 1001",
             "ntp trusted-key 1002",
             "ntp trusted-key 1003",
-            "ntp source-interface 192.168.1.100",
+            "ntp source-interface Ethernet1/1",
         ]
         result = self.execute_module(changed=True)
         self.assertEqual(set(result["commands"]), set(commands))
@@ -502,7 +502,7 @@ class TestNxosNtpGlobalModule(TestNxosModule):
             ntp trusted-key 1001
             ntp trusted-key 1002
             ntp trusted-key 1003
-            ntp source-interface 192.168.1.100
+            ntp source-interface  Ethernet1/1
             """
         )
         set_module_args(
@@ -513,10 +513,27 @@ class TestNxosNtpGlobalModule(TestNxosModule):
                         dict(key_id=1002),
                         dict(key_id=1003),
                     ],
-                    source_interface="192.168.1.100",
+                    source_interface="Ethernet1/1",
                 ),
                 state="merged",
             ),
+            ignore_provider_arg,
+        )
+        result = self.execute_module(changed=False)
+        self.assertEqual(result["commands"], [])
+
+    def test_nxos_ntp_global_source_interface_merged_idempotent(self):
+        # test merged for complex attributes - 3 (idempotent)
+        self.get_config.return_value = dedent(
+            """\
+            ntp trusted-key 1001
+            ntp trusted-key 1002
+            ntp trusted-key 1003
+            ntp source-interface Ethernet1/1
+            """
+        )
+        set_module_args(
+            dict(config=dict(source_interface="Ethernet1/1"), state="merged"),
             ignore_provider_arg,
         )
         result = self.execute_module(changed=False)


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes #399 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_ntp_global.py