### PR TITLE
fix slow stderr regex search

### DIFF
--- a/changelogs/fragments/stderr.yaml
+++ b/changelogs/fragments/stderr.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Fix slow stderr regex search

--- a/plugins/terminal/nxos.py
+++ b/plugins/terminal/nxos.py
@@ -45,7 +45,7 @@ class TerminalModule(TerminalBase):
         re.compile(rb"invalid input", re.I),
         re.compile(rb"(?:incomplete|ambiguous) command", re.I),
         re.compile(rb"connection timed out", re.I),
-        re.compile(rb"[^\r\n]+ not found", re.I),
+        re.compile(rb"[^\r\n] not found", re.I),
         re.compile(rb"'[^']' +returned error code: ?\d+"),
         re.compile(rb"syntax error"),
         re.compile(rb"unknown command"),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Don't match all non-newline characters before `not found`.

With larger responses (>15KB), `[^\r\n]+ not found` regex search gets painfully slow.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`plugins/terminal/nxos.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
When gathering facts, we get ~128KB JSON response for `show interface | json`. After 3 chunks of data above regex takes ~1s to search and timeouts even w/ a timeout of 3min (ansible-connection process takes 100% CPU on Macbook Pro 15" 2017).
```
ansible -m nxos_facts -i your-inventory.yml your-host -a 'gather_subset=all'
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
{
    "changed": false,
    "invocation": {
        "module_args": {
            "available_network_resources": false,
            "gather_network_resources": [
                "all",
                "!interfaces"
            ],
            "gather_subset": [
                "all",
                "!interfaces"
            ],
            "provider": null
        }
    },
    "msg": "command timeout triggered, timeout value is 30 secs.\nSee the timeout setting options in the Network Debug and Troubleshooting Guide."
}
```
