### PR TITLE
Fix default vlan state overridden issue

### DIFF
--- a/changelogs/fragments/fix_nxos_vlans.yaml
+++ b/changelogs/fragments/fix_nxos_vlans.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix for nxos_vlans issue (https://github.com/ansible-collections/cisco.nxos/issues/425).

--- a/plugins/module_utils/network/nxos/facts/vlans/vlans.py
+++ b/plugins/module_utils/network/nxos/facts/vlans/vlans.py
@@ -199,7 +199,7 @@ class VlansFacts(object):
                 # Sample match lines
                 # 202\n  name Production-Segment-100101\n  vn-segment 100101
                 # 5\n  state suspend\n  shutdown\n  name test-changeme\n  vn-segment 942
-                pattern = '^{0}\s+\S.*vn-segment'.format(v["vlan_id"])
+                pattern = r'^{0}\s+\S.*vn-segment'.format(v["vlan_id"])
                 if re.search(pattern, item, flags=re.DOTALL):
                     vlan["run_cfg"] = item
                     break

--- a/plugins/module_utils/network/nxos/facts/vlans/vlans.py
+++ b/plugins/module_utils/network/nxos/facts/vlans/vlans.py
@@ -196,9 +196,10 @@ class VlansFacts(object):
 
             vlan["run_cfg"] = ""
             for item in run_cfg_list:
-                # Sample match line
+                # Sample match lines
                 # 202\n  name Production-Segment-100101\n  vn-segment 100101
-                pattern = "^{0}\s+name.*vn-segment".format(v["vlan_id"])
+                # 5\n  state suspend\n  shutdown\n  name test-changeme\n  vn-segment 942
+                pattern = '^{0}\s+\S.*vn-segment'.format(v["vlan_id"])
                 if re.search(pattern, item, flags=re.DOTALL):
                     vlan["run_cfg"] = item
                     break

--- a/plugins/module_utils/network/nxos/facts/vlans/vlans.py
+++ b/plugins/module_utils/network/nxos/facts/vlans/vlans.py
@@ -199,7 +199,7 @@ class VlansFacts(object):
                 # Sample match lines
                 # 202\n  name Production-Segment-100101\n  vn-segment 100101
                 # 5\n  state suspend\n  shutdown\n  name test-changeme\n  vn-segment 942
-                pattern = r'^{0}\s+\S.*vn-segment'.format(v["vlan_id"])
+                pattern = r"^{0}\s+\S.*vn-segment".format(v["vlan_id"])
                 if re.search(pattern, item, flags=re.DOTALL):
                     vlan["run_cfg"] = item
                     break

--- a/plugins/module_utils/network/nxos/facts/vlans/vlans.py
+++ b/plugins/module_utils/network/nxos/facts/vlans/vlans.py
@@ -194,9 +194,14 @@ class VlansFacts(object):
             vlan.update(v)
             vlan.update(mtuinfo[index])
 
-            run_cfg = [
-                i for i in run_cfg_list if "%s\n" % v["vlan_id"] in i
-            ] or [""]
-            vlan["run_cfg"] = run_cfg.pop()
+            vlan["run_cfg"] = ""
+            for item in run_cfg_list:
+                # Sample match line
+                # 202\n  name Production-Segment-100101\n  vn-segment 100101
+                pattern = "^{0}\s+name.*vn-segment".format(v["vlan_id"])
+                if re.search(pattern, item, flags=re.DOTALL):
+                    vlan["run_cfg"] = item
+                    break
+
             vlans.append(vlan)
         return vlans


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/cisco.nxos/issues/425

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_vlans

##### ADDITIONAL INFORMATION
This fix changes the fact gathering logic for handling the unstructured output that comes back for `vlan` to `vni` mapping.  The old logic did a check to see if the vlan number exists in the output which could easily match in cases where a match is not desired.  This was causing the default vlan to be changed if `1`  matched anything next to a `\n` character  in the output line