### PR TITLE
[snmp_server] fix (#443)

### DIFF
--- a/changelogs/fragments/snmp_server_PR444.yaml
+++ b/changelogs/fragments/snmp_server_PR444.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "`snmp_server` - Snmp contact/location and location were not gathered if containing whitespaces."

--- a/plugins/module_utils/network/nxos/rm_templates/snmp_server.py
+++ b/plugins/module_utils/network/nxos/rm_templates/snmp_server.py
@@ -138,7 +138,7 @@ class Snmp_serverTemplate(NetworkTemplate):
             "getval": re.compile(
                 r"""
                 ^snmp-server
-                \scontact\s(?P<contact>\S+)
+                \scontact\s(?P<contact>.+)
                 $""", re.VERBOSE),
             "setval": "snmp-server contact {{ contact }}",
             "result": {
@@ -1245,7 +1245,7 @@ class Snmp_serverTemplate(NetworkTemplate):
             "getval": re.compile(
                 r"""
                 ^snmp-server
-                \slocation\s(?P<location>\S+)
+                \slocation\s(?P<location>.+)
                 $""", re.VERBOSE),
             "setval": "snmp-server location {{ location }}",
             "result": {

--- a/tests/unit/modules/network/nxos/test_nxos_snmp_server.py
+++ b/tests/unit/modules/network/nxos/test_nxos_snmp_server.py
@@ -294,6 +294,31 @@ class TestNxosSnmpServerModule(TestNxosModule):
         result = self.execute_module(changed=True)
         self.assertEqual(set(result["commands"]), set(commands))
 
+    def test_nxos_snmp_server_location_spaces(self):
+        # test replaced for linear attributes
+        self.get_config.return_value = dedent(
+            """\
+            snmp-server contact testswitch@localhost
+            snmp-server location lab
+            """
+        )
+        set_module_args(
+            dict(
+                config=dict(
+                    contact="test-switch @t localhost",
+                    location="long/and.(complicated) address",
+                ),
+                state="replaced",
+            ),
+            ignore_provider_arg,
+        )
+        commands = [
+            "snmp-server contact test-switch @t localhost",
+            "snmp-server location long/and.(complicated) address",
+        ]
+        result = self.execute_module(changed=True)
+        self.assertEqual(set(result["commands"]), set(commands))
+
     def test_nxos_snmp_server_traps_merged(self):
         # test merged for traps
         self.get_config.return_value = dedent(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Contact and location were not gathered if containing any whitespace.
This fix changes regex to allow any character.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes  #443

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_facts: network ressource snmp_server

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
