### PR TITLE
Remove `=` style formatting for debug statements

### DIFF
--- a/changelogs/fragments/unstyle_equal_debug.yaml
+++ b/changelogs/fragments/unstyle_equal_debug.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Remove = style formatting for debug statements

--- a/tests/integration/targets/nxos_aaa_server/tests/common/radius.yaml
+++ b/tests/integration/targets/nxos_aaa_server/tests/common/radius.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_aaa_server radius.yaml
-    sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_aaa_server radius.yaml sanity test
 
 - name: Setup
   ignore_errors: true
@@ -86,12 +85,12 @@
 
     - assert: *id003
   rescue:
-    - debug: msg="connection={{ ansible_connection }} nxos_aaa_server failure detected"
+    - ansible.builtin.debug:
+        msg: connection={{ ansible_connection }} nxos_aaa_server failure detected
   always:
     - name: Remove radius server configuration
       register: result
       cisco.nxos.nxos_aaa_server: *id004
 
-- debug:
-    msg="END connection={{ ansible_connection }} nxos_aaa_server radius.yaml
-    sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_aaa_server radius.yaml sanity test

--- a/tests/integration/targets/nxos_aaa_server/tests/common/tacacs.yaml
+++ b/tests/integration/targets/nxos_aaa_server/tests/common/tacacs.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_aaa_server tacacs.yaml
-    sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_aaa_server tacacs.yaml sanity test
 
 - name: Enable feature tacacs+
   cisco.nxos.nxos_feature:
@@ -91,7 +90,8 @@
 
     - assert: *id003
   rescue:
-    - debug: msg="connection={{ ansible_connection }} nxos_aaa_server failure detected"
+    - ansible.builtin.debug:
+        msg: connection={{ ansible_connection }} nxos_aaa_server failure detected
   always:
     - name: Remove tacacs server configuration
       register: result
@@ -102,6 +102,5 @@
         feature: tacacs+
         state: disabled
 
-- debug:
-    msg="END connection={{ ansible_connection }} nxos_aaa_server tacacs.yaml
-    sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_aaa_server tacacs.yaml sanity test

--- a/tests/integration/targets/nxos_aaa_server_host/tests/common/radius.yaml
+++ b/tests/integration/targets/nxos_aaa_server_host/tests/common/radius.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_aaa_server_host radius.yaml
-    sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_aaa_server_host radius.yaml sanity test
 
 - name: Setup
   ignore_errors: true
@@ -86,7 +85,7 @@
         host_timeout: 25
         auth_port: default
         acct_port: 2084
-        encrypt_type: 0
+        encrypt_type: 00
         key: hello
         state: present
 
@@ -186,14 +185,12 @@
 
     - assert: *id004
   rescue:
-    - debug:
-        msg="connection={{ ansible_connection }} nxos_aaa_server_host failure
-        detected"
+    - ansible.builtin.debug:
+        msg: connection={{ ansible_connection }} nxos_aaa_server_host failure detected
   always:
     - name: Remove radius server configuration
       register: result
       cisco.nxos.nxos_aaa_server_host: *id002
 
-    - debug:
-        msg="END connection={{ ansible_connection }} nxos_aaa_server_host radius.yaml
-        sanity test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_aaa_server_host radius.yaml sanity test

--- a/tests/integration/targets/nxos_aaa_server_host/tests/common/tacacs.yaml
+++ b/tests/integration/targets/nxos_aaa_server_host/tests/common/tacacs.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_aaa_server_host tacacs.yaml
-    sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_aaa_server_host tacacs.yaml sanity test
 
 - name: Enable feature tacacs+
   cisco.nxos.nxos_feature:
@@ -88,7 +87,7 @@
         address: 8.8.8.8
         host_timeout: 25
         tacacs_port: default
-        encrypt_type: 0
+        encrypt_type: 00
         key: hello
         state: present
 
@@ -184,9 +183,8 @@
 
     - assert: *id004
   rescue:
-    - debug:
-        msg="connection={{ ansible_connection }} nxos_aaa_server_host failure
-        detected"
+    - ansible.builtin.debug:
+        msg: connection={{ ansible_connection }} nxos_aaa_server_host failure detected
   always:
     - name: Remove tacacs server configuration
       register: result
@@ -197,6 +195,5 @@
         feature: tacacs+
         state: disabled
 
-    - debug:
-        msg="END connection={{ ansible_connection }} nxos_aaa_server_host tacacs.yaml
-        sanity test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_aaa_server_host tacacs.yaml sanity test

--- a/tests/integration/targets/nxos_acl/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_acl/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_acl sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_acl sanity test
 
 - set_fact: time_range="ans-range"
   when: platform is not search('N35|N5K|N6K')
@@ -227,4 +228,5 @@
 
 - assert: *id004
 
-- debug: msg="END connection={{ ansible_connection }} nxos_acl sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_acl sanity test

--- a/tests/integration/targets/nxos_acl_interface/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_acl_interface/tests/common/sanity.yaml
@@ -1,12 +1,12 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_acl_interface sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_acl_interface sanity test
 
 - set_fact: intname="{{ nxos_int1 }}"
 
 - name: Interface selected for this test
-  debug: msg="{{ intname }}"
+  ansible.builtin.debug:
+    msg: "{{ intname }}"
 
 - name: "Setup: Put interface into a default state"
   ignore_errors: true
@@ -116,6 +116,5 @@
       ignore_errors: true
       cisco.nxos.nxos_acl: *id008
 
-    - debug:
-        msg="END connection={{ ansible_connection }} nxos_acl_interface sanity
-        test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_acl_interface sanity test

--- a/tests/integration/targets/nxos_banner/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_banner/tests/common/sanity.yaml
@@ -1,16 +1,18 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_banner sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_banner sanity test
 
 - set_fact:
-    banner_exec_image_ok: True
+    banner_exec_image_ok: true
   when: platform is search("N7K|N3K-F")
 
 - set_fact:
-    banner_motd_image_ok: True
+    banner_motd_image_ok: true
   when: imagetag is not search("I7") and ansible_connection != "ansible.netcommon.httpapi"
 
 - block:
-    - debug: msg="START nxos_banner exec tests"
+    - ansible.builtin.debug:
+        msg: START nxos_banner exec tests
 
     - name: setup exec
       cisco.nxos.nxos_banner: &id002
@@ -27,8 +29,7 @@
     - assert:
         that:
           - result.changed == true
-          - "'banner exec @\nthis is my exec banner\nthat has a multiline\nstring\n\
-            @' in result.commands"
+          - "'banner exec @\nthis is my exec banner\nthat has a multiline\nstring\n@' in result.commands"
 
     - name: Set exec again (idempotent)
       register: result
@@ -73,4 +74,5 @@
       cisco.nxos.nxos_banner: *id004
   when: banner_motd_image_ok == True
 
-- debug: msg="END connection={{ ansible_connection }} nxos_banner sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_banner sanity test

--- a/tests/integration/targets/nxos_bfd_global/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_bfd_global/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_bfd_global sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_bfd_global sanity test
 
 - name: set facts common
   set_fact:
@@ -162,4 +163,5 @@
         lines: no interface loopback1
         match: none
 
-- debug: msg="END connection={{ ansible_connection }} nxos_bfd_global sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_bfd_global sanity test

--- a/tests/integration/targets/nxos_bgp/tests/common/dis_policy.yaml
+++ b/tests/integration/targets/nxos_bgp/tests/common/dis_policy.yaml
@@ -1,7 +1,9 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_bgp parameter test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_bgp parameter test
 
-- debug: msg="This bgp_disable_policy is not supported on {{ image_version }}"
+- ansible.builtin.debug:
+    msg: This bgp_disable_policy is not supported on {{ image_version }}
   when: imagetag is search("A8|D1")
 
 - set_fact: bgp_disable_policy="false"
@@ -66,7 +68,8 @@
     - assert: *id004
       when: bgp_disable_policy
   rescue:
-    - debug: msg="Tests can fail on A8 or helsinki images"
+    - ansible.builtin.debug:
+        msg: Tests can fail on A8 or helsinki images
   always:
     - name: Disable feature bgp
       ignore_errors: true
@@ -74,4 +77,5 @@
         feature: bgp
         state: disabled
 
-    - debug: msg="END connection={{ ansible_connection }} nxos_bgp parameter test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_bgp parameter test

--- a/tests/integration/targets/nxos_bgp/tests/common/hels.yaml
+++ b/tests/integration/targets/nxos_bgp/tests/common/hels.yaml
@@ -1,7 +1,9 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_bgp parameter test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_bgp parameter test
 
-- debug: msg="This test is not supported on {{ image_version }}"
+- ansible.builtin.debug:
+    msg: This test is not supported on {{ image_version }}
   when: imagetag is search("D1")
 
 - set_fact: test_helsinki="false"
@@ -81,7 +83,8 @@
     - assert: *id004
       when: test_helsinki
   rescue:
-    - debug: msg="Tests can fail on helsinki images"
+    - ansible.builtin.debug:
+        msg: Tests can fail on helsinki images
   always:
     - name: Disable feature bgp
       ignore_errors: true
@@ -90,4 +93,5 @@
         feature: bgp
         state: disabled
 
-    - debug: msg="END connection={{ ansible_connection }} nxos_bgp parameter test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_bgp parameter test

--- a/tests/integration/targets/nxos_bgp/tests/common/isolate.yaml
+++ b/tests/integration/targets/nxos_bgp/tests/common/isolate.yaml
@@ -1,7 +1,9 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_bgp parameter test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_bgp parameter test
 
-- debug: msg="This bgp_isolate is not supported on {{ image_version }}"
+- ansible.builtin.debug:
+    msg: This bgp_isolate is not supported on {{ image_version }}
   when: imagetag is search("A8")
 
 - set_fact: bgp_isolate="false"
@@ -62,7 +64,8 @@
     - assert: *id004
       when: bgp_isolate
   rescue:
-    - debug: msg="Tests can fail on A8 images"
+    - ansible.builtin.debug:
+        msg: Tests can fail on A8 images
   always:
     - name: Disable feature bgp
       ignore_errors: true
@@ -70,4 +73,5 @@
         feature: bgp
         state: disabled
 
-    - debug: msg="END connection={{ ansible_connection }} nxos_bgp parameter test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_bgp parameter test

--- a/tests/integration/targets/nxos_bgp/tests/common/param.yaml
+++ b/tests/integration/targets/nxos_bgp/tests/common/param.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_bgp parameter test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_bgp parameter test
 
 - name: Disable feature BGP
   ignore_errors: true
@@ -253,4 +254,5 @@
         feature: bgp
         state: disabled
 
-    - debug: msg="END connection={{ ansible_connection }} nxos_bgp parameter test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_bgp parameter test

--- a/tests/integration/targets/nxos_bgp/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_bgp/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_bgp sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_bgp sanity test
 
 - set_fact: neighbor_down_fib_accelerate="true"
   when: (not titanium) and ((imagetag != 'N1') and (imagetag != 'D1'))
@@ -127,4 +128,5 @@
         feature: bgp
         state: disabled
   always:
-    - debug: msg="END connection={{ ansible_connection }} nxos_bgp sanity test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_bgp sanity test

--- a/tests/integration/targets/nxos_bgp/tests/common/supp_fib.yaml
+++ b/tests/integration/targets/nxos_bgp/tests/common/supp_fib.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_bgp parameter test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_bgp parameter test
 
 - set_fact: bgp_best_path_limit="false"
 
@@ -98,7 +99,8 @@
     - assert: *id004
       when: bgp_suppress_fib_supported
   rescue:
-    - debug: msg="Tests can fail on I2/I4/A8/Fretta or helsinki images"
+    - ansible.builtin.debug:
+        msg: Tests can fail on I2/I4/A8/Fretta or helsinki images
   always:
     - name: Disable feature bgp
       ignore_errors: true
@@ -106,4 +108,5 @@
         feature: bgp
         state: disabled
 
-    - debug: msg="END connection={{ ansible_connection }} nxos_bgp parameter test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_bgp parameter test

--- a/tests/integration/targets/nxos_bgp_af/tests/common/multisite.yaml
+++ b/tests/integration/targets/nxos_bgp_af/tests/common/multisite.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_bgp_af multisite sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_bgp_af multisite sanity test
 
 - name: Enable feature BGP - multisite
   ignore_errors: true
@@ -15,7 +16,7 @@
 
 - name: Setup - multisite
   ignore_errors: true
-  cisco.nxos.nxos_bgp: &id012
+  cisco.nxos.nxos_bgp:
     asn: 65535
     state: absent
 
@@ -51,13 +52,13 @@
       register: result
       cisco.nxos.nxos_bgp_af: *id001
 
-    - assert: &id003
+    - assert: &id004
         that:
           - result.changed == false
 
     - name: Configure BGP_AF  Route Target Default
       register: result
-      cisco.nxos.nxos_bgp_af: &id004
+      cisco.nxos.nxos_bgp_af: &id003
         asn: 65535
         afi: l2vpn
         safi: evpn
@@ -68,9 +69,9 @@
 
     - name: Check Idempotence
       register: result
-      cisco.nxos.nxos_bgp_af: *id004
+      cisco.nxos.nxos_bgp_af: *id003
 
-    - assert: *id003
+    - assert: *id004
 
     - name: Configure BGP_AF 1 Route Target All
       register: result
@@ -87,11 +88,11 @@
       register: result
       cisco.nxos.nxos_bgp_af: *id005
 
-    - assert: *id003
+    - assert: *id004
 
     - name: Remove BGP - Route Target
       register: result
-      cisco.nxos.nxos_bgp_af: &id006
+      cisco.nxos.nxos_bgp_af:
         asn: 65535
         afi: l2vpn
         safi: evpn
@@ -127,4 +128,5 @@
     lines:
       - no nv overlay evpn
 
-- debug: msg="END connection={{ ansible_connection }} nxos_bgp_af multisite sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_bgp_af multisite sanity test

--- a/tests/integration/targets/nxos_bgp_af/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_bgp_af/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_bgp_af sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_bgp_af sanity test
 
 - set_fact: advertise_l2vpn_evpn="true"
   when: platform is search('N9K')
@@ -207,19 +208,26 @@
         dampening_reuse_time: 2
         dampening_suppress_time: 3
         inject_map:
-          [
-            [lax_inject_map, lax_exist_map],
-            [nyc_inject_map, nyc_exist_map, copy-attributes],
-            [fsd_inject_map, fsd_exist_map],
-          ]
+          -   - lax_inject_map
+              - lax_exist_map
+          -   - nyc_inject_map
+              - nyc_exist_map
+              - copy-attributes
+          -   - fsd_inject_map
+              - fsd_exist_map
         networks:
-          [
-            [10.0.0.0/16, routemap_LA],
-            [192.168.1.1/32, Chicago],
-            [192.168.2.0/24],
-            [192.168.3.0/24, routemap_NYC],
-          ]
-        redistribute: [[direct, rm_direct], [lisp, rm_lisp]]
+          -   - 10.0.0.0/16
+              - routemap_LA
+          -   - 192.168.1.1/32
+              - Chicago
+          -   - 192.168.2.0/24
+          -   - 192.168.3.0/24
+              - routemap_NYC
+        redistribute:
+          -   - direct
+              - rm_direct
+          -   - lisp
+              - rm_lisp
         state: present
 
     - assert: *id002
@@ -244,9 +252,14 @@
         dampening_max_suppress_time: 40
         dampening_reuse_time: 20
         dampening_suppress_time: 30
-        inject_map: [[fsd_inject_map, fsd_exist_map]]
-        networks: [[192.168.2.0/24]]
-        redistribute: [[lisp, rm_lisp]]
+        inject_map:
+          -   - fsd_inject_map
+              - fsd_exist_map
+        networks:
+          -   - 192.168.2.0/24
+        redistribute:
+          -   - lisp
+              - rm_lisp
         state: present
 
     - assert: *id002
@@ -323,4 +336,5 @@
         lines:
           - no nv overlay evpn
 
-    - debug: msg="END connection={{ ansible_connection }} nxos_bgp_af sanity test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_bgp_af sanity test

--- a/tests/integration/targets/nxos_bgp_af/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_bgp_af/tests/common/sanity.yaml
@@ -208,26 +208,26 @@
         dampening_reuse_time: 2
         dampening_suppress_time: 3
         inject_map:
-          -   - lax_inject_map
-              - lax_exist_map
-          -   - nyc_inject_map
-              - nyc_exist_map
-              - copy-attributes
-          -   - fsd_inject_map
-              - fsd_exist_map
+          - - lax_inject_map
+            - lax_exist_map
+          - - nyc_inject_map
+            - nyc_exist_map
+            - copy-attributes
+          - - fsd_inject_map
+            - fsd_exist_map
         networks:
-          -   - 10.0.0.0/16
-              - routemap_LA
-          -   - 192.168.1.1/32
-              - Chicago
-          -   - 192.168.2.0/24
-          -   - 192.168.3.0/24
-              - routemap_NYC
+          - - 10.0.0.0/16
+            - routemap_LA
+          - - 192.168.1.1/32
+            - Chicago
+          - - 192.168.2.0/24
+          - - 192.168.3.0/24
+            - routemap_NYC
         redistribute:
-          -   - direct
-              - rm_direct
-          -   - lisp
-              - rm_lisp
+          - - direct
+            - rm_direct
+          - - lisp
+            - rm_lisp
         state: present
 
     - assert: *id002
@@ -253,13 +253,13 @@
         dampening_reuse_time: 20
         dampening_suppress_time: 30
         inject_map:
-          -   - fsd_inject_map
-              - fsd_exist_map
+          - - fsd_inject_map
+            - fsd_exist_map
         networks:
-          -   - 192.168.2.0/24
+          - - 192.168.2.0/24
         redistribute:
-          -   - lisp
-              - rm_lisp
+          - - lisp
+            - rm_lisp
         state: present
 
     - assert: *id002

--- a/tests/integration/targets/nxos_bgp_neighbor/tests/common/multisite.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor/tests/common/multisite.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_bgp_neighbor multisite sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_bgp_neighbor multisite sanity test
 
 - set_fact: intname="{{ nxos_int1 }}"
 
@@ -59,13 +58,13 @@
       register: result
       cisco.nxos.nxos_bgp_neighbor: *id001
 
-    - assert: &id003
+    - assert: &id004
         that:
           - result.changed == false
 
     - name: Configure BGP neighbor2 - multisite
       register: result
-      cisco.nxos.nxos_bgp_neighbor: &id004
+      cisco.nxos.nxos_bgp_neighbor: &id003
         asn: 65535
         neighbor: 192.0.2.3/32
         peer_type: disable
@@ -74,9 +73,9 @@
 
     - name: Check Idempotence
       register: result
-      cisco.nxos.nxos_bgp_neighbor: *id004
+      cisco.nxos.nxos_bgp_neighbor: *id003
 
-    - assert: *id003
+    - assert: *id004
 
     - name: Configure BGP neighbor3 - multisite
       register: result
@@ -91,7 +90,7 @@
       register: result
       cisco.nxos.nxos_bgp_neighbor: *id005
 
-    - assert: *id003
+    - assert: *id004
 
     - name: Disable multisite border gateway - multisite
       cisco.nxos.nxos_config:
@@ -118,4 +117,5 @@
     lines:
       - no nv overlay evpn
 
-- debug: msg="END connection={{ ansible_connection }} nxos_bgp_neighbor multisite sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_bgp_neighbor multisite sanity test

--- a/tests/integration/targets/nxos_bgp_neighbor/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor/tests/common/sanity.yaml
@@ -1,6 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_bgp_neighbor sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_bgp_neighbor sanity test
 
 - set_fact: intname="{{ nxos_int1 }}"
 
@@ -343,4 +343,5 @@
         feature: "{{ item }}"
         state: disabled
 
-- debug: msg="END connection={{ ansible_connection }} nxos_bgp_neighbor sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_bgp_neighbor sanity test

--- a/tests/integration/targets/nxos_bgp_neighbor_af/tests/common/multisite.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_af/tests/common/multisite.yaml
@@ -1,14 +1,13 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_bgp_neighbor_af multisite
-    sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_bgp_neighbor_af multisite sanity test
 
 - set_fact: soft_reconfiguration_ina="always"
   when: imagetag is not search("D1|N1")
 
 - name: Disable feature BGP - multisite
   ignore_errors: true
-  cisco.nxos.nxos_feature: &id013
+  cisco.nxos.nxos_feature:
     feature: bgp
     state: disabled
 
@@ -63,13 +62,13 @@
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: *id001
 
-    - assert: &id003
+    - assert: &id004
         that:
           - result.changed == false
 
     - name: Configure BGP neighbor 1 - multisite
       register: result
-      cisco.nxos.nxos_bgp_neighbor_af: &id004
+      cisco.nxos.nxos_bgp_neighbor_af: &id003
         asn: 65535
         neighbor: 192.0.2.3
         afi: l2vpn
@@ -82,9 +81,9 @@
 
     - name: Check Idempotence
       register: result
-      cisco.nxos.nxos_bgp_neighbor_af: *id004
+      cisco.nxos.nxos_bgp_neighbor_af: *id003
 
-    - assert: *id003
+    - assert: *id004
 
     - name: Disable multisite border gateway - multisite
       cisco.nxos.nxos_config:
@@ -112,6 +111,5 @@
     lines:
       - no nv overlay evpn
 
-- debug:
-    msg="END connection={{ ansible_connection }} nxos_bgp_neighbor_af multisite
-    sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_bgp_neighbor_af multisite sanity test

--- a/tests/integration/targets/nxos_bgp_neighbor_af/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_af/tests/common/sanity.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_bgp_neighbor_af sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_bgp_neighbor_af sanity test
 
 - set_fact: soft_reconfiguration_ina="always"
   when: imagetag is not search("D1|N1")
@@ -290,6 +289,5 @@
     - name: Disable feature bgp
       cisco.nxos.nxos_feature: *id013
 
-    - debug:
-        msg="END connection={{ ansible_connection }} nxos_bgp_neighbor_af sanity
-        test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_bgp_neighbor_af sanity test

--- a/tests/integration/targets/nxos_command/tests/cli/cli_command.yaml
+++ b/tests/integration/targets/nxos_command/tests/cli/cli_command.yaml
@@ -23,4 +23,5 @@
       - result.failed == true
       - result.msg is defined
 
-- debug: msg="END cli/cli_command.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END cli/cli_command.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_command/tests/cli/contains.yaml
+++ b/tests/integration/targets/nxos_command/tests/cli/contains.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START common/contains.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: START common/contains.yaml on connection={{ ansible_connection }}
 
 - name: test contains operator
   register: result
@@ -15,4 +16,5 @@
     that:
       - result.changed == false
 
-- debug: msg="END common/contains.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END common/contains.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_command/tests/cli/sanity.yaml
+++ b/tests/integration/targets/nxos_command/tests/cli/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START cli/sanity.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: START cli/sanity.yaml on connection={{ ansible_connection }}
 
 - name: Disable feature BGP
   cisco.nxos.nxos_feature:
@@ -54,11 +55,13 @@
 
     - assert: *id001
   rescue:
-    - debug: msg="nxos_command sanity test failure detected"
+    - ansible.builtin.debug:
+        msg: nxos_command sanity test failure detected
   always:
     - name: Disable feature bgp
       cisco.nxos.nxos_feature:
         feature: bgp
         state: disabled
 
-- debug: msg="END cli/sanity.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END cli/sanity.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_command/tests/common/bad_operator.yaml
+++ b/tests/integration/targets/nxos_command/tests/common/bad_operator.yaml
@@ -1,6 +1,6 @@
 ---
-- debug: msg="START common/bad_operator.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: START common/bad_operator.yaml on connection={{ ansible_connection }}
 
 - name: test bad operator
   register: result
@@ -17,4 +17,5 @@
       - result.failed == true
       - result.msg is defined
 
-- debug: msg="END common/bad_operator.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END common/bad_operator.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_command/tests/common/equal.yaml
+++ b/tests/integration/targets/nxos_command/tests/common/equal.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START common/equal.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: START common/equal.yaml on connection={{ ansible_connection }}
 
 - name: test eq operator
   register: result
@@ -27,4 +28,5 @@
     that:
       - result.changed == false
 
-- debug: msg="END common/equal.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END common/equal.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_command/tests/common/greaterthan.yaml
+++ b/tests/integration/targets/nxos_command/tests/common/greaterthan.yaml
@@ -1,6 +1,6 @@
 ---
-- debug: msg="START common/greaterthan.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: START common/greaterthan.yaml on connection={{ ansible_connection }}
 
 - name: test gt operator
   register: result
@@ -28,4 +28,5 @@
     that:
       - result.changed == false
 
-- debug: msg="END common/greaterthan.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END common/greaterthan.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_command/tests/common/greaterthanorequal.yaml
+++ b/tests/integration/targets/nxos_command/tests/common/greaterthanorequal.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START common/greaterthanorequal.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: START common/greaterthanorequal.yaml on connection={{ ansible_connection }}
 
 - name: test ge operator
   register: result
@@ -29,6 +28,5 @@
     that:
       - result.changed == false
 
-- debug:
-    msg="END common/greaterthanorequal.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: END common/greaterthanorequal.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_command/tests/common/invalid.yaml
+++ b/tests/integration/targets/nxos_command/tests/common/invalid.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START common/invalid.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: START common/invalid.yaml on connection={{ ansible_connection }}
 
 - name: run invalid command
   register: result
@@ -24,4 +25,5 @@
     that:
       - result.failed == true
 
-- debug: msg="END common/invalid.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END common/invalid.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_command/tests/common/lessthan.yaml
+++ b/tests/integration/targets/nxos_command/tests/common/lessthan.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START common/lessthan.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: START common/lessthan.yaml on connection={{ ansible_connection }}
 
 - name: test lt operator
   register: result
@@ -27,4 +28,5 @@
     that:
       - result.changed == false
 
-- debug: msg="END common/lessthan.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END common/lessthan.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_command/tests/common/lessthanorequal.yaml
+++ b/tests/integration/targets/nxos_command/tests/common/lessthanorequal.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START common/lessthanorequal.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: START common/lessthanorequal.yaml on connection={{ ansible_connection }}
 
 - name: test le operator
   register: result
@@ -29,6 +28,5 @@
     that:
       - result.changed == false
 
-- debug:
-    msg="END common/lessthanorequal.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: END common/lessthanorequal.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_command/tests/common/not_comparison_operator.yaml
+++ b/tests/integration/targets/nxos_command/tests/common/not_comparison_operator.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START common/not_comparison_operator.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: START common/not_comparison_operator.yaml on connection={{ ansible_connection }}
 
 - name: test 'not' keyword in wait_for
   register: result
@@ -17,6 +16,5 @@
     that:
       - result.changed == false
 
-- debug:
-    msg="END common/not_comparison_operator.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: END common/not_comparison_operator.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_command/tests/common/notequal.yaml
+++ b/tests/integration/targets/nxos_command/tests/common/notequal.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START common/notequal.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: START common/notequal.yaml on connection={{ ansible_connection }}
 
 - name: test neq operator
   register: result
@@ -29,4 +30,5 @@
       - result.changed == false
       - result.stdout is defined
 
-- debug: msg="END common/notequal.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END common/notequal.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_command/tests/common/output.yaml
+++ b/tests/integration/targets/nxos_command/tests/common/output.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START common/output.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: START common/output.yaml on connection={{ ansible_connection }}
 
 - name: get output for single command
   register: result
@@ -22,4 +23,5 @@
     that:
       - result.changed == false
 
-- debug: msg="END common/output.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END common/output.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_command/tests/common/timeout.yaml
+++ b/tests/integration/targets/nxos_command/tests/common/timeout.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START common/timeout.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: START common/timeout.yaml on connection={{ ansible_connection }}
 
 - name: test bad condition
   register: result
@@ -15,4 +16,5 @@
       - result.failed == true
       - result.msg is defined
 
-- debug: msg="END common/timeout.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END common/timeout.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_command/tests/nxapi/contains.yaml
+++ b/tests/integration/targets/nxos_command/tests/nxapi/contains.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START common/contains.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: START common/contains.yaml on connection={{ ansible_connection }}
 
 - name: test contains operator
   register: result
@@ -18,4 +19,5 @@
     that:
       - result.changed == false
 
-- debug: msg="END common/contains.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END common/contains.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_command/tests/nxapi/sanity.yaml
+++ b/tests/integration/targets/nxos_command/tests/nxapi/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START nxapi/sanity.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: START nxapi/sanity.yaml on connection={{ ansible_connection }}
 
 - name: Disable feature BGP
   cisco.nxos.nxos_feature:
@@ -54,11 +55,13 @@
 
     - assert: *id001
   rescue:
-    - debug: msg="nxos_command sanity test failure detected"
+    - ansible.builtin.debug:
+        msg: nxos_command sanity test failure detected
   always:
     - name: Disable feature bgp
       cisco.nxos.nxos_feature:
         feature: bgp
         state: disabled
 
-- debug: msg="END nxapi/sanity.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END nxapi/sanity.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_config/tests/cli/diff.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli/diff.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START cli/diff.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: START cli/diff.yaml on connection={{ ansible_connection }}
 
 - name: setup hostname
   cisco.nxos.nxos_config:
@@ -10,9 +11,7 @@
   register: result
   cisco.nxos.nxos_config:
     diff_against: intended
-    intended_config:
-      "{{ lookup('file', '{{ role_path }}/templates/basic/intended_running_config')\
-      \ }}"
+    intended_config: "{{ lookup('file', '{{ role_path }}/templates/basic/intended_running_config') }}"
 
 - assert:
     that:
@@ -24,16 +23,13 @@
   register: result
   cisco.nxos.nxos_config:
     diff_against: intended
-    intended_config:
-      "{{ lookup('file', '{{ role_path }}/templates/basic/intended_running_config')\
-      \ }}"
-    running_config:
-      "{{ lookup('file', '{{ role_path }}/templates/basic/base_running_config')\
-      \ }}"
+    intended_config: "{{ lookup('file', '{{ role_path }}/templates/basic/intended_running_config') }}"
+    running_config: "{{ lookup('file', '{{ role_path }}/templates/basic/base_running_config') }}"
 
 - assert:
     that:
       - "'hostname an-nxos9k-01.ansible.com' in result['diff']['after']"
       - "'hostname an-nxos9k-02.ansible.com' in result['diff']['before']"
 
-- debug: msg="END cli/diff.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END cli/diff.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_config/tests/cli/multilevel.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli/multilevel.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START cli/mulitlevel.yaml"
+- ansible.builtin.debug:
+    msg: START cli/mulitlevel.yaml
 
 - name: get config
   register: config
@@ -49,4 +50,5 @@
       - no feature bgp
     match: none
 
-- debug: msg="END cli/mulitlevel.yaml"
+- ansible.builtin.debug:
+    msg: END cli/mulitlevel.yaml

--- a/tests/integration/targets/nxos_config/tests/cli/sublevel.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli/sublevel.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg='START cli/sublevel.yaml'
+- ansible.builtin.debug:
+    msg: START cli/sublevel.yaml
 
 - name: setup
   cisco.nxos.nxos_config:
@@ -33,4 +34,5 @@
     lines: no ip access-list test
     match: none
 
-- debug: msg='END cli/sublevel.yaml'
+- ansible.builtin.debug:
+    msg: END cli/sublevel.yaml

--- a/tests/integration/targets/nxos_config/tests/cli/sublevel_exact.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli/sublevel_exact.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg='START cli/sublevel_exact.yaml'
+- ansible.builtin.debug:
+    msg: START cli/sublevel_exact.yaml
 
 - name: setup
   cisco.nxos.nxos_config:
@@ -55,4 +56,5 @@
     lines: no ip access-list test
     match: none
 
-- debug: msg='END cli/sublevel_exact.yaml'
+- ansible.builtin.debug:
+    msg: END cli/sublevel_exact.yaml

--- a/tests/integration/targets/nxos_config/tests/cli/sublevel_strict.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli/sublevel_strict.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg='START cli/sublevel_strict.yaml'
+- ansible.builtin.debug:
+    msg: START cli/sublevel_strict.yaml
 
 - name: setup
   cisco.nxos.nxos_config:
@@ -56,4 +57,5 @@
     commands: no ip access-list test
     match: none
 
-- debug: msg='END cli/sublevel_strict.yaml'
+- ansible.builtin.debug:
+    msg: END cli/sublevel_strict.yaml

--- a/tests/integration/targets/nxos_config/tests/cli/toplevel_after.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli/toplevel_after.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg='START cli/toplevel_after.yaml'
+- ansible.builtin.debug:
+    msg: START cli/toplevel_after.yaml
 
 - name: setup
   cisco.nxos.nxos_config:
@@ -37,4 +38,5 @@
       - hostname switch
     match: none
 
-- debug: msg='END cli/toplevel_after.yaml'
+- ansible.builtin.debug:
+    msg: END cli/toplevel_after.yaml

--- a/tests/integration/targets/nxos_config/tests/cli/toplevel_before.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli/toplevel_before.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg='START cli/toplevel_before.yaml'
+- ansible.builtin.debug:
+    msg: START cli/toplevel_before.yaml
 
 - name: setup
   cisco.nxos.nxos_config:
@@ -37,4 +38,5 @@
       - hostname switch
     match: none
 
-- debug: msg='END cli/toplevel_before.yaml'
+- ansible.builtin.debug:
+    msg: END cli/toplevel_before.yaml

--- a/tests/integration/targets/nxos_config/tests/cli_config/cli_backup.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli_config/cli_backup.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="END cli_config/backup.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END cli_config/backup.yaml on connection={{ ansible_connection }}
 
 - set_fact: can_become="true"
 
@@ -116,4 +117,5 @@
     that:
       - backup_file.files is defined
 
-- debug: msg="END cli_config/backup.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END cli_config/backup.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_config/tests/cli_config/cli_basic.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli_config/cli_basic.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START cli_config/cli_basic.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: START cli_config/cli_basic.yaml on connection={{ ansible_connection }}
 
 - name: setup
   ansible.netcommon.cli_config: &id002
@@ -41,5 +40,5 @@
 - name: teardown
   ansible.netcommon.cli_config: *id002
 
-- debug: msg="END cli_config/cli_basic.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: END cli_config/cli_basic.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_config/tests/cli_config/cli_block_replace.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli_config/cli_block_replace.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START cli_config/cli_block_replace.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: START cli_config/cli_block_replace.yaml on connection={{ ansible_connection }}
 
 - name: setup - remove configuration
   ansible.netcommon.cli_config: &id002
@@ -29,6 +28,5 @@
 - name: teardown
   ansible.netcommon.cli_config: *id002
 
-- debug:
-    msg="END cli_config/cli_block_replace.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: END cli_config/cli_block_replace.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_config/tests/cli_config/cli_exact_match.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli_config/cli_exact_match.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START cli_config/cli_exact_match.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: START cli_config/cli_exact_match.yaml on connection={{ ansible_connection }}
 
 - name: setup - remove configuration
   ansible.netcommon.cli_config:
@@ -32,6 +31,5 @@
     config: no ip access-list test
     diff_match: none
 
-- debug:
-    msg="END cli_config/cli_exact_match.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: END cli_config/cli_exact_match.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_config/tests/cli_config/cli_strict_match.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli_config/cli_strict_match.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START cli_config/cli_strict_match.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: START cli_config/cli_strict_match.yaml on connection={{ ansible_connection }}
 
 - name: setup - remove configuration
   ansible.netcommon.cli_config:
@@ -24,6 +23,5 @@
     config: no ip access-list test
     diff_match: none
 
-- debug:
-    msg="END cli_config/cli_strict_match.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: END cli_config/cli_strict_match.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_config/tests/common/backup.yaml
+++ b/tests/integration/targets/nxos_config/tests/common/backup.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START common/backup.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: START common/backup.yaml on connection={{ ansible_connection }}
 
 - set_fact: intname="{{ nxos_int1 }}"
 
@@ -122,4 +123,5 @@
     that:
       - backup_file.files is defined
 
-- debug: msg="END common/backup.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END common/backup.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_config/tests/common/defaults.yaml
+++ b/tests/integration/targets/nxos_config/tests/common/defaults.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START common/defaults.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: START common/defaults.yaml on connection={{ ansible_connection }}
 
 - set_fact: intname="{{ nxos_int1 }}"
 
@@ -22,7 +23,8 @@
       - interface {{ intname }}
     defaults: true
 
-- debug: var=result
+- ansible.builtin.debug:
+    var: result
 
 - assert:
     that:
@@ -39,11 +41,13 @@
       - interface {{ intname }}
     defaults: true
 
-- debug: var=result
+- ansible.builtin.debug:
+    var: result
 
 - assert:
     that:
       - result.changed == false
       - result.updates is not defined
 
-- debug: msg="END common/defaults.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END common/defaults.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_config/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_config/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START common/sanity.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: START common/sanity.yaml on connection={{ ansible_connection }}
 
 - name: setup
   cisco.nxos.nxos_config:
@@ -34,7 +35,8 @@
     lines: no ip access-list test
     match: none
 
-- debug: msg='Verify https://github.com/ansible/ansible/issues/50635'
+- ansible.builtin.debug:
+    msg: Verify https://github.com/ansible/ansible/issues/50635
 
 - name: PUT INTERFACE INTO DEFAULT STATE
   cisco.nxos.nxos_config:
@@ -68,4 +70,5 @@
     that:
       - result.changed == false
 
-- debug: msg="END common/sanity.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END common/sanity.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_config/tests/common/save.yaml
+++ b/tests/integration/targets/nxos_config/tests/common/save.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START common/save.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: START common/save.yaml on connection={{ ansible_connection }}
 
 - set_fact: intname="{{ nxos_int1 }}"
 
@@ -30,4 +31,5 @@
     that:
       - result.changed == true
 
-- debug: msg="END common/save.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END common/save.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_config/tests/common/src_basic.yaml
+++ b/tests/integration/targets/nxos_config/tests/common/src_basic.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START common/src_basic.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: START common/src_basic.yaml on connection={{ ansible_connection }}
 
 - set_fact: intname="loopback1"
 
@@ -33,4 +34,5 @@
       - result.changed == false
       - result.updates is not defined
 
-- debug: msg="END common/src_basic.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END common/src_basic.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_config/tests/common/src_invalid.yaml
+++ b/tests/integration/targets/nxos_config/tests/common/src_invalid.yaml
@@ -1,6 +1,6 @@
 ---
-- debug: msg="START common/src_invalid.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: START common/src_invalid.yaml on connection={{ ansible_connection }}
 
 - name: configure with invalid src
   register: result
@@ -13,4 +13,5 @@
       - result.failed == true
       - result.msg == 'path specified in src not found'
 
-- debug: msg="END common/src_invalid.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END common/src_invalid.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_config/tests/common/src_match_none.yaml
+++ b/tests/integration/targets/nxos_config/tests/common/src_match_none.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START common/src_match_none.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: START common/src_match_none.yaml on connection={{ ansible_connection }}
 
 - set_fact: intname="{{ nxos_int1 }}"
 
@@ -45,5 +44,5 @@
       - result.changed == false
       - result.updates is not defined
 
-- debug: msg="END common/src_match_none.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: END common/src_match_none.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_config/tests/common/sublevel_block.yaml
+++ b/tests/integration/targets/nxos_config/tests/common/sublevel_block.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg='START common/sublevel_block.yaml on connection={{ ansible_connection
-    }}'
+- ansible.builtin.debug:
+    msg: START common/sublevel_block.yaml on connection={{ ansible_connection }}
 
 - name: setup
   ignore_errors: true
@@ -47,5 +46,5 @@
 - name: teardown
   cisco.nxos.nxos_config: *id001
 
-- debug: msg='END common/sublevel_block.yaml on connection={{ ansible_connection
-    }}'
+- ansible.builtin.debug:
+    msg: END common/sublevel_block.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_config/tests/common/toplevel.yaml
+++ b/tests/integration/targets/nxos_config/tests/common/toplevel.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg='START common/toplevel.yaml on connection={{ ansible_connection }}'
+- ansible.builtin.debug:
+    msg: START common/toplevel.yaml on connection={{ ansible_connection }}
 
 - name: setup
   cisco.nxos.nxos_config:
@@ -30,4 +31,5 @@
     lines: hostname switch
     match: none
 
-- debug: msg='END common/toplevel.yaml on connection={{ ansible_connection }}'
+- ansible.builtin.debug:
+    msg: END common/toplevel.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_config/tests/common/toplevel_nonidempotent.yaml
+++ b/tests/integration/targets/nxos_config/tests/common/toplevel_nonidempotent.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START common/nonidempotent.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: START common/nonidempotent.yaml on connection={{ ansible_connection }}
 
 - name: setup
   cisco.nxos.nxos_config:
@@ -34,5 +33,5 @@
     lines: hostname switch
     match: none
 
-- debug: msg="END common/nonidempotent.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: END common/nonidempotent.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_config/tests/nxapi/multilevel.yaml
+++ b/tests/integration/targets/nxos_config/tests/nxapi/multilevel.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START nxapi/mulitlevel.yaml"
+- ansible.builtin.debug:
+    msg: START nxapi/mulitlevel.yaml
 
 - name: setup
   cisco.nxos.nxos_config:
@@ -38,4 +39,5 @@
     lines: no feature bgp
     match: none
 
-- debug: msg="END nxapi/mulitlevel.yaml"
+- ansible.builtin.debug:
+    msg: END nxapi/mulitlevel.yaml

--- a/tests/integration/targets/nxos_config/tests/nxapi/sublevel.yaml
+++ b/tests/integration/targets/nxos_config/tests/nxapi/sublevel.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START nxapi/sublevel.yaml"
+- ansible.builtin.debug:
+    msg: START nxapi/sublevel.yaml
 
 - name: setup
   ignore_errors: true
@@ -34,4 +35,5 @@
     lines: no ip access-list test
     match: none
 
-- debug: msg="END nxapi/sublevel.yaml"
+- ansible.builtin.debug:
+    msg: END nxapi/sublevel.yaml

--- a/tests/integration/targets/nxos_config/tests/nxapi/sublevel_exact.yaml
+++ b/tests/integration/targets/nxos_config/tests/nxapi/sublevel_exact.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START nxapi/sublevel_exact.yaml"
+- ansible.builtin.debug:
+    msg: START nxapi/sublevel_exact.yaml
 
 - name: setup
   ignore_errors: true
@@ -56,4 +57,5 @@
     lines: no ip access-list test
     match: none
 
-- debug: msg="END nxapi/sublevel_exact.yaml"
+- ansible.builtin.debug:
+    msg: END nxapi/sublevel_exact.yaml

--- a/tests/integration/targets/nxos_config/tests/nxapi/sublevel_strict.yaml
+++ b/tests/integration/targets/nxos_config/tests/nxapi/sublevel_strict.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START nxapi/sublevel_strict.yaml"
+- ansible.builtin.debug:
+    msg: START nxapi/sublevel_strict.yaml
 
 - name: setup
   cisco.nxos.nxos_config:
@@ -55,4 +56,5 @@
     lines: no ip access-list test
     match: none
 
-- debug: msg="END nxapi/sublevel_strict.yaml"
+- ansible.builtin.debug:
+    msg: END nxapi/sublevel_strict.yaml

--- a/tests/integration/targets/nxos_config/tests/nxapi/toplevel_after.yaml
+++ b/tests/integration/targets/nxos_config/tests/nxapi/toplevel_after.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START nxapi/toplevel_after.yaml"
+- ansible.builtin.debug:
+    msg: START nxapi/toplevel_after.yaml
 
 - name: setup
   cisco.nxos.nxos_config:
@@ -37,4 +38,5 @@
       - hostname switch
     match: none
 
-- debug: msg="END nxapi/toplevel_after.yaml"
+- ansible.builtin.debug:
+    msg: END nxapi/toplevel_after.yaml

--- a/tests/integration/targets/nxos_config/tests/nxapi/toplevel_before.yaml
+++ b/tests/integration/targets/nxos_config/tests/nxapi/toplevel_before.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START nxapi/toplevel_before.yaml"
+- ansible.builtin.debug:
+    msg: START nxapi/toplevel_before.yaml
 
 - name: setup
   cisco.nxos.nxos_config:
@@ -37,4 +38,5 @@
       - hostname switch
     match: none
 
-- debug: msg="END nxapi/toplevel_before.yaml"
+- ansible.builtin.debug:
+    msg: END nxapi/toplevel_before.yaml

--- a/tests/integration/targets/nxos_config/tests/redirection/cli/shortname.yaml
+++ b/tests/integration/targets/nxos_config/tests/redirection/cli/shortname.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START cli/shortname.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: START cli/shortname.yaml on connection={{ ansible_connection }}
 
 - name: Use src with module alias
   register: result
@@ -34,4 +35,5 @@
     that:
       - backup_file.files is defined
 
-- debug: msg="END cli/shortname.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END cli/shortname.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_devicealias/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_devicealias/tests/common/sanity.yaml
@@ -1,6 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_devicealias sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_devicealias sanity test
 
 - name: Setup - Remove device alias if configured
   ignore_errors: true
@@ -29,10 +29,8 @@
 
     - assert:
         that:
-          - result.commands == ["terminal dont-ask", "device-alias database", "device-alias
-            name ansible_test1_add pwwn 57:bb:cc:dd:ee:ff:11:67", "device-alias
-            name ansible_test2_add pwwn 65:22:21:20:19:18:1a:0d", "device-alias
-            commit", "no terminal dont-ask"]
+          - result.commands == ["terminal dont-ask", "device-alias database", "device-alias name ansible_test1_add pwwn 57:bb:cc:dd:ee:ff:11:67", "device-alias name
+            ansible_test2_add pwwn 65:22:21:20:19:18:1a:0d", "device-alias commit", "no terminal dont-ask"]
 
     - name: Idempotence Check
       register: result
@@ -49,6 +47,5 @@
     - name: Remove device alias config
       cisco.nxos.nxos_devicealias: *id002
 
-    - debug:
-        msg="END connection={{ ansible_connection }} nxos_devicealias sanity
-        test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_devicealias sanity test

--- a/tests/integration/targets/nxos_evpn_global/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_evpn_global/tests/common/sanity.yaml
@@ -1,6 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_evpn_global sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_evpn_global sanity test
 
 - name: Setup
   ignore_errors: true
@@ -52,9 +52,8 @@
     - assert: *id004
   when: not ( platform is search('N3K|N35|N3L'))
   rescue:
-    - debug:
-        msg="connection={{ ansible_connection }} nxos_evpn_global sanity test
-        - FALURE ENCOUNTERED"
+    - ansible.builtin.debug:
+        msg: connection={{ ansible_connection }} nxos_evpn_global sanity test - FALURE ENCOUNTERED
   always:
     - name: Cleanup - Disable nv overlay evpn
       ignore_errors: true
@@ -64,6 +63,5 @@
       ignore_errors: true
       cisco.nxos.nxos_feature: *id006
 
-    - debug:
-        msg="END connection={{ ansible_connection }} nxos_evpn_global sanity
-        test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_evpn_global sanity test

--- a/tests/integration/targets/nxos_evpn_vni/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_evpn_vni/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_evpn_vni sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_evpn_vni sanity test
 
 - set_fact: nvoe_supported="{{ platform is not search('N3K|N3L|N35')}}"
 
@@ -106,4 +107,5 @@
             state: disabled
       when: nvoe_supported
 
-- debug: msg="END connection={{ ansible_connection }} nxos_evpn_vni sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_evpn_vni sanity test

--- a/tests/integration/targets/nxos_facts/tests/common/all_facts.yaml
+++ b/tests/integration/targets/nxos_facts/tests/common/all_facts.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }}/all_facts.yaml"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }}/all_facts.yaml
 
 - name: test getting all facts
   register: result
@@ -34,4 +35,5 @@
       - "{{ result['ansible_facts']['available_network_resources'] | symmetric_difference(result['ansible_facts']['ansible_net_gather_network_resources']) |length\
         \ == 0 }}"
 
-- debug: msg="END connection={{ ansible_connection }}/all_facts.yaml"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }}/all_facts.yaml

--- a/tests/integration/targets/nxos_facts/tests/common/default_facts.yaml
+++ b/tests/integration/targets/nxos_facts/tests/common/default_facts.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }}/default_facts.yaml"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }}/default_facts.yaml
 
 - name: test getting default facts
   register: result
@@ -21,4 +22,5 @@
       - result.ansible_facts.ansible_net_version is defined
       - result.ansible_facts.ansible_network_resources == {}
 
-- debug: msg="END cli/default.yaml"
+- ansible.builtin.debug:
+    msg: END cli/default.yaml

--- a/tests/integration/targets/nxos_facts/tests/common/invalid_subset.yaml
+++ b/tests/integration/targets/nxos_facts/tests/common/invalid_subset.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }}/invalid_subset.yaml"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }}/invalid_subset.yaml
 
 - name: test invalid subset (foobar)
   register: result
@@ -14,4 +15,5 @@
       - result.failed == true
       - "'Subset must be one of' in result.msg"
 
-- debug: msg="END connection={{ ansible_connection }}/invalid_subset.yaml"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }}/invalid_subset.yaml

--- a/tests/integration/targets/nxos_facts/tests/common/not_hardware.yaml
+++ b/tests/integration/targets/nxos_facts/tests/common/not_hardware.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }}/not_hardware_facts.yaml"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }}/not_hardware_facts.yaml
 
 - name: test not hardware
   register: result
@@ -16,4 +17,5 @@
       - "'hardware' not in result.ansible_facts.ansible_net_gather_subset"
       - result.ansible_facts.ansible_net_filesystems is not defined
 
-- debug: msg="END connection={{ ansible_connection }}/not_hardware_facts.yaml"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }}/not_hardware_facts.yaml

--- a/tests/integration/targets/nxos_facts/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_facts/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_facts sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_facts sanity test
 
 - name: nxos_facts gather hardware facts
   register: result
@@ -58,4 +59,5 @@
       - "'features' in result.ansible_facts.ansible_net_gather_subset"
       - result.ansible_facts.ansible_net_features_enabled is defined
 
-- debug: msg="END connection={{ ansible_connection }} nxos_facts sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_facts sanity test

--- a/tests/integration/targets/nxos_feature/tests/common/configure.yaml
+++ b/tests/integration/targets/nxos_feature/tests/common/configure.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }}/configure.yaml"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }}/configure.yaml
 
 - name: setup
   cisco.nxos.nxos_config: &teardown
@@ -93,4 +94,5 @@
 - name: teardown
   cisco.nxos.nxos_config: *teardown
 
-- debug: msg="END connection={{ ansible_connection }}/configure.yaml"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }}/configure.yaml

--- a/tests/integration/targets/nxos_feature/tests/common/invalid.yaml
+++ b/tests/integration/targets/nxos_feature/tests/common/invalid.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }}/invalid.yaml"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }}/invalid.yaml
 
 - name: configure invalid feature name
   register: result
@@ -11,4 +12,5 @@
     that:
       - result.failed == true
 
-- debug: msg="END connection={{ ansible_connection }}/invalid.yaml"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }}/invalid.yaml

--- a/tests/integration/targets/nxos_file_copy/tests/cli/input_validation.yaml
+++ b/tests/integration/targets/nxos_file_copy/tests/cli/input_validation.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START nxos_file_copy input_validation test"
+- ansible.builtin.debug:
+    msg: START nxos_file_copy input_validation test
 
 - name: Input Validation - param should be type <path>
   register: result
@@ -77,4 +78,5 @@
     that:
       - result is search("'value of file_pull_protocol must be one of:' scp, sftp, http, https, tftp, ftp, got: foobar")
 
-- debug: msg="END nxos_file_copy input_validation test"
+- ansible.builtin.debug:
+    msg: END nxos_file_copy input_validation test

--- a/tests/integration/targets/nxos_file_copy/tests/cli/negative.yaml
+++ b/tests/integration/targets/nxos_file_copy/tests/cli/negative.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START nxos_file_copy negative test"
+- ansible.builtin.debug:
+    msg: START nxos_file_copy negative test
 
 - set_fact:
     test_source_file: "data.cfg"
@@ -29,8 +30,7 @@
 
 - assert:
     that:
-      - result is search('Local file ./data.cfg_does_not_exist not
-        found')
+      - result is search('Local file ./data.cfg_does_not_exist not found')
 
 - name: Try and copy file using an invalid remote scp server name
   register: result
@@ -117,4 +117,5 @@
       - result.failed == True
       - "'Too many authentication failures' in result.module_stderr"
 
-- debug: msg="END nxos_file_copy negative test"
+- ansible.builtin.debug:
+    msg: END nxos_file_copy negative test

--- a/tests/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
+++ b/tests/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_file_copy sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_file_copy sanity test
 
 - set_fact:
     test_source_file: "data.cfg"
@@ -61,9 +62,7 @@
 
           - "'Sent: File copied to remote device.' in result.transfer_status"
 
-    - name:
-        Idempotence - Copy {{ test_source_file }} file from Ansible controller
-        to bootflash
+    - name: Idempotence - Copy {{ test_source_file }} file from Ansible controller to bootflash
       register: result
       cisco.nxos.nxos_file_copy: *id001
 
@@ -75,9 +74,7 @@
       register: result
       cisco.nxos.nxos_command: *id002
 
-    - name:
-        Copy {{ test_source_file }} file from Ansible controller to bootflash
-        renamed as {{ test_destination_file }}
+    - name: Copy {{ test_source_file }} file from Ansible controller to bootflash renamed as {{ test_destination_file }}
       register: result
       cisco.nxos.nxos_file_copy: &id003
         local_file: "{{ role_path }}/fixtures/{{ test_source_file }}"
@@ -93,9 +90,7 @@
           - "'{{ test_destination_file }}' in result.remote_file"
           - "'Sent: File copied to remote device.' in result.transfer_status"
 
-    - name:
-        Idempotence - Copy {{ test_source_file }} file from Ansible controller
-        to bootflash renamed as {{ test_destination_file }}
+    - name: Idempotence - Copy {{ test_source_file }} file from Ansible controller to bootflash renamed as {{ test_destination_file }}
       register: result
       cisco.nxos.nxos_file_copy: *id003
 
@@ -117,9 +112,7 @@
 
     - assert: *id004
 
-    - name:
-        Initiate copy from nxos device to copy {{ test_destination_file }} to
-        bootflash:dir1/dir2/dir3/{{ test_destination_file }}_copy
+    - name: Initiate copy from nxos device to copy {{ test_destination_file }} to bootflash:dir1/dir2/dir3/{{ test_destination_file }}_copy
       register: result
       cisco.nxos.nxos_file_copy: &id005
         file_pull: true
@@ -140,8 +133,7 @@
           - "'bootflash:dir1/dir2/dir3/{{ test_destination_file }}_copy' in result.local_file"
           - "'/{{ test_destination_file }}' in result.remote_file"
 
-          - "'Received: File copied/pulled to nxos device from remote scp server.'\
-            \ in result.transfer_status"
+          - "'Received: File copied/pulled to nxos device from remote scp server.' in result.transfer_status"
           - "'{{ mgmt0_ip }}' in result.remote_scp_server"
 
     - pause:
@@ -153,9 +145,7 @@
 
     - assert: *id006
 
-    - name:
-        Initiate copy with sftp from nxos device to copy /bootflash/{{ test_destination_file }} to
-        bootflash:dir2/dir2/dir3/{{ test_destination_file }}_another_copy
+    - name: Initiate copy with sftp from nxos device to copy /bootflash/{{ test_destination_file }} to bootflash:dir2/dir2/dir3/{{ test_destination_file }}_another_copy
       register: result
       cisco.nxos.nxos_file_copy:
         file_pull: true
@@ -177,8 +167,7 @@
           - "'bootflash:dir1/dir2/dir3/{{ test_destination_file }}_another_copy' in result.local_file"
           - "'/bootflash/{{ test_destination_file }}' in result.remote_file"
 
-          - "'Received: File copied/pulled to nxos device from remote scp server.'\
-            \ in result.transfer_status"
+          - "'Received: File copied/pulled to nxos device from remote scp server.' in result.transfer_status"
           - "'{{ mgmt0_ip }}' in result.remote_scp_server"
 
   always:
@@ -203,5 +192,5 @@
         feature: sftp-server
         state: disabled
 
-    - debug: msg="END connection={{ ansible_connection }} nxos_file_copy sanity
-        test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_file_copy sanity test

--- a/tests/integration/targets/nxos_file_copy/tests/nxapi/badtransport.yaml
+++ b/tests/integration/targets/nxos_file_copy/tests/nxapi/badtransport.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START nxapi/badtransport.yaml"
+- ansible.builtin.debug:
+    msg: START nxapi/badtransport.yaml
 
 - name: Sending transport other than cli should fail
   register: result
@@ -13,4 +14,5 @@
     that:
       - result.failed and result.msg is search('Connection type must be fully qualified name for network_cli connection type, got {{ ansible_connection }}')
 
-- debug: msg="END nxapi/badtransport.yaml"
+- ansible.builtin.debug:
+    msg: END nxapi/badtransport.yaml

--- a/tests/integration/targets/nxos_gir/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_gir/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_gir sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_gir sanity test
 
 - set_fact: gir_run='{{ true if (platform is not search("N35")) else false }}'
 
@@ -84,7 +85,8 @@
     - assert: *id002
   when: gir_run
   rescue:
-    - debug: msg="connection={{ ansible_connection }} nxos_gir failure detected"
+    - ansible.builtin.debug:
+        msg: connection={{ ansible_connection }} nxos_gir failure detected
   always:
     - name: Remove snapshots
       ignore_errors: true
@@ -104,4 +106,5 @@
       cisco.nxos.nxos_gir:
         system_mode_maintenance: false
 
-- debug: msg="END connection={{ ansible_connection }} nxos_gir sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_gir sanity test

--- a/tests/integration/targets/nxos_gir_profile_management/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_gir_profile_management/tests/common/sanity.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_gir_profile_management
-    sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_gir_profile_management sanity test
 
 - name: Setup - Remove maintenace mode profiles
   ignore_errors: true
@@ -85,9 +84,8 @@
     - assert: *id004
   when: not ( platform is match('N35')) and not titanium
   rescue:
-    - debug:
-        msg="connection={{ ansible_connection }} nxos_gir_profile_management
-        failure detected"
+    - ansible.builtin.debug:
+        msg: connection={{ ansible_connection }} nxos_gir_profile_management failure detected
   always:
     - name: Remove normal mode profile
       cisco.nxos.nxos_gir_profile_management: *id006
@@ -100,6 +98,5 @@
         feature: eigrp
         state: disabled
 
-    - debug:
-        msg="END connection={{ ansible_connection }} nxos_gir_profile_management
-        sanity test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_gir_profile_management sanity test

--- a/tests/integration/targets/nxos_hsrp/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_hsrp/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_hsrp sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_hsrp sanity test
 
 - set_fact: intname1="{{ nxos_int1 }}"
 
@@ -148,4 +149,5 @@
         feature: hsrp
         state: disabled
 
-- debug: msg="END connection={{ ansible_connection }} nxos_hsrp sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_hsrp sanity test

--- a/tests/integration/targets/nxos_igmp/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_igmp/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_igmp sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_igmp sanity test
 
 - set_fact: restart="true"
   when: platform is not match("N35")
@@ -63,4 +64,5 @@
       ignore_errors: true
       cisco.nxos.nxos_igmp: *id005
 
-    - debug: msg="END connection={{ ansible_connection }} nxos_igmp sanity test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_igmp sanity test

--- a/tests/integration/targets/nxos_igmp_interface/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_igmp_interface/tests/common/sanity.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_igmp_interface sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_igmp_interface sanity test
 
 - set_fact: intname="{{ nxos_int1 }}"
 
@@ -178,6 +177,5 @@
         feature: pim
         state: disabled
 
-    - debug:
-        msg="END connection={{ ansible_connection }} nxos_igmp_interface sanity
-        test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_igmp_interface sanity test

--- a/tests/integration/targets/nxos_igmp_snooping/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_igmp_snooping/tests/common/sanity.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_igmp_snooping sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_igmp_snooping sanity test
 
 - meta: end_host
   when: platform is search('N6K')
@@ -56,8 +55,7 @@
         - assert:
             that:
               - result.failed == true
-              - result.msg == 'group-timeout cannot be enabled or changed when ip
-                igmp snooping is disabled'
+              - result.msg == 'group-timeout cannot be enabled or changed when ip igmp snooping is disabled'
 
         - name: Configure group-timeout non-default
           register: result
@@ -110,6 +108,5 @@
       register: result
       cisco.nxos.nxos_igmp_snooping: *id006
 
-    - debug:
-        msg="END connection={{ ansible_connection }} nxos_igmp_snooping sanity
-        test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_igmp_snooping sanity test

--- a/tests/integration/targets/nxos_install_os/tasks/upgrade/clear_persistent_sockets.yaml
+++ b/tests/integration/targets/nxos_install_os/tasks/upgrade/clear_persistent_sockets.yaml
@@ -12,4 +12,5 @@
   delegate_to: 127.0.0.1
   register: output
 
-- debug: msg="Local Socket Info {{ output['stdout_lines'] }}"
+- ansible.builtin.debug:
+    msg: Local Socket Info {{ output['stdout_lines'] }}

--- a/tests/integration/targets/nxos_install_os/tasks/upgrade/install_os.yaml
+++ b/tests/integration/targets/nxos_install_os/tasks/upgrade/install_os.yaml
@@ -2,9 +2,7 @@
 - include: targets/nxos_install_os/tasks/upgrade/delete_files.yaml
   when: delete_files
 
-- include:
-    targets/nxos_install_os/tasks/upgrade/copy_kick_system_images.yaml ansible_connection=ansible.netcommon.network_cli
-    connection={{ cli }}
+- include: targets/nxos_install_os/tasks/upgrade/copy_kick_system_images.yaml ansible_connection=ansible.netcommon.network_cli connection={{ cli }}
   when: copy_images
 
 - include: targets/nxos_install_os/tasks/upgrade/install_with_kick.yaml
@@ -21,5 +19,5 @@
     commands:
       - show version | json
 
-- debug: msg="Version detected {{ output['stdout_lines'][0]['kickstart_ver_str']
-    }}"
+- ansible.builtin.debug:
+    msg: Version detected {{ output['stdout_lines'][0]['kickstart_ver_str'] }}

--- a/tests/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml
+++ b/tests/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml
@@ -33,7 +33,8 @@
       - terminal dont-ask
       - reload
 
-- debug: msg=" {{ result['install_state'] }}"
+- ansible.builtin.debug:
+    msg: " {{ result['install_state'] }}"
   when: not force
 
 - name: Wait for device to come back up with new image
@@ -45,7 +46,8 @@
     host: "{{ inventory_hostname }}"
   when: result.changed and not checkmode
 
-- debug: msg='Wait 5 mins to allow system to stabilize'
+- ansible.builtin.debug:
+    msg: Wait 5 mins to allow system to stabilize
   when: result.changed and not checkmode
 
 - pause:

--- a/tests/integration/targets/nxos_install_os/tasks/upgrade/install_with_kick.yaml
+++ b/tests/integration/targets/nxos_install_os/tasks/upgrade/install_with_kick.yaml
@@ -25,7 +25,8 @@
   cisco.nxos.nxos_command:
     commands: terminal dont-ask ; reload
 
-- debug: msg=" {{ result['install_state'] }}"
+- ansible.builtin.debug:
+    msg: " {{ result['install_state'] }}"
   when: not force
 
 - name: Wait for device to come back up with new image
@@ -37,7 +38,8 @@
     host: "{{ inventory_hostname }}"
   when: result.changed and not checkmode
 
-- debug: msg='Wait 5 mins to allow system to stabilize'
+- ansible.builtin.debug:
+    msg: Wait 5 mins to allow system to stabilize
   when: result.changed and not checkmode
 
 - pause:

--- a/tests/integration/targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
+++ b/tests/integration/targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="***WARNING*** Remove meta end_play to verify this module ***WARNING***"
+- ansible.builtin.debug:
+    msg: "***WARNING*** Remove meta end_play to verify this module ***WARNING***"
 
 - meta: end_play
 

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_os_install upgrade"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_os_install upgrade
   when: connection is defined
 
 - set_fact: image_dir='/Users/mwiebe/Projects/nxos_ansible/images/'
@@ -45,4 +46,5 @@
 - name: Upgrade to 7.0.3.I7.2
   include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
 
-- debug: msg="END connection={{ ansible_connection }} nxos_os_install upgrade"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_os_install upgrade

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_greensboro.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_greensboro.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_os_install upgrade"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_os_install upgrade
   when: connection is defined
 
 - set_fact: image_dir='/auto/fe_ssr/agents-ci/agents_images/release_images/greensboro/REL_7_0_3_I7_4/'

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_u61a.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_u61a.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_os_install upgrade"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_os_install upgrade
   when: connection is defined
 
 - set_fact: image_dir='/auto/fe_ssr/agents-ci/agents_images/release_images/602U6_1/'

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_u62a.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_u62a.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_os_install upgrade"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_os_install upgrade
   when: connection is defined
 
 - set_fact: image_dir='/auto/fe_ssr/agents-ci/agents_images/release_images/602U6_2/'

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_u63a.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_u63a.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_os_install upgrade"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_os_install upgrade
   when: connection is defined
 
 - set_fact: image_dir='/auto/fe_ssr/agents-ci/agents_images/release_images/602U6_3/'

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n35_62a88.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n35_62a88.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_os_install upgrade"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_os_install upgrade
   when: connection is defined
 
 - set_fact: image_dir='/auto/fe_ssr/agents-ci/agents_images/release_images/602A8_8/'

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n35_greensboro.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n35_greensboro.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_os_install upgrade"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_os_install upgrade
   when: connection is defined
 
 - set_fact: image_dir='/auto/fe_ssr/agents-ci/agents_images/release_images/greensboro/REL_7_0_3_I7_4/'

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n5k_730_N11.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n5k_730_N11.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_os_install upgrade"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_os_install upgrade
   when: connection is defined
 
 - set_fact: image_dir='/auto/fe_ssr/agents-ci/agents_images/release_images/730_N11/'

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n5k_733_N11.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n5k_733_N11.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_os_install upgrade"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_os_install upgrade
   when: connection is defined
 
 - set_fact: image_dir='/auto/fe_ssr/agents-ci/agents_images/release_images/733_N11/'

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n7k_atherton.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n7k_atherton.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_os_install upgrade"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_os_install upgrade
   when: connection is defined
 
 - set_fact: image_dir='/auto/fe_ssr/agents-ci/agents_images/release_images/atherton/REL_8_0_1/'

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n7k_helsinki.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n7k_helsinki.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_os_install upgrade"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_os_install upgrade
   when: connection is defined
 
 - set_fact: image_dir='/auto/fe_ssr/agents-ci/agents_images/release_images/helsinki/REL_7_3_0_D1_1/'

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n9k_greensboro.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n9k_greensboro.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_os_install upgrade"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_os_install upgrade
   when: connection is defined
 
 - set_fact: image_dir='/auto/fe_ssr/agents-ci/agents_images/release_images/greensboro/REL_7_0_3_I7_4/'

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n9k_greensboro_force.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n9k_greensboro_force.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_os_install upgrade"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_os_install upgrade
   when: connection is defined
 
 - set_fact: image_dir='/auto/fe_ssr/agents-ci/agents_images/release_images/greensboro/REL_7_0_3_I7_4/'

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n9k_hamilton.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n9k_hamilton.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_os_install upgrade"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_os_install upgrade
   when: connection is defined
 
 - set_fact: image_dir='/auto/fe_ssr/agents-ci/agents_images/release_images/hamilton/REL_9_2_1/'

--- a/tests/integration/targets/nxos_interface/tests/common/intent.yaml
+++ b/tests/integration/targets/nxos_interface/tests/common/intent.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_interface intent test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_interface intent test
 
 - set_fact: testint1="{{ nxos_int1 }}"
 
@@ -65,4 +66,5 @@
       - default interface {{ testint1 }}
       - default interface {{ testint2 }}
 
-- debug: msg="END connection={{ ansible_connection }} nxos_interface intent test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_interface intent test

--- a/tests/integration/targets/nxos_interface/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_interface/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_interface sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_interface sanity test
 
 - set_fact: testint="{{ nxos_int1 }}"
 
@@ -127,5 +128,5 @@
         feature: interface-vlan
         state: disabled
 
-    - debug: msg="END connection={{ ansible_connection }} nxos_interface sanity
-        test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_interface sanity test

--- a/tests/integration/targets/nxos_interface/tests/common/set_state_absent.yaml
+++ b/tests/integration/targets/nxos_interface/tests/common/set_state_absent.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }}/set_state_absent.yaml"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }}/set_state_absent.yaml
 
 - name: setup
   cisco.nxos.nxos_config:
@@ -26,4 +27,5 @@
     that:
       - result.changed == false
 
-- debug: msg="END connection={{ ansible_connection }}/set_state_absent.yaml"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }}/set_state_absent.yaml

--- a/tests/integration/targets/nxos_interface/tests/common/set_state_present.yaml
+++ b/tests/integration/targets/nxos_interface/tests/common/set_state_present.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }}/set_state_present.yaml"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }}/set_state_present.yaml
 
 - name: setup
   ignore_errors: true
@@ -29,4 +30,5 @@
     that:
       - result.changed == false
 
-- debug: msg="END connection={{ ansible_connection }}/set_state_present.yaml"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }}/set_state_present.yaml

--- a/tests/integration/targets/nxos_interface/tests/common/sub_int.yaml
+++ b/tests/integration/targets/nxos_interface/tests/common/sub_int.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_interface sub-interface
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_interface sub-interface test
 
 - set_fact: testint="{{ nxos_int1 }}"
 
@@ -72,6 +71,5 @@
     that:
       - result.changed == false
 
-- debug:
-    msg="END connection={{ ansible_connection }} nxos_interface sub-interface
-    test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_interface sub-interface test

--- a/tests/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_interface_ospf sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_interface_ospf sanity test
 
 - set_fact: testint="{{ nxos_int1 }}"
 
@@ -290,6 +289,5 @@
       ignore_errors: true
       cisco.nxos.nxos_config: *id014
 
-    - debug:
-        msg="END connection={{ ansible_connection }} nxos_interface_ospf sanity
-        test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_interface_ospf sanity test

--- a/tests/integration/targets/nxos_l2_interface/tests/common/agg.yaml
+++ b/tests/integration/targets/nxos_l2_interface/tests/common/agg.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_l2_interface aggregate
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_l2_interface aggregate test
 
 - set_fact: intname1="{{ nxos_int1 }}"
 
@@ -112,6 +111,5 @@
             access_vlan: 15
         state: absent
 
-- debug:
-    msg="END connection={{ ansible_connection }} nxos_l2_interface aggregate
-    test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_l2_interface aggregate test

--- a/tests/integration/targets/nxos_l2_interface/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_l2_interface/tests/common/sanity.yaml
@@ -1,11 +1,12 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_l2_interface sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_l2_interface sanity test
 
 - set_fact: intname="{{ nxos_int1 }}"
 
 - name: Interface selected for this test
-  debug: msg="{{ intname }}"
+  ansible.builtin.debug:
+    msg: "{{ intname }}"
 
 - name: Setup interface
   ignore_errors: true
@@ -67,9 +68,7 @@
 
     - assert: *id004
 
-    - name:
-        Ensure interface is a trunk port and ensure 2-50 are being tagged (doesn't
-        mean others aren't also being tagged)
+    - name: Ensure interface is a trunk port and ensure 2-50 are being tagged (doesn't mean others aren't also being tagged)
       register: result
       cisco.nxos.nxos_l2_interface: &id005
         name: "{{ intname }}"
@@ -107,9 +106,7 @@
 
     - assert: *id002
 
-    - name:
-        Check Idempotence Reconfigure interface trunk port and ensure 2-50 are
-        being tagged
+    - name: Check Idempotence Reconfigure interface trunk port and ensure 2-50 are being tagged
       register: result
       cisco.nxos.nxos_l2_interface: *id005
 
@@ -153,4 +150,5 @@
       ignore_errors: true
       cisco.nxos.nxos_config: *id009
 
-- debug: msg="END connection={{ ansible_connection }} nxos_l2_interface sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_l2_interface sanity test

--- a/tests/integration/targets/nxos_l3_interface/tests/cli/sanity.yaml
+++ b/tests/integration/targets/nxos_l3_interface/tests/cli/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START TRANSPORT:CLI nxos_l3_interface sanity test"
+- ansible.builtin.debug:
+    msg: START TRANSPORT:CLI nxos_l3_interface sanity test
 
 - set_fact: testint2="{{ nxos_int2 }}"
 
@@ -119,4 +120,5 @@
     that:
       - result.changed == false
 
-- debug: msg="END TRANSPORT:CLI nxos_l3_interface sanity test"
+- ansible.builtin.debug:
+    msg: END TRANSPORT:CLI nxos_l3_interface sanity test

--- a/tests/integration/targets/nxos_l3_interface/tests/nxapi/sanity.yaml
+++ b/tests/integration/targets/nxos_l3_interface/tests/nxapi/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START TRANSPORT:NXAPI nxos_l3_interface sanity test"
+- ansible.builtin.debug:
+    msg: START TRANSPORT:NXAPI nxos_l3_interface sanity test
 
 - set_fact: testint2="{{ nxos_int2 }}"
 
@@ -114,4 +115,5 @@
     that:
       - result.changed == false
 
-- debug: msg="END TRANSPORT:NXAPI nxos_l3_interface sanity test"
+- ansible.builtin.debug:
+    msg: END TRANSPORT:NXAPI nxos_l3_interface sanity test

--- a/tests/integration/targets/nxos_l3_interfaces/tests/common/multisite.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tests/common/multisite.yaml
@@ -210,7 +210,7 @@
 
     - name: setup1 - overidden
       ignore_errors: true
-      cisco.nxos.nxos_config: &id005
+      cisco.nxos.nxos_config: &id007
         lines:
           - "no system default switchport"
           - "default interface {{ item }}"
@@ -232,7 +232,7 @@
           - "  evpn multisite dci-tracking"
 
     - name: Gather l3_interfaces facts
-      cisco.nxos.nxos_facts: &id006
+      cisco.nxos.nxos_facts: &id005
         gather_subset:
           - "!all"
           - "!min"
@@ -249,7 +249,7 @@
 
     - name: Overridden
       register: result
-      cisco.nxos.nxos_l3_interfaces: &id007
+      cisco.nxos.nxos_l3_interfaces: &id006
         config: "{{ overriden_config + mgmt }}"
         state: overridden
 
@@ -269,7 +269,7 @@
           - result.commands|length == 9
 
     - name: Gather l3_interfaces post facts
-      cisco.nxos.nxos_facts: *id006
+      cisco.nxos.nxos_facts: *id005
 
     - assert:
         that:
@@ -277,7 +277,7 @@
 
     - name: Idempotence - Overridden
       register: result
-      cisco.nxos.nxos_l3_interfaces: *id007
+      cisco.nxos.nxos_l3_interfaces: *id006
 
     - assert:
         that:
@@ -286,7 +286,7 @@
 
     - name: teardown - overdidden
       ignore_errors: true
-      cisco.nxos.nxos_config: *id005
+      cisco.nxos.nxos_config: *id007
       loop:
         - "{{ test_int1 }}"
         - "{{ test_int2 }}"
@@ -294,7 +294,9 @@
 
     - name: Gather pre-facts
       cisco.nxos.nxos_facts:
-        gather_subset: ["!all", "!min"]
+        gather_subset:
+          - "!all"
+          - "!min"
         gather_network_resources: l3_interfaces
 
     # Interfaces used here doesn't actually exist on the device
@@ -307,7 +309,7 @@
               - address: 192.168.1.100/24
                 tag: 5
               - address: 10.1.1.1/24
-                secondary: True
+                secondary: true
                 tag: 10
             evpn_multisite_tracking: fabric-tracking
           - name: Ethernet1/800
@@ -318,8 +320,7 @@
         state: rendered
 
     - assert:
-        that: "{{ rendered_multi | symmetric_difference(result['rendered'])\
-          \ |length==0 }}"
+        that: "{{ rendered_multi | symmetric_difference(result['rendered']) |length==0 }}"
 
     - name: Gather l3_interfaces facts from the device and assert that its empty
       register: result
@@ -352,9 +353,7 @@
         state: parsed
 
     - assert:
-        that:
-          "{{ parsed_multi | symmetric_difference(result['parsed']) |length==0\
-          \ }}"
+        that: "{{ parsed_multi | symmetric_difference(result['parsed']) |length==0 }}"
 
   when: multiout is not search("Invalid command")
 
@@ -372,4 +371,5 @@
     feature: nve
     state: disabled
 
-- debug: msg="END connection={{ ansible_connection }} nxos_l3_interfaces multisite test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_l3_interfaces multisite test

--- a/tests/integration/targets/nxos_linkagg/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_linkagg/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_linkagg sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_linkagg sanity test
 
 - set_fact: testint1="{{ nxos_int1 }}"
 
@@ -195,4 +196,5 @@
     feature: lacp
     state: disabled
 
-- debug: msg="END connection={{ ansible_connection }} nxos_linkagg sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_linkagg sanity test

--- a/tests/integration/targets/nxos_lldp/tests/cli/sanity.yaml
+++ b/tests/integration/targets/nxos_lldp/tests/cli/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START TRANSPORT:CLI nxos_lldp sanity test"
+- ansible.builtin.debug:
+    msg: START TRANSPORT:CLI nxos_lldp sanity test
 
 - name: Make sure LLDP is not running before tests
   cisco.nxos.nxos_feature:
@@ -44,4 +45,5 @@
     that:
       - result.changed == false
 
-- debug: msg="END TRANSPORT:CLI nxos_lldp sanity test"
+- ansible.builtin.debug:
+    msg: END TRANSPORT:CLI nxos_lldp sanity test

--- a/tests/integration/targets/nxos_lldp/tests/nxapi/sanity.yaml
+++ b/tests/integration/targets/nxos_lldp/tests/nxapi/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START TRANSPORT:NXAPI nxos_lldp sanity test"
+- ansible.builtin.debug:
+    msg: START TRANSPORT:NXAPI nxos_lldp sanity test
 
 - name: Make sure LLDP is not running before tests
   cisco.nxos.nxos_feature:
@@ -44,4 +45,5 @@
     that:
       - result.changed == false
 
-- debug: msg="END TRANSPORT:NXAPI nxos_lldp sanity test"
+- ansible.builtin.debug:
+    msg: END TRANSPORT:NXAPI nxos_lldp sanity test

--- a/tests/integration/targets/nxos_logging/tests/common/basic.yaml
+++ b/tests/integration/targets/nxos_logging/tests/common/basic.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_logging basic test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_logging basic test
 
 - name: Workaround to clear logging logfile size
   ignore_errors: true
@@ -15,7 +16,7 @@
   register: result
   cisco.nxos.nxos_logging: &id001
     dest: console
-    dest_level: 0
+    dest_level: 00
     state: present
 
 - assert:
@@ -52,7 +53,7 @@
 - block:
     - name: Logfile logging with level
       register: result
-      cisco.nxos.nxos_logging: &id005
+      cisco.nxos.nxos_logging: &id004
         dest: logfile
         name: test
         dest_level: 1
@@ -65,14 +66,14 @@
 
     - name: Logfile logging with level (idempotent)
       register: result
-      cisco.nxos.nxos_logging: *id005
+      cisco.nxos.nxos_logging: *id004
 
     - assert: *id003
   when: platform is not search('N5K|N7K') and imagetag is not search("A8")
 
 - name: Configure module with level
   register: result
-  cisco.nxos.nxos_logging: &id006
+  cisco.nxos.nxos_logging: &id005
     dest: module
     dest_level: 2
 
@@ -83,13 +84,13 @@
 
 - name: Configure module with level (idempotent)
   register: result
-  cisco.nxos.nxos_logging: *id006
+  cisco.nxos.nxos_logging: *id005
 
 - assert: *id003
 
 - name: Configure monitor with level
   register: result
-  cisco.nxos.nxos_logging: &id007
+  cisco.nxos.nxos_logging: &id006
     dest: monitor
     dest_level: 3
 
@@ -100,13 +101,13 @@
 
 - name: Configure monitor with level (idempotent)
   register: result
-  cisco.nxos.nxos_logging: *id007
+  cisco.nxos.nxos_logging: *id006
 
 - assert: *id003
 
 - name: Configure monitor with level 5 (edge case)
   register: result
-  cisco.nxos.nxos_logging: &id008
+  cisco.nxos.nxos_logging: &id007
     dest: monitor
     dest_level: 5
 
@@ -117,13 +118,13 @@
 
 - name: Configure monitor with level 5 (edge case) (idempotent)
   register: result
-  cisco.nxos.nxos_logging: *id008
+  cisco.nxos.nxos_logging: *id007
 
 - assert: *id003
 
 - name: Configure facility with level
   register: result
-  cisco.nxos.nxos_logging: &id009
+  cisco.nxos.nxos_logging: &id008
     facility: daemon
     facility_level: 4
 
@@ -134,13 +135,13 @@
 
 - name: Configure facility with level (idempotent)
   register: result
-  cisco.nxos.nxos_logging: *id009
+  cisco.nxos.nxos_logging: *id008
 
 - assert: *id003
 
 - name: Configure Remote Logging
   register: result
-  cisco.nxos.nxos_logging: &id010
+  cisco.nxos.nxos_logging: &id009
     dest: server
     remote_server: test-syslogserver.com
     facility: auth
@@ -151,18 +152,17 @@
 - assert:
     that:
       - result.changed == true
-      - '"logging server test-syslogserver.com 1 facility auth use-vrf management"
-        in result.commands'
+      - '"logging server test-syslogserver.com 1 facility auth use-vrf management" in result.commands'
 
 - name: Configure Remote Logging (idempotent)
   register: result
-  cisco.nxos.nxos_logging: *id010
+  cisco.nxos.nxos_logging: *id009
 
 - assert: *id003
 
 - name: Configure Source Interface for Logging
   register: result
-  cisco.nxos.nxos_logging: &id011
+  cisco.nxos.nxos_logging: &id010
     interface: mgmt0
 
 - assert:
@@ -172,7 +172,7 @@
 
 - name: Configure Source Interface for Logging (idempotent)
   register: result
-  cisco.nxos.nxos_logging: *id011
+  cisco.nxos.nxos_logging: *id010
 
 - assert:
     that:
@@ -180,7 +180,7 @@
 
 - name: remove logging as collection tearDown
   register: result
-  cisco.nxos.nxos_logging: &id012
+  cisco.nxos.nxos_logging: &id011
     aggregate:
       - dest: console
         dest_level: 3
@@ -230,24 +230,24 @@
 
 - name: remove aggregate logging (idempotent)
   register: result
-  cisco.nxos.nxos_logging: *id012
+  cisco.nxos.nxos_logging: *id011
 
 - assert: *id003
 
 - block:
     - name: Configure Logging message
       register: result
-      cisco.nxos.nxos_logging: &id013
+      cisco.nxos.nxos_logging: &id012
         interface_message: add-interface-description
         state: present
 
-    - assert: &id014
+    - assert: &id013
         that:
           - result.changed == true
 
     - name: Configure Logging message (idempotent)
       register: result
-      cisco.nxos.nxos_logging: *id013
+      cisco.nxos.nxos_logging: *id012
 
     - assert: *id003
 
@@ -257,12 +257,12 @@
         interface_message: add-interface-description
         state: absent
 
-    - assert: *id014
+    - assert: *id013
   when: platform is not search('N5K') and imagetag is not search("A8")
 
 - name: Logfile logging with level and size
   register: result
-  cisco.nxos.nxos_logging: &id015
+  cisco.nxos.nxos_logging: &id014
     dest: logfile
     name: test
     dest_level: 1
@@ -276,7 +276,7 @@
 
 - name: Logfile logging with level and size (idempotent)
   register: result
-  cisco.nxos.nxos_logging: *id015
+  cisco.nxos.nxos_logging: *id014
 
 - assert: *id003
 
@@ -289,11 +289,11 @@
     file_size: 16384
     state: absent
 
-- assert: *id014
+- assert: *id013
 
 - name: Set up logging event link enable
   register: result
-  cisco.nxos.nxos_logging: &id016
+  cisco.nxos.nxos_logging: &id015
     event: link-enable
 
 - assert:
@@ -303,27 +303,27 @@
 
 - name: Set up logging event link enable again (idempotent)
   register: result
-  cisco.nxos.nxos_logging: *id016
+  cisco.nxos.nxos_logging: *id015
 
 - assert: *id003
 
 - name: Remove logging event link enable
   register: result
-  cisco.nxos.nxos_logging: &id017
+  cisco.nxos.nxos_logging: &id016
     event: link-enable
     state: absent
 
-- assert: *id014
+- assert: *id013
 
 - name: Remove logging event link enable again (idempotent)
   register: result
-  cisco.nxos.nxos_logging: *id017
+  cisco.nxos.nxos_logging: *id016
 
 - assert: *id003
 
 - name: Set up logging event link default
   register: result
-  cisco.nxos.nxos_logging: &id018
+  cisco.nxos.nxos_logging: &id017
     event: link-default
 
 - assert:
@@ -333,27 +333,27 @@
 
 - name: Set up logging event link default again (idempotent)
   register: result
-  cisco.nxos.nxos_logging: *id018
+  cisco.nxos.nxos_logging: *id017
 
 - assert: *id003
 
 - name: Remove logging event link default
   register: result
-  cisco.nxos.nxos_logging: &id019
+  cisco.nxos.nxos_logging: &id018
     event: link-default
     state: absent
 
-- assert: *id014
+- assert: *id013
 
 - name: Remove logging event link default again (idempotent)
   register: result
-  cisco.nxos.nxos_logging: *id019
+  cisco.nxos.nxos_logging: *id018
 
 - assert: *id003
 
 - name: Set up logging event trunk enable
   register: result
-  cisco.nxos.nxos_logging: &id020
+  cisco.nxos.nxos_logging: &id019
     event: trunk-enable
 
 - assert:
@@ -363,27 +363,27 @@
 
 - name: Set up logging event trunk enable again (idempotent)
   register: result
-  cisco.nxos.nxos_logging: *id020
+  cisco.nxos.nxos_logging: *id019
 
 - assert: *id003
 
 - name: Remove logging event trunk enable
   register: result
-  cisco.nxos.nxos_logging: &id021
+  cisco.nxos.nxos_logging: &id020
     event: trunk-enable
     state: absent
 
-- assert: *id014
+- assert: *id013
 
 - name: Remove logging event trunk enable again (idempotent)
   register: result
-  cisco.nxos.nxos_logging: *id021
+  cisco.nxos.nxos_logging: *id020
 
 - assert: *id003
 
 - name: Set up logging event trunk default
   register: result
-  cisco.nxos.nxos_logging: &id022
+  cisco.nxos.nxos_logging: &id021
     event: trunk-default
 
 - assert:
@@ -393,35 +393,35 @@
 
 - name: Set up logging event trunk default again (idempotent)
   register: result
-  cisco.nxos.nxos_logging: *id022
+  cisco.nxos.nxos_logging: *id021
 
 - assert: *id003
 
 - name: Remove logging event trunk default
   register: result
-  cisco.nxos.nxos_logging: &id023
+  cisco.nxos.nxos_logging: &id022
     event: trunk-default
     state: absent
 
-- assert: *id014
+- assert: *id013
 
 - name: Remove logging event trunk default again (idempotent)
   register: result
-  cisco.nxos.nxos_logging: *id023
+  cisco.nxos.nxos_logging: *id022
 
 - assert: *id003
 
 - name: Set up Logging Timestamp
   register: result
-  cisco.nxos.nxos_logging: &id024
+  cisco.nxos.nxos_logging: &id023
     timestamp: microseconds
     state: present
 
-- assert: *id014
+- assert: *id013
 
 - name: Set up Logging Timestamp (idempotent)
   register: result
-  cisco.nxos.nxos_logging: *id024
+  cisco.nxos.nxos_logging: *id023
 
 - assert: *id003
 
@@ -431,20 +431,20 @@
     timestamp: microseconds
     state: absent
 
-- assert: *id014
+- assert: *id013
 
 - name: Set up Facility ethpm Link UP Error
   register: result
-  cisco.nxos.nxos_logging: &id025
+  cisco.nxos.nxos_logging: &id024
     facility: ethpm
     facility_link_status: link-up-error
     state: present
 
-- assert: *id014
+- assert: *id013
 
 - name: Set up Facility ethpm Link UP Error (idempotent)
   register: result
-  cisco.nxos.nxos_logging: *id025
+  cisco.nxos.nxos_logging: *id024
 
 - assert: *id003
 
@@ -455,20 +455,20 @@
     facility_link_status: link-up-error
     state: absent
 
-- assert: *id014
+- assert: *id013
 
 - name: Set up Facility ethpm Link DOWN Error
   register: result
-  cisco.nxos.nxos_logging: &id026
+  cisco.nxos.nxos_logging: &id025
     facility: ethpm
     facility_link_status: link-down-error
     state: present
 
-- assert: *id014
+- assert: *id013
 
 - name: Set up Facility ethpm Link DOWN Error (idempotent)
   register: result
-  cisco.nxos.nxos_logging: *id026
+  cisco.nxos.nxos_logging: *id025
 
 - assert: *id003
 
@@ -479,6 +479,7 @@
     facility_link_status: link-down-error
     state: absent
 
-- assert: *id014
+- assert: *id013
 
-- debug: msg="END connection={{ ansible_connection }} nxos_logging basic test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_logging basic test

--- a/tests/integration/targets/nxos_logging/tests/common/net_logging.yaml
+++ b/tests/integration/targets/nxos_logging/tests/common/net_logging.yaml
@@ -1,18 +1,19 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos common/net_logging.yaml"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos common/net_logging.yaml
 
 - name: Delete/disable console logging - setup
   register: result
   ansible.netcommon.net_logging:
     dest: console
-    dest_level: 0
+    dest_level: 00
     state: absent
 
 - name: Set up console logging using platform agnostic module
   register: result
   ansible.netcommon.net_logging:
     dest: console
-    dest_level: 0
+    dest_level: 00
     state: present
 
 - assert:
@@ -24,7 +25,8 @@
   register: result
   ansible.netcommon.net_logging:
     dest: console
-    dest_level: 0
+    dest_level: 00
     state: absent
 
-- debug: msg="END connection={{ ansible_connection }} nxos common/net_logging.yaml"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos common/net_logging.yaml

--- a/tests/integration/targets/nxos_logging/tests/common/purge.yaml
+++ b/tests/integration/targets/nxos_logging/tests/common/purge.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_logging purge test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_logging purge test
 
 - name: Purge logging configuration first
   cisco.nxos.nxos_logging:
@@ -10,7 +11,7 @@
       register: result
       cisco.nxos.nxos_logging:
         dest: console
-        dest_level: 0
+        dest_level: 00
         state: present
 
     - assert:
@@ -86,7 +87,7 @@
       cisco.nxos.nxos_logging:
         aggregate:
           - dest: console
-            dest_level: 0
+            dest_level: 00
 
           - dest: monitor
             dest_level: 3
@@ -106,4 +107,5 @@
           - '"no logging monitor" in result.commands'
   when: ansible_connection != "local"
 
-- debug: msg="END connection={{ ansible_connection }} nxos_logging purge test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_logging purge test

--- a/tests/integration/targets/nxos_ntp/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_ntp/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_ntp sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_ntp sanity test
 
 - name: Setup - Remove ntp if configured
   ignore_errors: true
@@ -109,4 +110,5 @@
     - name: Remove ntp config
       cisco.nxos.nxos_ntp: *id005
 
-    - debug: msg="END connection={{ ansible_connection }} nxos_ntp sanity test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_ntp sanity test

--- a/tests/integration/targets/nxos_ntp_auth/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_ntp_auth/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_ntp_auth sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_ntp_auth sanity test
 
 - name: Configure text ntp authentication
   ignore_errors: true
@@ -128,4 +129,5 @@
       ignore_errors: true
       cisco.nxos.nxos_ntp_auth: *id009
 
-    - debug: msg="END connection={{ ansible_connection }} nxos_ntp_auth sanity test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_ntp_auth sanity test

--- a/tests/integration/targets/nxos_ntp_options/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_ntp_options/tests/common/sanity.yaml
@@ -1,6 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_ntp_options sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_ntp_options sanity test
 
 - name: Apply default ntp config
   ignore_errors: true
@@ -95,6 +95,5 @@
       register: result
       cisco.nxos.nxos_ntp_options: *id007
 
-    - debug:
-        msg="END connection={{ ansible_connection }} nxos_ntp_options sanity
-        test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_ntp_options sanity test

--- a/tests/integration/targets/nxos_nxapi/tests/cli/configure.yaml
+++ b/tests/integration/targets/nxos_nxapi/tests/cli/configure.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START cli/configure.yaml"
+- ansible.builtin.debug:
+    msg: START cli/configure.yaml
 
 - set_fact: nxapi_sandbox_option="yes"
   when: platform is search('N7K')
@@ -137,4 +138,5 @@
       cisco.nxos.nxos_nxapi:
         state: present
 
-    - debug: msg="END cli/configure.yaml"
+    - ansible.builtin.debug:
+        msg: END cli/configure.yaml

--- a/tests/integration/targets/nxos_nxapi/tests/cli/disable.yaml
+++ b/tests/integration/targets/nxos_nxapi/tests/cli/disable.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START cli/disable.yaml"
+- ansible.builtin.debug:
+    msg: START cli/disable.yaml
 
 - name: Disable NXAPI
   register: result
@@ -25,4 +26,5 @@
   assert:
     that: result.changed == false
 
-- debug: msg="END cli/disable.yaml"
+- ansible.builtin.debug:
+    msg: END cli/disable.yaml

--- a/tests/integration/targets/nxos_nxapi/tests/cli/enable.yaml
+++ b/tests/integration/targets/nxos_nxapi/tests/cli/enable.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START cli/enable.yaml"
+- ansible.builtin.debug:
+    msg: START cli/enable.yaml
 
 - name: Setup - put NXAPI in stopped state
   register: result
@@ -29,4 +30,5 @@
   assert:
     that: result.changed == false
 
-- debug: msg="END cli/enable.yaml"
+- ansible.builtin.debug:
+    msg: END cli/enable.yaml

--- a/tests/integration/targets/nxos_nxapi/tests/cli/nxapi_ssl.yaml
+++ b/tests/integration/targets/nxos_nxapi/tests/cli/nxapi_ssl.yaml
@@ -243,5 +243,6 @@
 
     - ansible.builtin.debug:
         msg: END cli/nxapi_ssl.yaml
-  when: (platform is match("N9K") or platform is match("N3K") or platform is match("N9K-F") or platform is match("N35") or platform is match("N3L")) and major_version
+  when:
+    (platform is match("N9K") or platform is match("N3K") or platform is match("N9K-F") or platform is match("N35") or platform is match("N3L")) and major_version
     is version('9.2', '>=')

--- a/tests/integration/targets/nxos_nxapi/tests/cli/nxapi_ssl.yaml
+++ b/tests/integration/targets/nxos_nxapi/tests/cli/nxapi_ssl.yaml
@@ -1,6 +1,7 @@
 ---
 - block:
-    - debug: msg="START cli/nxapi_ssl.yaml"
+    - ansible.builtin.debug:
+        msg: START cli/nxapi_ssl.yaml
 
     - name: Configure NXAPI HTTPs w/weak ciphers
       register: result
@@ -240,8 +241,7 @@
       cisco.nxos.nxos_nxapi:
         state: present
 
-    - debug: msg="END cli/nxapi_ssl.yaml"
-  when:
-    (platform is match("N9K") or platform is match("N3K") or platform is match("N9K-F")
-    or platform is match("N35") or platform is match("N3L")) and major_version is
-    version('9.2', '>=')
+    - ansible.builtin.debug:
+        msg: END cli/nxapi_ssl.yaml
+  when: (platform is match("N9K") or platform is match("N3K") or platform is match("N9K-F") or platform is match("N35") or platform is match("N3L")) and major_version
+    is version('9.2', '>=')

--- a/tests/integration/targets/nxos_nxapi/tests/nxapi/badtransport.yaml
+++ b/tests/integration/targets/nxos_nxapi/tests/nxapi/badtransport.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START nxapi/badtransport.yaml"
+- ansible.builtin.debug:
+    msg: START nxapi/badtransport.yaml
 
 - name: Sending transport other than cli should fail
   register: result
@@ -14,4 +15,5 @@
     that:
       - result.failed and result.msg is search('Transport')
 
-- debug: msg="END nxapi/badtransport.yaml"
+- ansible.builtin.debug:
+    msg: END nxapi/badtransport.yaml

--- a/tests/integration/targets/nxos_ospf/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_ospf/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_ospf sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_ospf sanity test
 
 - name: Enable feature OSPF
   ignore_errors: true
@@ -46,4 +47,5 @@
 
     - assert: *id004
 
-    - debug: msg="END connection={{ ansible_connection }} nxos_ospf sanity test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_ospf sanity test

--- a/tests/integration/targets/nxos_ospf_vrf/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_ospf_vrf/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_ospf_vrf sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_ospf_vrf sanity test
 
 - set_fact: def_met_default="default"
   when: imagetag is not search("I7")
@@ -134,4 +135,5 @@
         feature: "{{ item }}"
         state: disabled
 
-- debug: msg="END connection={{ ansible_connection }} nxos_ospf_vrf sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_ospf_vrf sanity test

--- a/tests/integration/targets/nxos_overlay_global/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_overlay_global/tests/common/sanity.yaml
@@ -1,17 +1,14 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_overlay_global sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_overlay_global sanity test
 
 - set_fact: overlay_global_supported="false"
 
 - set_fact: overlay_global_supported="true"
-  when:
-    platform is search("N35NG|N7K|^N9K$") or ( platform is match("N9k-F") and
-    imagetag is version('F3', 'ne'))
+  when: platform is search("N35NG|N7K|^N9K$") or ( platform is match("N9k-F") and imagetag is version('F3', 'ne'))
 
-- debug: msg="Platform {{ platform }} running Image version {{ image_version }}
-    supports nxos_overlay_global"
+- ansible.builtin.debug:
+    msg: Platform {{ platform }} running Image version {{ image_version }} supports nxos_overlay_global
   when: overlay_global_supported
 
 - block:
@@ -92,6 +89,5 @@
       cisco.nxos.nxos_evpn_global:
         nv_overlay_evpn: false
 
-    - debug:
-        msg="END connection={{ ansible_connection }} nxos_overlay_global sanity
-        test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_overlay_global sanity test

--- a/tests/integration/targets/nxos_pim/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_pim/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_pim sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_pim sanity test
 
 - name: "Setup: Disable features"
   ignore_errors: true
@@ -78,4 +79,5 @@
         feature: "{{ item }}"
         state: disabled
 
-- debug: msg="END connection={{ ansible_connection }} nxos_pim sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_pim sanity test

--- a/tests/integration/targets/nxos_pim_interface/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_pim_interface/tests/common/sanity.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_pim_interface sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_pim_interface sanity test
 
 - name: "Setup: Disable features"
   loop:
@@ -192,5 +191,5 @@
         - bfd
       cisco.nxos.nxos_feature: *id011
 
-- debug: msg="END connection={{ ansible_connection }} nxos_pim_interface sanity
-    test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_pim_interface sanity test

--- a/tests/integration/targets/nxos_pim_rp_address/tests/common/configure.yaml
+++ b/tests/integration/targets/nxos_pim_rp_address/tests/common/configure.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_pim_rp_address sanity"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_pim_rp_address sanity
 
 - block:
     - set_fact: bidir_true="true"
@@ -210,4 +211,5 @@
     - name: Disable feature PIM
       cisco.nxos.nxos_feature: *id014
 
-- debug: msg="END connection={{ ansible_connection }} nxos_pim_rp_address sanity"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_pim_rp_address sanity

--- a/tests/integration/targets/nxos_reboot/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_reboot/tests/common/sanity.yaml
@@ -1,7 +1,9 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_reboot sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_reboot sanity test
 
-- debug: msg="***WARNING*** Set run_nxos_reboot_test to True to verify this module ***WARNING***"
+- ansible.builtin.debug:
+    msg: "***WARNING*** Set run_nxos_reboot_test to True to verify this module ***WARNING***"
 
 - block:
     - name: Reboot Switch
@@ -17,5 +19,6 @@
         delay: 60
         host: "{{ inventory_hostname }}"
 
-    - debug: msg="END connection={{ ansible_connection }} nxos_reboot sanity test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_reboot sanity test
   when: run_nxos_reboot_test | d(False)

--- a/tests/integration/targets/nxos_rollback/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_rollback/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_rollback sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_rollback sanity test
 
 - name: delete existing checkpoint file
   ignore_errors: true
@@ -21,4 +22,5 @@
   ignore_errors: true
   cisco.nxos.nxos_config: *id001
 
-- debug: msg="END connection={{ ansible_connection }} nxos_rollback sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_rollback sanity test

--- a/tests/integration/targets/nxos_rpm/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_rpm/tests/common/sanity.yaml
@@ -1,21 +1,19 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_rpm sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_rpm sanity test
 
 - set_fact: smu_run="false"
 
 - set_fact: smu_run="true"
-  when:
-    ((platform is search('N9K')) and (imagetag and 'I' in imagetag and (imagetag is version_compare('I2',
-    'ge'))))
+  when: ((platform is search('N9K')) and (imagetag and 'I' in imagetag and (imagetag is version_compare('I2', 'ge'))))
 
 - set_fact: sdk_run="false"
 
 - set_fact: sdk_run="true"
-  when:
-    ((platform is search('N9K')) and (imagetag and 'I' in imagetag and (imagetag is version_compare('I6',
-    'ge'))))
+  when: ((platform is search('N9K')) and (imagetag and 'I' in imagetag and (imagetag is version_compare('I6', 'ge'))))
 
-- debug: msg="***WARNING*** Set run_nxos_rpm_test to True to verify this module ***WARNING***"
+- ansible.builtin.debug:
+    msg: "***WARNING*** Set run_nxos_rpm_test to True to verify this module ***WARNING***"
 
 - block:
     - block:
@@ -149,4 +147,5 @@
       when: smu_run
   when: run_nxos_rpm_test|d(False)
 
-- debug: msg="END connection={{ ansible_connection }} nxos_rpm sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_rpm sanity test

--- a/tests/integration/targets/nxos_smoke/tests/cli/misc_tests.yaml
+++ b/tests/integration/targets/nxos_smoke/tests/cli/misc_tests.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START cli/misc_tests.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: START cli/misc_tests.yaml on connection={{ ansible_connection }}
 
 - block:
     - name: Test that provider values are properly ignored

--- a/tests/integration/targets/nxos_smoke/tests/common/caching.yaml
+++ b/tests/integration/targets/nxos_smoke/tests/common/caching.yaml
@@ -1,6 +1,7 @@
 ---
 - block:
-    - debug: msg="START connection={{ ansible_connection }} common/caching.yaml"
+    - ansible.builtin.debug:
+        msg: START connection={{ ansible_connection }} common/caching.yaml
 
     - name: Set system defaults for switchports
       cisco.nxos.nxos_config:

--- a/tests/integration/targets/nxos_smoke/tests/common/common_config.yaml
+++ b/tests/integration/targets/nxos_smoke/tests/common/common_config.yaml
@@ -4,8 +4,10 @@
 
 # hit NetworkConfig
 # Select interface for test
-- debug: msg="START connection={{ ansible_connection }} common/common_config.yaml"
-- debug: msg="Using provider={{ connection.transport }}"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} common/common_config.yaml
+- ansible.builtin.debug:
+    msg: Using provider={{ connection.transport }}
   when: ansible_connection == "local"
 
 - set_fact: intname="{{ nxos_int1 }}"
@@ -40,7 +42,7 @@
       - shutdown
     parents:
       - "interface {{ intname }}"
-    backup: yes
+    backup: true
     provider: "{{ connection }}"
   register: result
 
@@ -64,7 +66,7 @@
     lines: no ip access-list test
     provider: "{{ connection }}"
     match: none
-  ignore_errors: yes
+  ignore_errors: true
 
 # hit NetworkConfig._diff_exact
 - name: configure sub level command using block replace - exact
@@ -109,7 +111,7 @@
 # hit CustomNetworkConfig
 - block:
     - name: create static route
-      cisco.nxos.nxos_static_route: &configure
+      cisco.nxos.nxos_static_route:
         prefix: "192.168.20.64/24"
         next_hop: "192.0.2.3"
         route_name: testing
@@ -124,7 +126,7 @@
           - "result.changed == true"
 
     - name: remove static route
-      cisco.nxos.nxos_static_route: &remove
+      cisco.nxos.nxos_static_route:
         prefix: "192.168.20.64/24"
         next_hop: "192.0.2.3"
         route_name: testing
@@ -148,13 +150,15 @@
         vrf: testing
         state: absent
         provider: "{{ connection }}"
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: remove static route aggregate
       cisco.nxos.nxos_static_route:
         aggregate:
-          - { prefix: "192.168.22.64/24", next_hop: "192.0.2.3" }
-          - { prefix: "192.168.24.64/24", next_hop: "192.0.2.3" }
+          - prefix: "192.168.22.64/24"
+            next_hop: "192.0.2.3"
+          - prefix: "192.168.24.64/24"
+            next_hop: "192.0.2.3"
         state: absent
         provider: "{{ connection }}"
-      ignore_errors: yes
+      ignore_errors: true

--- a/tests/integration/targets/nxos_smoke/tests/common/common_utils.yaml
+++ b/tests/integration/targets/nxos_smoke/tests/common/common_utils.yaml
@@ -3,8 +3,10 @@
 # nxos_config -> to_list
 # nxos_interface -> conditional, remove_default_spec
 
-- debug: msg="START connection={{ ansible_connection }} common/common_utils.yaml"
-- debug: msg="Using provider={{ connection.transport }}"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} common/common_utils.yaml
+- ansible.builtin.debug:
+    msg: Using provider={{ connection.transport }}
   when: ansible_connection == "local"
 
 # hit ComplexList
@@ -48,7 +50,7 @@
       - "default interface {{ testint1 }}"
       - "default interface {{ testint2 }}"
     provider: "{{ connection }}"
-  ignore_errors: yes
+  ignore_errors: true
 
   register: result
 
@@ -72,7 +74,7 @@
     tx_rate: lt(0)
     rx_rate: lt(0)
     provider: "{{ connection }}"
-  ignore_errors: yes
+  ignore_errors: true
   register: result
 
 - assert:
@@ -84,11 +86,10 @@
 - name: aggregate definition of interface
   cisco.nxos.nxos_interface:
     aggregate:
-      - {
-          name: "{{ testint1 }}",
-          description: "Test aggregation on first interface",
-        }
-      - { name: "{{ testint2 }}", mode: layer3 }
+      - name: "{{ testint1 }}"
+        description: "Test aggregation on first interface"
+      - name: "{{ testint2 }}"
+        mode: layer3
     provider: "{{ connection }}"
   register: result
 
@@ -102,4 +103,4 @@
       - "default interface {{ testint1 }}"
       - "default interface {{ testint2 }}"
     provider: "{{ connection }}"
-  ignore_errors: yes
+  ignore_errors: true

--- a/tests/integration/targets/nxos_smoke/tests/common/misc_tests.yaml
+++ b/tests/integration/targets/nxos_smoke/tests/common/misc_tests.yaml
@@ -1,6 +1,8 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} common/misc_tests.yaml"
-- debug: msg="Using provider={{ connection.transport }}"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} common/misc_tests.yaml
+- ansible.builtin.debug:
+    msg: Using provider={{ connection.transport }}
   when: ansible_connection == "local"
 
 - name: hit conditional for lists of 10 or more commands

--- a/tests/integration/targets/nxos_snapshot/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_snapshot/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_snapshot sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_snapshot sanity test
 
 - set_fact: snapshot_run="true"
 
@@ -123,4 +124,5 @@
       cisco.nxos.nxos_snapshot:
         action: delete_all
 
-- debug: msg="END connection={{ ansible_connection }} nxos_snapshot sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_snapshot sanity test

--- a/tests/integration/targets/nxos_snmp_community/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_snmp_community/tests/common/sanity.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_snmp_community sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_snmp_community sanity test
 
 - name: Setup - Remove snmp_community if configured - 1
   ignore_errors: true
@@ -158,6 +157,5 @@
     - name: Cleanup
       cisco.nxos.nxos_snmp_community: *id010
 
-    - debug:
-        msg="END connection={{ ansible_connection }} nxos_snmp_community sanity
-        test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_snmp_community sanity test

--- a/tests/integration/targets/nxos_snmp_contact/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_snmp_contact/tests/common/sanity.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_snmp_community sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_snmp_community sanity test
 
 - name: Setup - Remove snmp_contact if configured
   cisco.nxos.nxos_snmp_contact: &id005
@@ -56,6 +55,5 @@
     - name: Cleanup
       cisco.nxos.nxos_snmp_contact: *id005
 
-    - debug:
-        msg="END connection={{ ansible_connection }} nxos_snmp_community sanity
-        test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_snmp_community sanity test

--- a/tests/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v1_trap.yaml
+++ b/tests/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v1_trap.yaml
@@ -3,9 +3,8 @@
 
 - set_fact: snmp_version="v1"
 
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_snmp_host {{ snmp_type
-    }} {{ snmp_version }} sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_snmp_host {{ snmp_type }} {{ snmp_version }} sanity test
 
 - set_fact: intname="{{ nxos_int1 }}"
   when: platform is not search('N5K|N6K')
@@ -118,6 +117,5 @@
     - name: Cleanup
       cisco.nxos.nxos_snmp_host: *id007
 
-    - debug:
-        msg="END connection={{ ansible_connection }} nxos_snmp_host {{ snmp_type
-        }} {{ snmp_version }} sanity test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_snmp_host {{ snmp_type }} {{ snmp_version }} sanity test

--- a/tests/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v2_inform.yaml
+++ b/tests/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v2_inform.yaml
@@ -3,9 +3,8 @@
 
 - set_fact: snmp_version="v2c"
 
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_snmp_host {{ snmp_type
-    }} {{ snmp_version }} sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_snmp_host {{ snmp_type }} {{ snmp_version }} sanity test
 
 - set_fact: intname="{{ nxos_int1 }}"
   when: platform is not search('N5K|N6K')
@@ -118,6 +117,5 @@
     - name: Cleanup
       cisco.nxos.nxos_snmp_host: *id007
 
-    - debug:
-        msg="END connection={{ ansible_connection }} nxos_snmp_host {{ snmp_type
-        }} {{ snmp_version }} sanity test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_snmp_host {{ snmp_type }} {{ snmp_version }} sanity test

--- a/tests/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_inform.yaml
+++ b/tests/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_inform.yaml
@@ -5,9 +5,8 @@
 
 - set_fact: snmp_auth="priv"
 
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_snmp_host {{ snmp_type
-    }} {{ snmp_version }} sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_snmp_host {{ snmp_type }} {{ snmp_version }} sanity test
 
 - set_fact: intname="{{ nxos_int1 }}"
   when: platform is not search('N5K|N6K')
@@ -124,6 +123,5 @@
       register: result
       cisco.nxos.nxos_snmp_host: *id007
 
-    - debug:
-        msg="END connection={{ ansible_connection }} nxos_snmp_host {{ snmp_type
-        }} {{ snmp_version }} sanity test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_snmp_host {{ snmp_type }} {{ snmp_version }} sanity test

--- a/tests/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_trap.yaml
+++ b/tests/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_trap.yaml
@@ -5,9 +5,8 @@
 
 - set_fact: snmp_auth="priv"
 
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_snmp_host {{ snmp_type
-    }} {{ snmp_version }} sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_snmp_host {{ snmp_type }} {{ snmp_version }} sanity test
 
 - set_fact: intname="{{ nxos_int1 }}"
   when: platform is not search('N5K|N6K')
@@ -123,6 +122,5 @@
       register: result
       cisco.nxos.nxos_snmp_host: *id007
 
-    - debug:
-        msg="END connection={{ ansible_connection }} nxos_snmp_host {{ snmp_type
-        }} {{ snmp_version }} sanity test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_snmp_host {{ snmp_type }} {{ snmp_version }} sanity test

--- a/tests/integration/targets/nxos_snmp_location/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_snmp_location/tests/common/sanity.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_snmp_location sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_snmp_location sanity test
 
 - name: Setup - Remove snmp_location if configured
   cisco.nxos.nxos_snmp_location: &id005
@@ -57,6 +56,5 @@
       register: result
       cisco.nxos.nxos_snmp_location: *id005
 
-    - debug:
-        msg="END connection={{ ansible_connection }} nxos_snmp_location sanity
-        test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_snmp_location sanity test

--- a/tests/integration/targets/nxos_snmp_traps/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_snmp_traps/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_snmp_traps sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_snmp_traps sanity test
 
 - name: Setup - Remove snmp_traps if configured
   cisco.nxos.nxos_snmp_traps: &id006
@@ -70,5 +71,5 @@
     - name: Cleanup
       cisco.nxos.nxos_snmp_traps: *id006
 
-    - debug: msg="END connection={{ ansible_connection }} nxos_snmp_traps sanity
-        test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_snmp_traps sanity test

--- a/tests/integration/targets/nxos_snmp_user/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_snmp_user/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_snmp_user sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_snmp_user sanity test
 
 - set_fact: delete_last_user_allowed='true'
 
@@ -103,4 +104,5 @@
       when: platform is search('N5K|N6K|N9K-F')
       cisco.nxos.nxos_user: *id007
 
-- debug: msg="END connection={{ ansible_connection }} nxos_snmp_user sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_snmp_user sanity test

--- a/tests/integration/targets/nxos_static_route/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_static_route/tests/common/sanity.yaml
@@ -1,6 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_static_route sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_static_route sanity test
 
 - set_fact: test_track_feature="true"
 
@@ -11,12 +11,14 @@
     lines:
       - track 1 ip sla 1
 
-- debug: msg="cmd result {{ cmd_result }}"
+- ansible.builtin.debug:
+    msg: cmd result {{ cmd_result }}
 
 - set_fact: test_track_feature="false"
   when: cmd_result.failed
 
-- debug: msg="Test Track Feature {{ test_track_feature }}"
+- ansible.builtin.debug:
+    msg: Test Track Feature {{ test_track_feature }}
 
 - name: Setup and teardown, remove test routes if present
   with_items: "{{ vrfs }}"
@@ -203,4 +205,5 @@
       ignore_errors: true
       cisco.nxos.nxos_static_route: *id009
 
-- debug: msg="END connection={{ ansible_connection }} nxos_static_route sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_static_route sanity test

--- a/tests/integration/targets/nxos_system/tests/cli/net_system.yaml
+++ b/tests/integration/targets/nxos_system/tests/cli/net_system.yaml
@@ -1,6 +1,6 @@
 ---
-- debug: msg="START nxos cli/net_system.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: START nxos cli/net_system.yaml on connection={{ ansible_connection }}
 
 - name: setup
   cisco.nxos.nxos_config:
@@ -29,4 +29,5 @@
       - no ip domain-list redhat.com
     match: none
 
-- debug: msg="END nxos cli/net_system.yaml on connection={{ ansible_connection }}"
+- ansible.builtin.debug:
+    msg: END nxos cli/net_system.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_system/tests/cli/set_domain_list.yaml
+++ b/tests/integration/targets/nxos_system/tests/cli/set_domain_list.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START cli/set_domain_list.yaml"
+- ansible.builtin.debug:
+    msg: START cli/set_domain_list.yaml
 
 - name: setup
   cisco.nxos.nxos_config:
@@ -109,4 +110,5 @@
       - no ip domain-list eng.ansible.com
     match: none
 
-- debug: msg="END cli/set_domain_search.yaml"
+- ansible.builtin.debug:
+    msg: END cli/set_domain_search.yaml

--- a/tests/integration/targets/nxos_system/tests/cli/set_domain_name.yaml
+++ b/tests/integration/targets/nxos_system/tests/cli/set_domain_name.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START cli/set_domain_name.yaml"
+- ansible.builtin.debug:
+    msg: START cli/set_domain_name.yaml
 
 - name: setup
   cisco.nxos.nxos_config:
@@ -29,4 +30,5 @@
     lines: no ip domain-name eng.ansible.com
     match: none
 
-- debug: msg="END cli/set_domain_name.yaml"
+- ansible.builtin.debug:
+    msg: END cli/set_domain_name.yaml

--- a/tests/integration/targets/nxos_system/tests/cli/set_name_servers.yaml
+++ b/tests/integration/targets/nxos_system/tests/cli/set_name_servers.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START cli/set_name_servers.yaml"
+- ansible.builtin.debug:
+    msg: START cli/set_name_servers.yaml
 
 - name: setup
   cisco.nxos.nxos_config: &id002
@@ -70,4 +71,5 @@
   ignore_errors: true
   cisco.nxos.nxos_config: *id002
 
-- debug: msg="END cli/set_name_servers.yaml"
+- ansible.builtin.debug:
+    msg: END cli/set_name_servers.yaml

--- a/tests/integration/targets/nxos_system/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_system/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }}/sanity.yaml"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }}/sanity.yaml
 
 - block:
     - name: remove configuration
@@ -125,4 +126,5 @@
     - name: Re-configure hostname
       cisco.nxos.nxos_system: *id001
 
-    - debug: msg="END connection={{ ansible_connection }}/sanity.yaml"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }}/sanity.yaml

--- a/tests/integration/targets/nxos_system/tests/common/set_hostname.yaml
+++ b/tests/integration/targets/nxos_system/tests/common/set_hostname.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }}/set_hostname.yaml"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }}/set_hostname.yaml
 
 - block:
     - name: setup
@@ -30,4 +31,5 @@
         lines: hostname switch
         match: none
 
-    - debug: msg="END connection={{ ansible_connection }}/set_hostname.yaml"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }}/set_hostname.yaml

--- a/tests/integration/targets/nxos_system/tests/nxapi/net_system.yaml
+++ b/tests/integration/targets/nxos_system/tests/nxapi/net_system.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START nxos nxapi/net_system.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: START nxos nxapi/net_system.yaml on connection={{ ansible_connection }}
 
 - name: setup
   ignore_errors: true
@@ -31,5 +30,5 @@
       - no ip domain-list redhat.com
     match: none
 
-- debug: msg="END nxos nxapi/net_system.yaml on connection={{ ansible_connection
-    }}"
+- ansible.builtin.debug:
+    msg: END nxos nxapi/net_system.yaml on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_system/tests/nxapi/set_domain_list.yaml
+++ b/tests/integration/targets/nxos_system/tests/nxapi/set_domain_list.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START nxapi/set_domain_list.yaml"
+- ansible.builtin.debug:
+    msg: START nxapi/set_domain_list.yaml
 
 - name: setup
   ignore_errors: true
@@ -115,4 +116,5 @@
       - no ip domain-list {{ item }}
     match: none
 
-- debug: msg="END nxapi/set_domain_search.yaml"
+- ansible.builtin.debug:
+    msg: END nxapi/set_domain_search.yaml

--- a/tests/integration/targets/nxos_system/tests/nxapi/set_domain_name.yaml
+++ b/tests/integration/targets/nxos_system/tests/nxapi/set_domain_name.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START nxapi/set_domain_name.yaml"
+- ansible.builtin.debug:
+    msg: START nxapi/set_domain_name.yaml
 
 - name: setup
   ignore_errors: true
@@ -30,4 +31,5 @@
     lines: no ip domain-name eng.ansible.com
     match: none
 
-- debug: msg="END nxapi/set_domain_name.yaml"
+- ansible.builtin.debug:
+    msg: END nxapi/set_domain_name.yaml

--- a/tests/integration/targets/nxos_system/tests/nxapi/set_name_servers.yaml
+++ b/tests/integration/targets/nxos_system/tests/nxapi/set_name_servers.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START nxapi/set_name_servers.yaml"
+- ansible.builtin.debug:
+    msg: START nxapi/set_name_servers.yaml
 
 - name: setup
   ignore_errors: true
@@ -77,4 +78,5 @@
   ignore_errors: true
   cisco.nxos.nxos_config: *id002
 
-- debug: msg="END nxapi/set_name_servers.yaml"
+- ansible.builtin.debug:
+    msg: END nxapi/set_name_servers.yaml

--- a/tests/integration/targets/nxos_telemetry/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_telemetry/tests/common/deleted.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_telemetry deleted sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_telemetry deleted sanity test
 
 - set_fact: source_interface="Loopback55"
   when: imagetag and (major_version is version_compare('9.1', 'ge'))
@@ -60,7 +59,7 @@
           data_source: NX-API
           path:
             name: '"show bgp l2vpn evpn summary"'
-            depth: 0
+            depth: 00
             query_condition: foo
             filter_condition: foo
 
@@ -76,7 +75,7 @@
           data_source: DME
           path:
             name: sys/bgp/inst/dom-default/peer-[10.10.10.11]/ent-[10.10.10.11]
-            depth: 0
+            depth: 00
             query_condition: foo
             filter_condition: foo
 
@@ -84,7 +83,7 @@
           data_source: DME
           path:
             name: sys/ospf
-            depth: 0
+            depth: 00
             query_condition: foo
             filter_condition: or(eq(ethpmPhysIf.operSt,"down"),eq(ethpmPhysIf.operSt,"up"))
       subscriptions:
@@ -128,16 +127,14 @@
 
     - assert:
         that:
-          - (ansible_facts.network_resources.telemetry|dict2items)|symmetric_difference(result.before|dict2items)|length
-            == 0
+          - (ansible_facts.network_resources.telemetry|dict2items)|symmetric_difference(result.before|dict2items)|length == 0
 
     - name: Gather Telemetry Facts After Changes
       cisco.nxos.nxos_facts: *id001
 
     - assert:
         that:
-          - (ansible_facts.network_resources.telemetry|dict2items)|symmetric_difference(result.after|dict2items)|length
-            == 0
+          - (ansible_facts.network_resources.telemetry|dict2items)|symmetric_difference(result.after|dict2items)|length == 0
 
     - name: Telemetry - deleted - idempotence
       register: result
@@ -152,5 +149,5 @@
       ignore_errors: true
       cisco.nxos.nxos_feature: *id003
 
-    - debug: msg="END connection={{ ansible_connection }} nxos_telemetry deleted
-        sanity test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_telemetry deleted sanity test

--- a/tests/integration/targets/nxos_telemetry/tests/common/gathered.yaml
+++ b/tests/integration/targets/nxos_telemetry/tests/common/gathered.yaml
@@ -1,11 +1,10 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_telemetry gathered sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_telemetry gathered sanity test
 
 - name: Setup 1
   ignore_errors: true
-  cisco.nxos.nxos_feature: &id004
+  cisco.nxos.nxos_feature: &id001
     feature: telemetry
     state: disabled
 
@@ -41,4 +40,4 @@
   always:
     - name: Setup 1
       ignore_errors: true
-      cisco.nxos.nxos_feature: *id004
+      cisco.nxos.nxos_feature: *id001

--- a/tests/integration/targets/nxos_telemetry/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_telemetry/tests/common/merged.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_telemetry merged sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_telemetry merged sanity test
 
 - set_fact: source_interface="Loopback55"
   when: imagetag and (major_version is version_compare('9.1', 'ge'))
@@ -70,7 +69,7 @@
               data_source: NX-API
               path:
                 name: '"show bgp l2vpn evpn summary"'
-                depth: 0
+                depth: 00
                 query_condition: foo
                 filter_condition: foo
 
@@ -86,7 +85,7 @@
               data_source: DME
               path:
                 name: sys/bgp/inst/dom-default/peer-[10.10.10.11]/ent-[10.10.10.11]
-                depth: 0
+                depth: 00
                 query_condition: foo
                 filter_condition: foo
 
@@ -94,7 +93,7 @@
               data_source: DME
               path:
                 name: sys/ospf
-                depth: 0
+                depth: 00
                 query_condition: foo
                 filter_condition: or(eq(ethpmPhysIf.operSt,"down"),eq(ethpmPhysIf.operSt,"up"))
           subscriptions:
@@ -134,18 +133,14 @@
           - "'ip address 192.168.0.2 port 60001 protocol grpc encoding gpb' in result.commands"
           - "'sensor-group 8' in result.commands"
           - "'data-source NX-API' in result.commands"
-          - result.commands is search("path .*show bgp l2vpn evpn summary.* depth
-            0 query-condition foo filter-condition foo")
+          - result.commands is search("path .*show bgp l2vpn evpn summary.* depth 0 query-condition foo filter-condition foo")
           - "'sensor-group 2' in result.commands"
           - "'data-source NX-API' in result.commands"
-          - result.commands is search("path .*show ip bgp neighbors.* depth unbounded
-            query-condition foo filter-condition foo")
+          - result.commands is search("path .*show ip bgp neighbors.* depth unbounded query-condition foo filter-condition foo")
           - "'sensor-group 55' in result.commands"
           - "'data-source DME' in result.commands"
-          - "'path sys/bgp/inst/dom-default/peer-[10.10.10.11]/ent-[10.10.10.11]\
-            \ depth 0 query-condition foo filter-condition foo' in result.commands"
-          - "'path sys/ospf depth 0 query-condition foo filter-condition or(eq(ethpmPhysIf.operSt,\"\
-            down\"),eq(ethpmPhysIf.operSt,\"up\"))' in result.commands"
+          - "'path sys/bgp/inst/dom-default/peer-[10.10.10.11]/ent-[10.10.10.11] depth 0 query-condition foo filter-condition foo' in result.commands"
+          - "'path sys/ospf depth 0 query-condition foo filter-condition or(eq(ethpmPhysIf.operSt,\"down\"),eq(ethpmPhysIf.operSt,\"up\"))' in result.commands"
           - "'subscription 44' in result.commands"
           - "'dst-grp 10' in result.commands"
           - "'dst-grp 2' in result.commands"
@@ -163,16 +158,14 @@
 
     - assert:
         that:
-          - (ansible_facts.network_resources.telemetry|dict2items)|symmetric_difference(result.before|dict2items)|length
-            == 0
+          - (ansible_facts.network_resources.telemetry|dict2items)|symmetric_difference(result.before|dict2items)|length == 0
 
     - name: Gather Telemetry Facts After Changes
       cisco.nxos.nxos_facts: *id001
 
     - assert:
         that:
-          - (ansible_facts.network_resources.telemetry|dict2items)|symmetric_difference(result.after|dict2items)|length
-            == 0
+          - (ansible_facts.network_resources.telemetry|dict2items)|symmetric_difference(result.after|dict2items)|length == 0
 
     - name: Telemetry - merged - idempotence
       register: result
@@ -227,7 +220,7 @@
               data_source: NX-API
               path:
                 name: '"show bgp l2vpn evpn summary"'
-                depth: 0
+                depth: 00
                 query_condition: foo
                 filter_condition: foo
 
@@ -243,7 +236,7 @@
               data_source: DME
               path:
                 name: sys/bgp/inst/dom-default/peer-[10.10.10.11]/ent-[10.10.10.11]
-                depth: 0
+                depth: 00
                 query_condition: foo
                 filter_condition: foo
 
@@ -251,7 +244,7 @@
               data_source: DME
               path:
                 name: sys/ospf
-                depth: 0
+                depth: 00
                 query_condition: foo
                 filter_condition: or(eq(ethpmPhysIf.operSt,"down"),eq(ethpmPhysIf.operSt,"up"))
           subscriptions:
@@ -298,5 +291,5 @@
       ignore_errors: true
       cisco.nxos.nxos_feature: *id004
 
-    - debug: msg="END connection={{ ansible_connection }} nxos_telemetry merged
-        sanity test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_telemetry merged sanity test

--- a/tests/integration/targets/nxos_telemetry/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_telemetry/tests/common/merged.yaml
@@ -140,7 +140,7 @@
           - "'sensor-group 55' in result.commands"
           - "'data-source DME' in result.commands"
           - "'path sys/bgp/inst/dom-default/peer-[10.10.10.11]/ent-[10.10.10.11] depth 0 query-condition foo filter-condition foo' in result.commands"
-          - "'path sys/ospf depth 0 query-condition foo filter-condition or(eq(ethpmPhysIf.operSt,\"down\"),eq(ethpmPhysIf.operSt,\"up\"))' in result.commands"
+          - '''path sys/ospf depth 0 query-condition foo filter-condition or(eq(ethpmPhysIf.operSt,"down"),eq(ethpmPhysIf.operSt,"up"))'' in result.commands'
           - "'subscription 44' in result.commands"
           - "'dst-grp 10' in result.commands"
           - "'dst-grp 2' in result.commands"

--- a/tests/integration/targets/nxos_telemetry/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_telemetry/tests/common/replaced.yaml
@@ -1,6 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_telemetry replaced
-    sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_telemetry replaced sanity test
 
 - set_fact: source_interface="Loopback55"
   when: imagetag and (major_version is version_compare('9.1', 'ge'))
@@ -108,16 +108,13 @@
           - "'no destination-group 99' in result.commands"
           - "'no destination-group 10' in result.commands"
           - "'destination-group 2' in result.commands"
-          - "'no ip address 192.168.0.1 port 50001 protocol grpc encoding gpb' in\
-            \ result.commands"
-          - "'no ip address 192.168.0.2 port 60001 protocol grpc encoding gpb' in\
-            \ result.commands"
+          - "'no ip address 192.168.0.1 port 50001 protocol grpc encoding gpb' in result.commands"
+          - "'no ip address 192.168.0.2 port 60001 protocol grpc encoding gpb' in result.commands"
           - "'destination-group 2' in result.commands"
           - "'ip address 192.168.0.1 port 65001 protocol grpc encoding gpb' in result.commands"
           - "'ip address 192.168.0.3 port 55001 protocol grpc encoding gpb' in result.commands"
           - "'sensor-group 100' in result.commands"
-          - result.commands is search("path .*show bgp l2vpn evpn summary.* depth
-            unbounded query-condition foo filter-condition foo")
+          - result.commands is search("path .*show bgp l2vpn evpn summary.* depth unbounded query-condition foo filter-condition foo")
           - "'data-source NX-API' in result.commands"
           - "'subscription 99' in result.commands"
           - "'snsr-grp 100 sample-interval 2000' in result.commands"
@@ -133,16 +130,14 @@
 
     - assert:
         that:
-          - (ansible_facts.network_resources.telemetry|dict2items)|symmetric_difference(result.before|dict2items)|length
-            == 0
+          - (ansible_facts.network_resources.telemetry|dict2items)|symmetric_difference(result.before|dict2items)|length == 0
 
     - name: Gather Telemetry Facts After Changes
       cisco.nxos.nxos_facts: *id001
 
     - assert:
         that:
-          - (ansible_facts.network_resources.telemetry|dict2items)|symmetric_difference(result.after|dict2items)|length
-            == 0
+          - (ansible_facts.network_resources.telemetry|dict2items)|symmetric_difference(result.after|dict2items)|length == 0
 
     - name: Telemetry - replaced - idempotence
       register: result
@@ -157,6 +152,5 @@
       ignore_errors: true
       cisco.nxos.nxos_feature: *id003
 
-    - debug:
-        msg="END connection={{ ansible_connection }} nxos_telemetry replaced
-        sanity test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_telemetry replaced sanity test

--- a/tests/integration/targets/nxos_udld/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_udld/tests/common/sanity.yaml
@@ -1,12 +1,11 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_udld sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_udld sanity test
 
 - set_fact: udld_run="true"
 
 - set_fact: udld_run="false"
-  when:
-    ((platform is search('N9K-F')) and (imagetag and (imagetag is version_compare('F3',
-    'lt'))))
+  when: ((platform is search('N9K-F')) and (imagetag and (imagetag is version_compare('F3', 'lt'))))
 
 - set_fact: udld_run="false"
   when: titanium
@@ -91,4 +90,5 @@
         feature: udld
         state: disabled
 
-- debug: msg="END connection={{ ansible_connection }} nxos_udld sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_udld sanity test

--- a/tests/integration/targets/nxos_udld_interface/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_udld_interface/tests/common/sanity.yaml
@@ -1,16 +1,13 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_udld_interface sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_udld_interface sanity test
 
 - set_fact: udld_run="true"
 
 - set_fact: udld_enable="true"
 
 - set_fact: udld_run="false"
-  when:
-    ((platform is search('N9K-F')) and (imagetag and (imagetag is version_compare('F3',
-    'lt'))))
+  when: ((platform is search('N9K-F')) and (imagetag and (imagetag is version_compare('F3', 'lt'))))
 
 - set_fact: udld_run="false"
   when: titanium
@@ -108,5 +105,5 @@
         feature: udld
         state: disabled
 
-- debug: msg="END connection={{ ansible_connection }} nxos_udld_interface sanity
-    test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_udld_interface sanity test

--- a/tests/integration/targets/nxos_user/tests/common/basic.yaml
+++ b/tests/integration/targets/nxos_user/tests/common/basic.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_user basic test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_user basic test
 
 - name: Remove old entries of user
   cisco.nxos.nxos_user: &rem
@@ -24,7 +25,8 @@
     roles: network-operator
     state: present
 
-- debug: msg="{{result}}"
+- ansible.builtin.debug:
+    msg: "{{result}}"
 
 - assert:
     that:
@@ -63,7 +65,7 @@
     name: ansibletest_failed
     configured_password: abc
   register: result
-  ignore_errors: True
+  ignore_errors: true
 
 - assert:
     that:
@@ -117,7 +119,7 @@
     role: invalid_role
     state: present
   register: result
-  ignore_errors: True
+  ignore_errors: true
 
 - assert:
     that:
@@ -138,4 +140,5 @@
     lines:
       - no role name customrole
 
-- debug: msg="END connection={{ ansible_connection }} nxos_user basic test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_user basic test

--- a/tests/integration/targets/nxos_user/tests/common/net_user.yaml
+++ b/tests/integration/targets/nxos_user/tests/common/net_user.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos common/net_user.yaml"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos common/net_user.yaml
 
 - name: Remove old entries of user - setup
   ansible.netcommon.net_user:
@@ -24,4 +25,5 @@
     name: ansibletest1
     state: absent
 
-- debug: msg="END connection={{ ansible_connection }} nxos common/net_user.yaml"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos common/net_user.yaml

--- a/tests/integration/targets/nxos_user/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_user/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_user parameter test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_user parameter test
 
 - set_fact: idem="true"
 
@@ -44,9 +45,8 @@
 
     - assert: *id004
 
-    - debug:
-        msg="skipping sshkey test as the key needs to be created on the server
-        first"
+    - ansible.builtin.debug:
+        msg: skipping sshkey test as the key needs to be created on the server first
 
     - name: Collection of users
       register: result
@@ -91,4 +91,5 @@
       ignore_errors: true
       cisco.nxos.nxos_user: *id006
 
-- debug: msg="END connection={{ ansible_connection }} nxos_user parameter test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_user parameter test

--- a/tests/integration/targets/nxos_vlan/tests/common/agg.yaml
+++ b/tests/integration/targets/nxos_vlan/tests/common/agg.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }}/agg.yaml"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }}/agg.yaml
 
 - name: setup - remove vlan used in test
   ignore_errors: true
@@ -117,4 +118,5 @@
   ignore_errors: true
   cisco.nxos.nxos_config: *id005
 
-- debug: msg="END connection={{ ansible_connection }}/agg.yaml"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }}/agg.yaml

--- a/tests/integration/targets/nxos_vlan/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vlan/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_vlan sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_vlan sanity test
 
 - set_fact: testint1="{{ nxos_int1 }}"
 
@@ -221,4 +222,5 @@
         feature: vn-segment-vlan-based
         state: disabled
 
-- debug: msg="END connection={{ ansible_connection }} nxos_vlan sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_vlan sanity test

--- a/tests/integration/targets/nxos_vpc/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vpc/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_vpc sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_vpc sanity test
 
 - block:
     - set_fact: delay_restore_orphan_port=25
@@ -122,9 +123,7 @@
         peer_gw: true
         delay_restore: default
         delay_restore_interface_vlan: default
-        delay_restore_orphan_port:
-          "{{ def_delay_restore_orphan_port|default(omit)
-          }}"
+        delay_restore_orphan_port: "{{ def_delay_restore_orphan_port|default(omit) }}"
 
     - assert: *id002
 
@@ -175,4 +174,5 @@
         feature: vpc
         state: disabled
 
-- debug: msg="END connection={{ ansible_connection }} nxos_vpc sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_vpc sanity test

--- a/tests/integration/targets/nxos_vpc_interface/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vpc_interface/tests/common/sanity.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_vpc_interface sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_vpc_interface sanity test
 
 - block:
     - name: enable feature vpc
@@ -135,5 +134,5 @@
         feature: vpc
         state: disabled
 
-- debug: msg="END connection={{ ansible_connection }} nxos_vpc_interface sanity
-    test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_vpc_interface sanity test

--- a/tests/integration/targets/nxos_vrf/tests/common/intent.yaml
+++ b/tests/integration/targets/nxos_vrf/tests/common/intent.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_vrf intent & aggregate
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_vrf intent & aggregate test
 
 - set_fact: testint1="{{ nxos_int1 }}"
 
@@ -191,6 +190,5 @@
     lines:
       - no vrf context test2
 
-- debug:
-    msg="END connection={{ ansible_connection }} nxos_vrf intent & aggregate
-    test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_vrf intent & aggregate test

--- a/tests/integration/targets/nxos_vrf/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vrf/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_vrf sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_vrf sanity test
 
 - set_fact: intname1="{{ nxos_int1 }}"
 
@@ -107,4 +108,5 @@
         feature: bgp
         state: disabled
 
-    - debug: msg="END connection={{ ansible_connection }} nxos_vrf sanity test"
+    - ansible.builtin.debug:
+        msg: END connection={{ ansible_connection }} nxos_vrf sanity test

--- a/tests/integration/targets/nxos_vrf_af/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vrf_af/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_vrf_af sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_vrf_af sanity test
 
 - name: Configure feature bgp
   cisco.nxos.nxos_feature:
@@ -141,4 +142,5 @@
         feature: bgp
         state: disabled
 
-- debug: msg="END connection={{ ansible_connection }} nxos_vrf_af sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_vrf_af sanity test

--- a/tests/integration/targets/nxos_vrf_interface/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vrf_interface/tests/common/sanity.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_vrf_interface sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_vrf_interface sanity test
 
 - set_fact: intname="{{ nxos_int1 }}"
 
@@ -54,5 +53,5 @@
         lines: default interface {{ intname }}
         match: none
 
-- debug: msg="END connection={{ ansible_connection }} nxos_vrf_interface sanity
-    test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_vrf_interface sanity test

--- a/tests/integration/targets/nxos_vrrp/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vrrp/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_vrrp sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_vrrp sanity test
 
 - block:
     - name: Enable interface-vlan
@@ -128,4 +129,5 @@
         feature: vrrp
         state: disabled
 
-- debug: msg="END connection={{ ansible_connection }} nxos_vrrp sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_vrrp sanity test

--- a/tests/integration/targets/nxos_vsan/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vsan/tests/common/sanity.yaml
@@ -1,10 +1,9 @@
 ---
-- debug: msg="START nxos_vsan sanity test with connection={{ ansible_connection
-    }} "
+- ansible.builtin.debug:
+    msg: "START nxos_vsan sanity test with connection={{ ansible_connection }} "
 
-- debug: msg="Using vsans {{ vsan1 }}, {{ vsan2 }} for running this sanity test,
-    please make sure these are not used in the setup, these will be deleted after
-    the tests"
+- ansible.builtin.debug:
+    msg: Using vsans {{ vsan1 }}, {{ vsan2 }} for running this sanity test, please make sure these are not used in the setup, these will be deleted after the tests
 
 - block:
     - name: Setup - Remove vsan if configured
@@ -40,10 +39,8 @@
 
     - assert:
         that:
-          - result.commands == ["terminal dont-ask", "vsan database", "vsan 922",
-            "vsan 922 name vsan-SAN-A", "vsan 922 suspend", "vsan 922 interface
-            fc1/1", "vsan 923", "vsan 923 name vsan-SAN-B", "no vsan 923 suspend",
-            "vsan 923 interface fc1/2", "no terminal dont-ask"]
+          - result.commands == ["terminal dont-ask", "vsan database", "vsan 922", "vsan 922 name vsan-SAN-A", "vsan 922 suspend", "vsan 922 interface fc1/1", "vsan
+            923", "vsan 923 name vsan-SAN-B", "no vsan 923 suspend", "vsan 923 interface fc1/2", "no terminal dont-ask"]
 
     - name: Idempotence Check
       register: result

--- a/tests/integration/targets/nxos_vtp_domain/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vtp_domain/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_vtp_domain sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_vtp_domain sanity test
 
 - set_fact: vtp_run="true"
 
@@ -41,4 +42,5 @@
         feature: vtp
         state: disabled
 
-- debug: msg="END connection={{ ansible_connection }} nxos_vtp_domain sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_vtp_domain sanity test

--- a/tests/integration/targets/nxos_vtp_password/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vtp_password/tests/common/sanity.yaml
@@ -1,6 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_vtp_password sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_vtp_password sanity test
 
 - set_fact: vtp_run="true"
 
@@ -61,4 +61,5 @@
         feature: vtp
         state: disabled
 
-- debug: msg="END connection={{ ansible_connection }} nxos_vtp_password sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_vtp_password sanity test

--- a/tests/integration/targets/nxos_vtp_version/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vtp_version/tests/common/sanity.yaml
@@ -1,6 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_vtp_version sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_vtp_version sanity test
 
 - set_fact: vtp_run="true"
 
@@ -46,4 +46,5 @@
         feature: vtp
         state: disabled
 
-- debug: msg="END connection={{ ansible_connection }} nxos_vtp_version sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_vtp_version sanity test

--- a/tests/integration/targets/nxos_vxlan_vtep/tests/common/multisite.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep/tests/common/multisite.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_vxlan_vtep multisite sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_vxlan_vtep multisite sanity test
 
 - name: Enable feature nv overlay - multisite
   cisco.nxos.nxos_config:
@@ -41,13 +42,13 @@
       register: result
       cisco.nxos.nxos_vxlan_vtep: *id001
 
-    - assert: &id003
+    - assert: &id004
         that:
           - result.changed == false
 
     - name: reset vxlan_vtep
       register: result
-      cisco.nxos.nxos_vxlan_vtep: &id004
+      cisco.nxos.nxos_vxlan_vtep: &id003
         interface: nve1
         description: default
         host_reachability: false
@@ -61,9 +62,9 @@
 
     - name: reset Idempotence
       register: result
-      cisco.nxos.nxos_vxlan_vtep: *id004
+      cisco.nxos.nxos_vxlan_vtep: *id003
 
-    - assert: *id003
+    - assert: *id004
 
     - name: remove vxlan_vtep
       register: result
@@ -108,4 +109,5 @@
     feature: nve
     state: disabled
 
-- debug: msg="END connection={{ ansible_connection }} nxos_vxlan_vtep sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_vxlan_vtep sanity test

--- a/tests/integration/targets/nxos_vxlan_vtep/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep/tests/common/sanity.yaml
@@ -1,5 +1,6 @@
 ---
-- debug: msg="START connection={{ ansible_connection }} nxos_vxlan_vtep sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_vxlan_vtep sanity test
 
 - block:
     - set_fact: global_mcast_group_L2="225.1.1.2"
@@ -21,9 +22,7 @@
       register: tcam_state
       cisco.nxos.nxos_command:
         commands:
-          - command:
-              show hardware access-list tcam region | incl arp-ether | sed
-              's/.*size = *//'
+          - command: show hardware access-list tcam region | incl arp-ether | sed 's/.*size = *//'
             output: text
 
     - block:
@@ -62,9 +61,7 @@
             host_reachability: true
             source_interface: Loopback0
             source_interface_hold_down_time: 30
-            global_ingress_replication_bgp:
-              "{{ global_ingress_replication_bgp|default(omit)
-              }}"
+            global_ingress_replication_bgp: "{{ global_ingress_replication_bgp|default(omit) }}"
             global_suppress_arp: "{{ global_suppress_arp|default(omit) }}"
             global_mcast_group_L3: "{{ global_mcast_group_L3|default(omit) }}"
             shutdown: false
@@ -89,9 +86,7 @@
             host_reachability: false
             source_interface_hold_down_time: default
             source_interface: default
-            global_ingress_replication_bgp:
-              "{{ def_global_ingress_replication_bgp|default(omit)
-              }}"
+            global_ingress_replication_bgp: "{{ def_global_ingress_replication_bgp|default(omit) }}"
             global_suppress_arp: "{{ def_global_suppress_arp|default(omit) }}"
             global_mcast_group_L3: "{{ def_global_mcast_group_L3|default(omit) }}"
             shutdown: true
@@ -216,4 +211,5 @@
         feature: nve
         state: disabled
 
-- debug: msg="END connection={{ ansible_connection }} nxos_vxlan_vtep sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_vxlan_vtep sanity test

--- a/tests/integration/targets/nxos_vxlan_vtep_vni/tests/common/multisite.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep_vni/tests/common/multisite.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_vxlan_vtep_vni multisite
-    sanity test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_vxlan_vtep_vni multisite sanity test
 
 - name: Disable feature nv overlay - multisite
   ignore_errors: true
@@ -49,13 +48,13 @@
       register: result
       cisco.nxos.nxos_vxlan_vtep_vni: *id001
 
-    - assert: &id003
+    - assert: &id004
         that:
           - result.changed == false
 
     - name: Remove multisite ingress replication - multisite
       register: result
-      cisco.nxos.nxos_vxlan_vtep_vni: &id004
+      cisco.nxos.nxos_vxlan_vtep_vni: &id003
         interface: nve1
         vni: 8000
         multisite_ingress_replication: disable
@@ -64,9 +63,9 @@
 
     - name: Idempotence check
       register: result
-      cisco.nxos.nxos_vxlan_vtep_vni: *id004
+      cisco.nxos.nxos_vxlan_vtep_vni: *id003
 
-    - assert: *id003
+    - assert: *id004
 
     - name: Configure optimized multisite ingress replication - multisite
       register: result
@@ -81,7 +80,7 @@
       register: result
       cisco.nxos.nxos_vxlan_vtep_vni: *id005
 
-    - assert: *id003
+    - assert: *id004
 
     - name: Disable multisite border gateway - multisite
       cisco.nxos.nxos_config:
@@ -104,6 +103,5 @@
     lines:
       - no nv overlay evpn
 
-- debug:
-    msg="END connection={{ ansible_connection }} nxos_vxlan_vtep_vni multisite
-    sanity test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_vxlan_vtep_vni multisite sanity test

--- a/tests/integration/targets/nxos_vxlan_vtep_vni/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep_vni/tests/common/sanity.yaml
@@ -1,7 +1,6 @@
 ---
-- debug:
-    msg="START connection={{ ansible_connection }} nxos_vxlan_vtep_vni sanity
-    test"
+- ansible.builtin.debug:
+    msg: START connection={{ ansible_connection }} nxos_vxlan_vtep_vni sanity test
 
 - block:
     - name: Apply N7K specific setup config
@@ -247,5 +246,5 @@
         feature: nve
         state: disabled
 
-- debug: msg="END connection={{ ansible_connection }} nxos_vxlan_vtep_vni sanity
-    test"
+- ansible.builtin.debug:
+    msg: END connection={{ ansible_connection }} nxos_vxlan_vtep_vni sanity test

--- a/tests/integration/targets/nxos_zone_zoneset/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_zone_zoneset/tests/common/sanity.yaml
@@ -1,11 +1,9 @@
 ---
-- debug:
-    msg="START nxos_zone_zoneset sanity test with connection={{ ansible_connection
-    }} "
+- ansible.builtin.debug:
+    msg: "START nxos_zone_zoneset sanity test with connection={{ ansible_connection }} "
 
-- debug: msg="Using vsans {{ vsan1 }}, {{ vsan2 }} for running this sanity test,
-    please make sure these are not used in the setup, these will be deleted after
-    the tests"
+- ansible.builtin.debug:
+    msg: Using vsans {{ vsan1 }}, {{ vsan2 }} for running this sanity test, please make sure these are not used in the setup, these will be deleted after the tests
 
 - always:
     - name: Remove vsan config
@@ -112,18 +110,12 @@
 
     - assert:
         that:
-          - result.commands == ["terminal dont-ask", "zone mode enhanced vsan 922",
-            "zone name zoneA vsan 922", "member pwwn 11:11:11:11:11:11:11:11", "member
-            device-alias test123", "zone name zoneB vsan 922", "member pwwn 10:11:11:11:11:11:11:11",
-            "member pwwn 62:62:62:62:21:21:21:21", "zoneset name zsetname1 vsan
-            922", "member zoneA", "member zoneB", "zoneset activate name zsetname1
-            vsan 922", "zone commit vsan 922", "zone smart-zoning enable vsan 923",
-            "zone name zone21A vsan 923", "member pwwn 11:11:11:11:11:11:11:11 both",
-            "member pwwn 62:62:62:62:12:12:12:12", "zone name zone21B vsan 923",
-            "member pwwn 10:11:11:11:11:11:11:11", "member pwwn 62:62:62:62:21:21:21:21",
-            "member device-alias somedummyname", "zoneset name zsetname21 vsan 923",
-            "member zone21A", "member zone21B", "zoneset activate name zsetname21
-            vsan 923", "no terminal dont-ask"]
+          - result.commands == ["terminal dont-ask", "zone mode enhanced vsan 922", "zone name zoneA vsan 922", "member pwwn 11:11:11:11:11:11:11:11", "member device-alias
+            test123", "zone name zoneB vsan 922", "member pwwn 10:11:11:11:11:11:11:11", "member pwwn 62:62:62:62:21:21:21:21", "zoneset name zsetname1 vsan 922",
+            "member zoneA", "member zoneB", "zoneset activate name zsetname1 vsan 922", "zone commit vsan 922", "zone smart-zoning enable vsan 923", "zone name zone21A
+            vsan 923", "member pwwn 11:11:11:11:11:11:11:11 both", "member pwwn 62:62:62:62:12:12:12:12", "zone name zone21B vsan 923", "member pwwn 10:11:11:11:11:11:11:11",
+            "member pwwn 62:62:62:62:21:21:21:21", "member device-alias somedummyname", "zoneset name zsetname21 vsan 923", "member zone21A", "member zone21B", "zoneset
+            activate name zsetname21 vsan 923", "no terminal dont-ask"]
 
     - name: Idempotence Check
       register: result
@@ -183,11 +175,8 @@
 
     - assert:
         that:
-          - result.commands == ["terminal dont-ask", "no zone name zoneA vsan 922",
-            "no zone name zoneB vsan 922", "no zoneset name zsetname1 vsan 922",
-            "zone commit vsan 922", "no zone name zone21A vsan 923", "no zone name
-            zone21B vsan 923", "no zoneset name zsetname21 vsan 923", "no terminal
-            dont-ask"]
+          - result.commands == ["terminal dont-ask", "no zone name zoneA vsan 922", "no zone name zoneB vsan 922", "no zoneset name zsetname1 vsan 922", "zone commit
+            vsan 922", "no zone name zone21A vsan 923", "no zone name zone21B vsan 923", "no zoneset name zsetname21 vsan 923", "no terminal dont-ask"]
 
     - name: Idempotence Check for zone/zoneset removal
       register: result


### PR DESCRIPTION
- Update debug statements using `=` style parameters with longhand
- Update the same to fully qualified plugin names
- Some anchor/aliases were modified, which is a result of ruamel and could not be avoided.
- Unused anchors were removed by ruamel
- At least one int `00` was replace with an equivalent value `0`
- More booleans were set to their yaml 1.2 counterpart