### PR TITLE
[ntp_global] fail when using missing auth key

### DIFF
--- a/changelogs/fragments/ntp.yaml
+++ b/changelogs/fragments/ntp.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "`nxos_ntp_global` - correctly propagate CLI failure for non-existent auth keys (https://github.com/ansible-collections/cisco.nxos/issues/467)."

--- a/plugins/terminal/nxos.py
+++ b/plugins/terminal/nxos.py
@@ -64,6 +64,7 @@ class TerminalModule(TerminalBase):
             rb"Cannot apply ACL to an interface that is a port-channel member",
             re.I,
         ),
+        re.compile(rb"No corresponding (.+) configured", re.I),
     ]
 
     terminal_config_prompt = re.compile(r"^.*\((?!maint-mode).*\)#$")

--- a/tests/integration/targets/nxos_ntp_global/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_ntp_global/tests/common/merged.yaml
@@ -63,5 +63,17 @@
           - result['changed'] == false
           - result.commands|length == 0
 
+    - name: Attempt to configure non-existent auth key (should fail)
+      cisco.nxos.nxos_ntp_global:
+        config:
+          trusted_keys:
+            - key_id: 12344
+      register: result
+      ignore_errors: True
+
+    - assert:
+        that:
+          - "result.failed == True"
+
   always:
     - include_tasks: _remove_config.yaml


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes #467 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_logging_global.py
