### PR TITLE
[ntp_global] ensure aliased keys are idempotent

### DIFF
--- a/changelogs/fragments/ntp_global.yaml
+++ b/changelogs/fragments/ntp_global.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "`nxos_ntp_global` - Ensure idempotence for aliased keys (https://github.com/ansible-collections/cisco.nxos/issues/484)."

--- a/plugins/module_utils/network/nxos/config/ntp_global/ntp_global.py
+++ b/plugins/module_utils/network/nxos/config/ntp_global/ntp_global.py
@@ -105,6 +105,11 @@ class Ntp_global(ResourceModule):
 
             for wkey, wentry in iteritems(wantx):
                 hentry = havex.pop(wkey, {})
+
+                # pop aliased keys to preserve idempotence
+                if x in ["peers", "servers"]:
+                    wentry.pop("use_vrf", None)
+
                 if wentry != hentry:
                     if x in keys[1:3] and self.state in [
                         "overridden",

--- a/tests/unit/modules/network/nxos/test_nxos_ntp_global.py
+++ b/tests/unit/modules/network/nxos/test_nxos_ntp_global.py
@@ -647,3 +647,84 @@ class TestNxosNtpGlobalModule(TestNxosModule):
         ]
         result = self.execute_module(changed=True)
         self.assertEqual(set(result["commands"]), set(commands))
+
+    def test_nxos_ntp_global_alias(self):
+        self.get_config.return_value = dedent(
+            """\
+            """
+        )
+        set_module_args(
+            dict(
+                config=dict(
+                    servers=[
+                        dict(
+                            server="1.1.1.1",
+                            vrf="management",
+                        ),
+                        dict(
+                            server="1.1.1.3",
+                            use_vrf="v200",
+                        ),
+                    ],
+                    peers=[
+                        dict(
+                            peer="192.168.1.1",
+                            vrf="default",
+                        ),
+                        dict(
+                            peer="192.168.1.2",
+                            use_vrf="v200",
+                        ),
+                    ],
+                ),
+                state="merged",
+            ),
+            ignore_provider_arg,
+        )
+        commands = [
+            "ntp server 1.1.1.1 use-vrf management",
+            "ntp server 1.1.1.3 use-vrf v200",
+            "ntp peer 192.168.1.1 use-vrf default",
+            "ntp peer 192.168.1.2 use-vrf v200",
+        ]
+        result = self.execute_module(changed=True)
+        self.assertEqual(set(result["commands"]), set(commands))
+
+    def test_nxos_ntp_global_alias_idempotent(self):
+        self.get_config.return_value = dedent(
+            """\
+            ntp server 1.1.1.1 use-vrf management
+            ntp server 1.1.1.3 use-vrf v200
+            ntp peer 192.168.1.1 use-vrf default
+            ntp peer 192.168.1.2 use-vrf v200
+            """
+        )
+        set_module_args(
+            dict(
+                config=dict(
+                    servers=[
+                        dict(
+                            server="1.1.1.1",
+                            vrf="management",
+                        ),
+                        dict(
+                            server="1.1.1.3",
+                            use_vrf="v200",
+                        ),
+                    ],
+                    peers=[
+                        dict(
+                            peer="192.168.1.1",
+                            vrf="default",
+                        ),
+                        dict(
+                            peer="192.168.1.2",
+                            use_vrf="v200",
+                        ),
+                    ],
+                ),
+                state="merged",
+            ),
+            ignore_provider_arg,
+        )
+        self.execute_module(changed=False)


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes https://github.com/ansible-collections/cisco.nxos/issues/484

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_ntp_global.py