### PR TITLE
Bump min required netcommon

### DIFF
--- a/changelogs/fragments/min_netcommon.yaml
+++ b/changelogs/fragments/min_netcommon.yaml
@@ -1,0 +1,3 @@
+---
+major_changes:
+  - "The minimum required ansible.netcommon version has been bumped to v2.6.1."

--- a/changelogs/fragments/netcommon_ref_update.yaml
+++ b/changelogs/fragments/netcommon_ref_update.yaml
@@ -1,4 +1,3 @@
 ---
 major_changes:
-  - "Minimum required ansible.netcommon version is 2.5.1."
   - "Updated base plugin references to ansible.netcommon."

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 authors:
   - Ansible Network Community (ansible-network)
 dependencies:
-  "ansible.netcommon": ">=2.5.1"
+  "ansible.netcommon": ">=2.6.1"
 license_file: LICENSE
 name: nxos
 namespace: cisco


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

Bumping netcommon because of dependency on these patches:
- https://github.com/ansible-collections/ansible.netcommon/pull/367
- https://github.com/ansible-collections/ansible.netcommon/pull/370