### PR TITLE
Capitalize all task names

### DIFF
--- a/changelogs/fragments/512.yaml
+++ b/changelogs/fragments/512.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Capitalize all task names

--- a/tests/integration/targets/nxos_aaa_server/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_aaa_server/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_aaa_server/tasks/main.yaml
+++ b/tests/integration/targets/nxos_aaa_server/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_aaa_server/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_aaa_server/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_aaa_server/tests/common/radius.yaml
+++ b/tests/integration/targets/nxos_aaa_server/tests/common/radius.yaml
@@ -18,7 +18,7 @@
         server_type: radius
         state: present
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server: *id001
 
@@ -39,7 +39,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server: *id002
 
@@ -61,7 +61,7 @@
 
     - ansible.builtin.assert: *id005
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server: *id006
 
@@ -79,7 +79,7 @@
 
     - ansible.builtin.assert: *id005
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server: *id007
 

--- a/tests/integration/targets/nxos_aaa_server/tests/common/tacacs.yaml
+++ b/tests/integration/targets/nxos_aaa_server/tests/common/tacacs.yaml
@@ -23,7 +23,7 @@
         server_type: tacacs
         state: present
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server: *id001
 
@@ -44,7 +44,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server: *id002
 
@@ -66,7 +66,7 @@
 
     - ansible.builtin.assert: *id005
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server: *id006
 
@@ -84,7 +84,7 @@
 
     - ansible.builtin.assert: *id005
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server: *id007
 

--- a/tests/integration/targets/nxos_aaa_server_host/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_aaa_server_host/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_aaa_server_host/tasks/main.yaml
+++ b/tests/integration/targets/nxos_aaa_server_host/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_aaa_server_host/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_aaa_server_host/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_aaa_server_host/tests/common/radius.yaml
+++ b/tests/integration/targets/nxos_aaa_server_host/tests/common/radius.yaml
@@ -21,7 +21,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server_host: *id001
 
@@ -35,7 +35,7 @@
 
     - ansible.builtin.assert: *id003
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server_host: *id002
 
@@ -53,7 +53,7 @@
 
     - ansible.builtin.assert: *id003
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server_host: *id005
 
@@ -71,7 +71,7 @@
 
     - ansible.builtin.assert: *id003
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server_host: *id006
 
@@ -91,7 +91,7 @@
 
     - ansible.builtin.assert: *id003
 
-    - name: Check NOT Idempotent
+    - name: Check not idempotent
       register: result
       cisco.nxos.nxos_aaa_server_host: *id007
 
@@ -117,7 +117,7 @@
 
     - ansible.builtin.assert: *id003
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server_host: *id008
 
@@ -140,7 +140,7 @@
           - result.changed == true
           - "'key 7' in result.updates[0]"
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server_host: *id009
 
@@ -160,7 +160,7 @@
 
     - ansible.builtin.assert: *id003
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server_host: *id010
 
@@ -179,7 +179,7 @@
 
     - ansible.builtin.assert: *id003
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server_host: *id011
 

--- a/tests/integration/targets/nxos_aaa_server_host/tests/common/tacacs.yaml
+++ b/tests/integration/targets/nxos_aaa_server_host/tests/common/tacacs.yaml
@@ -26,7 +26,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server_host: *id001
 
@@ -40,7 +40,7 @@
 
     - ansible.builtin.assert: *id003
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server_host: *id002
 
@@ -57,7 +57,7 @@
 
     - ansible.builtin.assert: *id003
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server_host: *id005
 
@@ -74,7 +74,7 @@
 
     - ansible.builtin.assert: *id003
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server_host: *id006
 
@@ -93,7 +93,7 @@
 
     - ansible.builtin.assert: *id003
 
-    - name: Check NOT Idempotent
+    - name: Check not idempotent
       register: result
       cisco.nxos.nxos_aaa_server_host: *id007
 
@@ -118,7 +118,7 @@
 
     - ansible.builtin.assert: *id003
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server_host: *id008
 
@@ -140,7 +140,7 @@
           - result.changed == true
           - "'key 7' in result.updates[0]"
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server_host: *id009
 
@@ -159,7 +159,7 @@
 
     - ansible.builtin.assert: *id003
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server_host: *id010
 
@@ -177,7 +177,7 @@
 
     - ansible.builtin.assert: *id003
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_aaa_server_host: *id011
 

--- a/tests/integration/targets/nxos_acl/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_acl/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_acl/tasks/main.yaml
+++ b/tests/integration/targets/nxos_acl/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_acl/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_acl/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_acl/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_acl/tests/common/sanity.yaml
@@ -7,14 +7,14 @@
     time_range: ans-range
   when: platform is not search('N35|N5K|N6K')
 
-- name: "Setup: Cleanup possibly existing acl."
+- name: "Setup: cleanup possibly existing acl."
   ignore_errors: true
   cisco.nxos.nxos_acl: &id012
     name: TEST_ACL
     seq: 10
     state: delete_acl
 
-- name: Configure ACE10
+- name: Configure ace10
   register: result
   cisco.nxos.nxos_acl: &id001
     name: TEST_ACL
@@ -44,7 +44,7 @@
     that:
       - result.changed == true
 
-- name: Check Idempotence
+- name: Check idempotence
   register: result
   cisco.nxos.nxos_acl: *id001
 
@@ -52,7 +52,7 @@
     that:
       - result.changed == false
 
-- name: Change ACE10
+- name: Change ace10
   register: result
   cisco.nxos.nxos_acl: &id003
     name: TEST_ACL
@@ -80,13 +80,13 @@
 
 - ansible.builtin.assert: *id002
 
-- name: Check Idempotence
+- name: Check idempotence
   register: result
   cisco.nxos.nxos_acl: *id003
 
 - ansible.builtin.assert: *id004
 
-- name: ace remark
+- name: Ace remark
   register: result
   cisco.nxos.nxos_acl: &id005
     name: TEST_ACL
@@ -97,13 +97,13 @@
 
 - ansible.builtin.assert: *id002
 
-- name: Check Idempotence
+- name: Check idempotence
   register: result
   cisco.nxos.nxos_acl: *id005
 
 - ansible.builtin.assert: *id004
 
-- name: change remark
+- name: Change remark
   register: result
   cisco.nxos.nxos_acl: &id006
     name: TEST_ACL
@@ -114,13 +114,13 @@
 
 - ansible.builtin.assert: *id002
 
-- name: Check Idempotence
+- name: Check idempotence
   register: result
   cisco.nxos.nxos_acl: *id006
 
 - ansible.builtin.assert: *id004
 
-- name: ace 30
+- name: Ace 30
   register: result
   cisco.nxos.nxos_acl: &id007
     name: TEST_ACL
@@ -135,13 +135,13 @@
 
 - ansible.builtin.assert: *id002
 
-- name: Check Idempotence
+- name: Check idempotence
   register: result
   cisco.nxos.nxos_acl: *id007
 
 - ansible.builtin.assert: *id004
 
-- name: change ace 30 options
+- name: Change ace 30 options
   register: result
   cisco.nxos.nxos_acl: &id008
     name: TEST_ACL
@@ -155,13 +155,13 @@
 
 - ansible.builtin.assert: *id002
 
-- name: Check Idempotence
+- name: Check idempotence
   register: result
   cisco.nxos.nxos_acl: *id008
 
 - ansible.builtin.assert: *id004
 
-- name: ace 40
+- name: Ace 40
   register: result
   cisco.nxos.nxos_acl: &id009
     name: TEST_ACL
@@ -177,13 +177,13 @@
 
 - ansible.builtin.assert: *id002
 
-- name: Check Idempotence
+- name: Check idempotence
   register: result
   cisco.nxos.nxos_acl: *id009
 
 - ansible.builtin.assert: *id004
 
-- name: change ace 40
+- name: Change ace 40
   register: result
   cisco.nxos.nxos_acl: &id010
     name: TEST_ACL
@@ -197,13 +197,13 @@
 
 - ansible.builtin.assert: *id002
 
-- name: Check Idempotence
+- name: Check idempotence
   register: result
   cisco.nxos.nxos_acl: *id010
 
 - ansible.builtin.assert: *id004
 
-- name: remove ace 30
+- name: Remove ace 30
   register: result
   cisco.nxos.nxos_acl: &id011
     name: TEST_ACL
@@ -212,19 +212,19 @@
 
 - ansible.builtin.assert: *id002
 
-- name: Check Idempotence
+- name: Check idempotence
   register: result
   cisco.nxos.nxos_acl: *id011
 
 - ansible.builtin.assert: *id004
 
-- name: Remove ACL
+- name: Remove acl
   register: result
   cisco.nxos.nxos_acl: *id012
 
 - ansible.builtin.assert: *id002
 
-- name: Check Idempotence
+- name: Check idempotence
   register: result
   cisco.nxos.nxos_acl: *id012
 

--- a/tests/integration/targets/nxos_acl_interface/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_acl_interface/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_acl_interface/tasks/main.yaml
+++ b/tests/integration/targets/nxos_acl_interface/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_acl_interface/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_acl_interface/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_acl_interface/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_acl_interface/tests/common/sanity.yaml
@@ -10,13 +10,13 @@
   ansible.builtin.debug:
     msg: "{{ intname }}"
 
-- name: "Setup: Put interface into a default state"
+- name: "Setup: put interface into a default state"
   ignore_errors: true
   cisco.nxos.nxos_config: &id007
     lines:
       - default interface {{ intname }}
 
-- name: "Setup: Put interface into no switch port mode"
+- name: "Setup: put interface into no switch port mode"
   ignore_errors: true
   cisco.nxos.nxos_config:
     commands:
@@ -25,14 +25,14 @@
       - interface {{ intname }}
     match: none
 
-- name: "Setup: Cleanup possibly existing acl"
+- name: "Setup: cleanup possibly existing acl"
   ignore_errors: true
   cisco.nxos.nxos_acl: &id008
     name: ANSIBLE_ACL
     seq: 10
     state: delete_acl
 
-- name: Configure Supporting ACL
+- name: Configure supporting acl
   cisco.nxos.nxos_acl:
     name: ANSIBLE_ACL
     seq: 10
@@ -54,7 +54,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence egress
+    - name: Check idempotence egress
       register: result
       cisco.nxos.nxos_acl_interface: *id001
 
@@ -72,7 +72,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence ingress
+    - name: Check idempotence ingress
       register: result
       cisco.nxos.nxos_acl_interface: *id003
 
@@ -88,7 +88,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence egress cleanup
+    - name: Check idempotence egress cleanup
       register: result
       cisco.nxos.nxos_acl_interface: *id005
 
@@ -104,7 +104,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence ingress cleanup
+    - name: Check idempotence ingress cleanup
       register: result
       cisco.nxos.nxos_acl_interface: *id006
 
@@ -114,7 +114,7 @@
       ignore_errors: true
       cisco.nxos.nxos_config: *id007
   always:
-    - name: Remove possible configured ACL
+    - name: Remove possible configured acl
       ignore_errors: true
       cisco.nxos.nxos_acl: *id008
 

--- a/tests/integration/targets/nxos_acl_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_acl_interfaces/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_acl_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/nxos_acl_interfaces/tasks/main.yaml
@@ -4,12 +4,12 @@
     lines: "no system default switchport"
   connection: ansible.netcommon.network_cli
 
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_acl_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_acl_interfaces/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_acl_interfaces/tests/common/deleted.yml
+++ b/tests/integration/targets/nxos_acl_interfaces/tests/common/deleted.yml
@@ -9,7 +9,7 @@
 - ansible.builtin.include_tasks: populate_config.yaml
 
 - block:
-    - name: Delete all ACLs configuration from given interface
+    - name: Delete all acls configuration from given interface
       register: result
       cisco.nxos.nxos_acl_interfaces: &id002
         config:
@@ -25,7 +25,7 @@
 
     - ansible.builtin.include_tasks: populate_config.yaml
 
-    - name: Delete all ACLs from all interfaces (from all interfaces)
+    - name: Delete all acls from all interfaces (from all interfaces)
       register: result
       cisco.nxos.nxos_acl_interfaces:
         config:

--- a/tests/integration/targets/nxos_acl_interfaces/tests/common/gathered.yml
+++ b/tests/integration/targets/nxos_acl_interfaces/tests/common/gathered.yml
@@ -22,7 +22,7 @@
           - result.changed == false
           - ansible_facts.network_resources.acl_interfaces == result.gathered
 
-    - name: Idempotence - Gathered
+    - name: Idempotence - gathered
       register: result
       cisco.nxos.nxos_acl_interfaces: *id001
 

--- a/tests/integration/targets/nxos_acl_interfaces/tests/common/merged.yml
+++ b/tests/integration/targets/nxos_acl_interfaces/tests/common/merged.yml
@@ -58,7 +58,7 @@
           - "'ipv6 traffic-filter ACL1v6 in' in result.commands"
           - "result.commands | length == 7 "
 
-    - name: Idempotence - Merged
+    - name: Idempotence - merged
       register: result
       cisco.nxos.nxos_acl_interfaces: *id001
 

--- a/tests/integration/targets/nxos_acl_interfaces/tests/common/parsed.yml
+++ b/tests/integration/targets/nxos_acl_interfaces/tests/common/parsed.yml
@@ -13,7 +13,8 @@
     - name: Parsed
       register: result
       cisco.nxos.nxos_acl_interfaces: &id001
-        running_config: "interface Ethernet1/2\nipv6 traffic-filter ACL1v6 in\ninterface Ethernet1/5\nipv6 traffic-filter ACL1v6 in\nip access-group ACL1v4 out\n\
+        running_config:
+          "interface Ethernet1/2\nipv6 traffic-filter ACL1v6 in\ninterface Ethernet1/5\nipv6 traffic-filter ACL1v6 in\nip access-group ACL1v4 out\n\
           ip port access-group PortACL in\n"
         state: parsed
 

--- a/tests/integration/targets/nxos_acl_interfaces/tests/common/parsed.yml
+++ b/tests/integration/targets/nxos_acl_interfaces/tests/common/parsed.yml
@@ -13,8 +13,7 @@
     - name: Parsed
       register: result
       cisco.nxos.nxos_acl_interfaces: &id001
-        running_config:
-          "interface Ethernet1/2\nipv6 traffic-filter ACL1v6 in\ninterface Ethernet1/5\nipv6 traffic-filter ACL1v6 in\nip access-group ACL1v4 out\n\
+        running_config: "interface Ethernet1/2\nipv6 traffic-filter ACL1v6 in\ninterface Ethernet1/5\nipv6 traffic-filter ACL1v6 in\nip access-group ACL1v4 out\n\
           ip port access-group PortACL in\n"
         state: parsed
 
@@ -23,7 +22,7 @@
           - result.changed == false
           - result.parsed == parsed
 
-    - name: Idempotence - Parsed
+    - name: Idempotence - parsed
       register: result
       cisco.nxos.nxos_acl_interfaces: *id001
 

--- a/tests/integration/targets/nxos_acl_interfaces/tests/common/rendered.yml
+++ b/tests/integration/targets/nxos_acl_interfaces/tests/common/rendered.yml
@@ -46,7 +46,7 @@
       - "'ip access-group ACL1v4 out' in result.rendered"
       - result.rendered | length == 7
 
-- name: Idempotence - Rendered
+- name: Idempotence - rendered
   register: result
   cisco.nxos.nxos_acl_interfaces: *id001
 

--- a/tests/integration/targets/nxos_acl_interfaces/tests/common/replaced.yml
+++ b/tests/integration/targets/nxos_acl_interfaces/tests/common/replaced.yml
@@ -51,7 +51,7 @@
         that:
           - ansible_facts.network_resources.acl_interfaces == result.after
 
-    - name: Idempotence - Replaced
+    - name: Idempotence - replaced
       register: result
       cisco.nxos.nxos_acl_interfaces: *id001
 

--- a/tests/integration/targets/nxos_acl_interfaces/tests/common/rtt.yml
+++ b/tests/integration/targets/nxos_acl_interfaces/tests/common/rtt.yml
@@ -9,7 +9,7 @@
 - ansible.builtin.include_tasks: populate_config.yaml
 
 - block:
-    - name: RTT- Apply provided configuration
+    - name: Rtt- apply provided configuration
       cisco.nxos.nxos_acl_interfaces:
         config:
           - name: Ethernet1/2

--- a/tests/integration/targets/nxos_acls/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_acls/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_acls/tasks/main.yaml
+++ b/tests/integration/targets/nxos_acls/tasks/main.yaml
@@ -6,12 +6,12 @@
       - "system default switchport shutdown"
   connection: ansible.netcommon.network_cli
 
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_acls/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_acls/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_acls/tests/common/deleted.yml
+++ b/tests/integration/targets/nxos_acls/tests/common/deleted.yml
@@ -5,7 +5,7 @@
 - ansible.builtin.include_tasks: populate_config.yaml
 
 - block:
-    - name: Deleted (All ACLs)
+    - name: Deleted (all acls)
       cisco.nxos.nxos_acls:
         config:
         state: deleted

--- a/tests/integration/targets/nxos_acls/tests/common/gathered.yml
+++ b/tests/integration/targets/nxos_acls/tests/common/gathered.yml
@@ -22,7 +22,7 @@
           - result.changed == false
           - ansible_facts.network_resources.acls == result.gathered
 
-    - name: Idempotence - Gathered
+    - name: Idempotence - gathered
       register: result
       cisco.nxos.nxos_acls: *id001
 

--- a/tests/integration/targets/nxos_acls/tests/common/merged.yml
+++ b/tests/integration/targets/nxos_acls/tests/common/merged.yml
@@ -72,7 +72,7 @@
         that:
           - ansible_facts.network_resources.acls == result.after
 
-    - name: Idempotence - Merged
+    - name: Idempotence - merged
       register: result
       cisco.nxos.nxos_acls: *id001
 
@@ -80,7 +80,7 @@
         that:
           - result.changed == false
 
-    - name: Update one parameter of an existing ACE with state merged (should fail)
+    - name: Update one parameter of an existing ace with state merged (should fail)
       register: result
       cisco.nxos.nxos_acls:
         config:

--- a/tests/integration/targets/nxos_acls/tests/common/parsed.yml
+++ b/tests/integration/targets/nxos_acls/tests/common/parsed.yml
@@ -15,7 +15,8 @@
     - name: Parsed
       register: result
       cisco.nxos.nxos_acls: &id001
-        running_config: "ip access-list ACL1v4\n10 permit ip any any\n20 deny udp any any\nip access-list ACL2v4\n10 permit ahp 192.0.2.0 0.0.0.255 any\nipv6 access-list\
+        running_config:
+          "ip access-list ACL1v4\n10 permit ip any any\n20 deny udp any any\nip access-list ACL2v4\n10 permit ahp 192.0.2.0 0.0.0.255 any\nipv6 access-list\
           \ ACL1v6\n10 permit sctp any any\n20 remark IPv6 ACL\nipv6 access-list ACL2v6\n10 deny ipv6 any 2001:db8:3000::36/128\n20 permit tcp 2001:db8:2000:2::2/128\
           \ 2001:db8:2000:ab::2/128\n"
         state: parsed

--- a/tests/integration/targets/nxos_acls/tests/common/parsed.yml
+++ b/tests/integration/targets/nxos_acls/tests/common/parsed.yml
@@ -15,8 +15,7 @@
     - name: Parsed
       register: result
       cisco.nxos.nxos_acls: &id001
-        running_config:
-          "ip access-list ACL1v4\n10 permit ip any any\n20 deny udp any any\nip access-list ACL2v4\n10 permit ahp 192.0.2.0 0.0.0.255 any\nipv6 access-list\
+        running_config: "ip access-list ACL1v4\n10 permit ip any any\n20 deny udp any any\nip access-list ACL2v4\n10 permit ahp 192.0.2.0 0.0.0.255 any\nipv6 access-list\
           \ ACL1v6\n10 permit sctp any any\n20 remark IPv6 ACL\nipv6 access-list ACL2v6\n10 deny ipv6 any 2001:db8:3000::36/128\n20 permit tcp 2001:db8:2000:2::2/128\
           \ 2001:db8:2000:ab::2/128\n"
         state: parsed
@@ -26,7 +25,7 @@
           - result.changed == false
           - ansible_facts.network_resources.acls == result.parsed
 
-    - name: Idempotence - Parsed
+    - name: Idempotence - parsed
       register: result
       cisco.nxos.nxos_acls: *id001
 

--- a/tests/integration/targets/nxos_acls/tests/common/rendered.yml
+++ b/tests/integration/targets/nxos_acls/tests/common/rendered.yml
@@ -60,7 +60,7 @@
       - "'10 permit sctp any 2001:db8:12::/32' in result.rendered"
       - result.rendered | length == 5
 
-- name: Idempotence - Rendered
+- name: Idempotence - rendered
   register: result
   cisco.nxos.nxos_acls: *id001
 

--- a/tests/integration/targets/nxos_acls/tests/common/replaced.yml
+++ b/tests/integration/targets/nxos_acls/tests/common/replaced.yml
@@ -54,7 +54,7 @@
         that:
           - ansible_facts.network_resources.acls == result.after
 
-    - name: Idempotence - Replaced
+    - name: Idempotence - replaced
       register: result
       cisco.nxos.nxos_acls: *id001
 

--- a/tests/integration/targets/nxos_acls/tests/common/rtt.yml
+++ b/tests/integration/targets/nxos_acls/tests/common/rtt.yml
@@ -3,7 +3,7 @@
     msg: Start nxos_acls round trip integration tests connection = {{ansible_connection}}
 
 - block:
-    - name: RTT - Apply provided configuration
+    - name: Rtt - apply provided configuration
       cisco.nxos.nxos_acls:
         config:
           - afi: ipv4

--- a/tests/integration/targets/nxos_banner/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_banner/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_banner/tasks/main.yaml
+++ b/tests/integration/targets/nxos_banner/tasks/main.yaml
@@ -4,12 +4,12 @@
     banner_exec_image_ok: false
     banner_motd_image_ok: false
 
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_banner/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_banner/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_banner/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_banner/tests/common/sanity.yaml
@@ -16,7 +16,7 @@
     - ansible.builtin.debug:
         msg: START nxos_banner exec tests
 
-    - name: setup exec
+    - name: Setup exec
       cisco.nxos.nxos_banner: &id002
         banner: exec
         state: absent
@@ -42,12 +42,12 @@
           - result.changed == false
           - result.commands | length == 0
 
-    - name: teardown exec
+    - name: Teardown exec
       cisco.nxos.nxos_banner: *id002
   when: banner_exec_image_ok == True
 
 - block:
-    - name: setup motd
+    - name: Setup motd
       cisco.nxos.nxos_banner: &id004
         banner: motd
         state: absent
@@ -72,7 +72,7 @@
         that:
           - result.changed == false
 
-    - name: teardown motd
+    - name: Teardown motd
       cisco.nxos.nxos_banner: *id004
   when: banner_motd_image_ok == True
 

--- a/tests/integration/targets/nxos_bfd_global/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_bfd_global/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_bfd_global/tasks/main.yaml
+++ b/tests/integration/targets/nxos_bfd_global/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_bfd_global/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bfd_global/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_bfd_global/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_bfd_global/tests/common/sanity.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }} nxos_bfd_global sanity test
 
-- name: set facts common
+- name: Set facts common
   ansible.builtin.set_fact:
     echo: deleted
     nd_echo: loopback1
@@ -17,7 +17,7 @@
     slow: 2000
     nd_slow: 2001
 
-- name: set facts (exclude 5K/6K)
+- name: Set facts (exclude 5k/6k)
   ansible.builtin.set_fact:
     echo_rx: 50
     nd_echo_rx: 51
@@ -32,7 +32,7 @@
     nd_ipv4_slow: 2044
   when: platform is not search('N5K|N6K')
 
-- name: set facts (exclude 35/5K/6K)
+- name: Set facts (exclude 35/5k/6k)
   ansible.builtin.set_fact:
     ipv6_echo_rx: 50
     nd_ipv6_echo_rx: 56
@@ -42,13 +42,13 @@
     nd_ipv6_slow: 2046
   when: platform is not search('N35|N5K|N6K')
 
-- name: set facts (exclude 5K/6K/7K)
+- name: Set facts (exclude 5k/6k/7k)
   ansible.builtin.set_fact:
     startup: 5
     nd_startup: 6
   when: platform is not search('N35|N5K|N6K|N7K')
 
-- name: set facts 3k defaults (resets some values above)
+- name: Set facts 3k defaults (resets some values above)
   ansible.builtin.set_fact:
     echo_rx: 250
     interval: &id003
@@ -63,7 +63,7 @@
     ipv6_slow: 2000
   when: platform is search('N3K')
 
-- name: set facts fabricpath
+- name: Set facts fabricpath
   ansible.builtin.set_fact:
     fab_interval: *id001
     nd_fab_interval:
@@ -87,7 +87,7 @@
     lines: interface loopback1
     match: none
 
-- name: feature bfd init
+- name: Feature bfd init
   delay: 3
   retries: 1
   register: result
@@ -97,7 +97,7 @@
     slow_timer: "{{ nd_slow }}"
 
 - block:
-    - name: BFD non defaults
+    - name: Bfd non defaults
       register: result
       cisco.nxos.nxos_bfd_global: &id004
         echo_interface: "{{ nd_echo }}"
@@ -119,7 +119,7 @@
         that:
           - result.changed == true
 
-    - name: bfd_non_def idempotence
+    - name: Bfd_non_def idempotence
       register: result
       cisco.nxos.nxos_bfd_global: *id004
 
@@ -127,7 +127,7 @@
         that:
           - result.changed == false
 
-    - name: BFD defaults
+    - name: Bfd defaults
       register: result
       cisco.nxos.nxos_bfd_global: &id006
         echo_interface: "{{ echo }}"
@@ -147,7 +147,7 @@
 
     - ansible.builtin.assert: *id005
 
-    - name: bfd_def idempotence
+    - name: Bfd_def idempotence
       register: result
       cisco.nxos.nxos_bfd_global: *id006
 

--- a/tests/integration/targets/nxos_bfd_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_bfd_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_bfd_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tasks/nxapi.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_bfd_interfaces/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tests/common/deleted.yaml
@@ -12,21 +12,21 @@
     bfd_disable: disable
   when: platform is not search('N5K|N6K')
 
-- name: setup1
+- name: Setup1
   cisco.nxos.nxos_config: &id002
     lines:
       - "no feature bfd"
       - "default interface {{ test_int1 }}"
 
 - block:
-    - name: setup2
+    - name: Setup2
       cisco.nxos.nxos_config:
         lines:
           - "feature bfd"
           - "interface {{ test_int1 }}"
           - "  no switchport"
 
-    - name: setup initial bfd state
+    - name: Setup initial bfd state
       cisco.nxos.nxos_bfd_interfaces:
         config:
           - name: "{{ test_int1 }}"
@@ -41,7 +41,7 @@
           - "!min"
         gather_network_resources: bfd_interfaces
 
-    - name: deleted
+    - name: Deleted
       register: result
       cisco.nxos.nxos_bfd_interfaces: &id001
         config:
@@ -69,5 +69,5 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_config: *id002

--- a/tests/integration/targets/nxos_bfd_interfaces/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tests/common/merged.yaml
@@ -12,14 +12,14 @@
     bfd_disable: disable
   when: platform is not search('N5K|N6K')
 
-- name: setup1
+- name: Setup1
   cisco.nxos.nxos_config: &id002
     lines:
       - "no feature bfd"
       - "default interface {{ test_int1 }}"
 
 - block:
-    - name: setup2
+    - name: Setup2
       cisco.nxos.nxos_config:
         lines:
           - "feature bfd"
@@ -58,7 +58,7 @@
         that:
           - ansible_facts.network_resources.bfd_interfaces|symmetric_difference(result.after)|length == 0
 
-    - name: Idempotence - Merged
+    - name: Idempotence - merged
       register: result
       cisco.nxos.nxos_bfd_interfaces: *id001
 
@@ -67,5 +67,5 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_config: *id002

--- a/tests/integration/targets/nxos_bfd_interfaces/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tests/common/overridden.yaml
@@ -16,7 +16,7 @@
     bfd_disable: disable
   when: platform is not search('N5K|N6K')
 
-- name: setup1
+- name: Setup1
   cisco.nxos.nxos_config: &id002
     lines:
       - "no feature bfd"
@@ -24,12 +24,12 @@
       - "default interface {{ test_int2 }}"
 
 - block:
-    - name: setup2
+    - name: Setup2
       cisco.nxos.nxos_config:
         lines:
           - "feature bfd"
 
-    - name: setup3
+    - name: Setup3
       cisco.nxos.nxos_config:
         lines:
           - "no switchport"
@@ -38,7 +38,7 @@
         - "{{ test_int1 }}"
         - "{{ test_int2 }}"
 
-    - name: setup initial bfd state
+    - name: Setup initial bfd state
       cisco.nxos.nxos_bfd_interfaces:
         config:
           - name: "{{ test_int1 }}"
@@ -66,7 +66,7 @@
           - result.commands[3] == 'no bfd echo'
         msg: "Assert failed. 'result.commands': {{ result.commands }}"
 
-    - name: Idempotence - Overridden
+    - name: Idempotence - overridden
       register: result
       cisco.nxos.nxos_bfd_interfaces: *id001
 
@@ -75,5 +75,5 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_config: *id002

--- a/tests/integration/targets/nxos_bfd_interfaces/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tests/common/replaced.yaml
@@ -12,21 +12,21 @@
     bfd_disable: disable
   when: platform is not search('N5K|N6K')
 
-- name: setup1
+- name: Setup1
   cisco.nxos.nxos_config: &id002
     lines:
       - "no feature bfd"
       - "default interface {{ test_int1 }}"
 
 - block:
-    - name: setup2
+    - name: Setup2
       cisco.nxos.nxos_config:
         lines:
           - "feature bfd"
           - "interface {{ test_int1 }}"
           - "  no switchport"
 
-    - name: setup initial bfd state
+    - name: Setup initial bfd state
       cisco.nxos.nxos_bfd_interfaces:
         config:
           - name: "{{ test_int1 }}"
@@ -55,7 +55,7 @@
         msg: "Assert failed. 'result.commands': {{ result.commands }}"
       when: bfd_enable is defined
 
-    - name: Idempotence - Replaced
+    - name: Idempotence - replaced
       register: result
       cisco.nxos.nxos_bfd_interfaces: *id001
 
@@ -64,5 +64,5 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_config: *id002

--- a/tests/integration/targets/nxos_bgp/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_bgp/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_bgp/tasks/main.yaml
+++ b/tests/integration/targets/nxos_bgp/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_bgp/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bgp/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_bgp/tests/common/dis_policy.yaml
+++ b/tests/integration/targets/nxos_bgp/tests/common/dis_policy.yaml
@@ -15,20 +15,20 @@
     bgp_disable_policy: true
   when: imagetag is not search("A8|D1")
 
-- name: Disable feature BGP
+- name: Disable feature bgp
   ignore_errors: true
   cisco.nxos.nxos_feature:
     feature: bgp
     state: disabled
 
-- name: Enable feature BGP
+- name: Enable feature bgp
   ignore_errors: true
   cisco.nxos.nxos_feature:
     feature: bgp
     state: enabled
 
 - block:
-    - name: set disable policy
+    - name: Set disable policy
       register: result
       when: bgp_disable_policy
       cisco.nxos.nxos_bgp: &id001
@@ -42,7 +42,7 @@
           - result.changed == true
       when: bgp_disable_policy
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       when: bgp_disable_policy
       cisco.nxos.nxos_bgp: *id001
@@ -52,7 +52,7 @@
           - result.changed == false
       when: bgp_disable_policy
 
-    - name: reset disable policy
+    - name: Reset disable policy
       register: result
       when: bgp_disable_policy
       cisco.nxos.nxos_bgp: &id003
@@ -64,7 +64,7 @@
     - ansible.builtin.assert: *id002
       when: bgp_disable_policy
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       when: bgp_disable_policy
       cisco.nxos.nxos_bgp: *id003

--- a/tests/integration/targets/nxos_bgp/tests/common/hels.yaml
+++ b/tests/integration/targets/nxos_bgp/tests/common/hels.yaml
@@ -15,14 +15,14 @@
     test_helsinki: true
   when: imagetag is not search("D1")
 
-- name: Disable feature BGP
+- name: Disable feature bgp
   ignore_errors: true
   when: test_helsinki
   cisco.nxos.nxos_feature:
     feature: bgp
     state: disabled
 
-- name: Enable feature BGP
+- name: Enable feature bgp
   ignore_errors: true
   when: test_helsinki
   cisco.nxos.nxos_feature:
@@ -30,7 +30,7 @@
     state: enabled
 
 - block:
-    - name: set helsinki
+    - name: Set helsinki
       with_items: "{{ vrfs }}"
       register: result
       when: test_helsinki
@@ -49,7 +49,7 @@
           - result.changed == true
       when: test_helsinki
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       when: test_helsinki
@@ -60,7 +60,7 @@
           - result.changed == false
       when: test_helsinki
 
-    - name: reset helsinki
+    - name: Reset helsinki
       with_items: "{{ vrfs }}"
       register: result
       when: test_helsinki
@@ -78,7 +78,7 @@
     - ansible.builtin.assert: *id002
       when: test_helsinki
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       when: test_helsinki

--- a/tests/integration/targets/nxos_bgp/tests/common/isolate.yaml
+++ b/tests/integration/targets/nxos_bgp/tests/common/isolate.yaml
@@ -15,20 +15,20 @@
     bgp_isolate: true
   when: imagetag is not search("A8")
 
-- name: Disable feature BGP
+- name: Disable feature bgp
   ignore_errors: true
   cisco.nxos.nxos_feature:
     feature: bgp
     state: disabled
 
-- name: Enable feature BGP
+- name: Enable feature bgp
   ignore_errors: true
   cisco.nxos.nxos_feature:
     feature: bgp
     state: enabled
 
 - block:
-    - name: set isolate
+    - name: Set isolate
       register: result
       when: bgp_isolate
       cisco.nxos.nxos_bgp: &id001
@@ -40,7 +40,7 @@
           - result.changed == true
       when: bgp_isolate
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       when: bgp_isolate
       cisco.nxos.nxos_bgp: *id001
@@ -50,7 +50,7 @@
           - result.changed == false
       when: bgp_isolate
 
-    - name: reset isolate
+    - name: Reset isolate
       register: result
       when: bgp_isolate
       cisco.nxos.nxos_bgp: &id003
@@ -60,7 +60,7 @@
     - ansible.builtin.assert: *id002
       when: bgp_isolate
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       when: bgp_isolate
       cisco.nxos.nxos_bgp: *id003

--- a/tests/integration/targets/nxos_bgp/tests/common/param.yaml
+++ b/tests/integration/targets/nxos_bgp/tests/common/param.yaml
@@ -2,20 +2,20 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }} nxos_bgp parameter test
 
-- name: Disable feature BGP
+- name: Disable feature bgp
   ignore_errors: true
   cisco.nxos.nxos_feature:
     feature: bgp
     state: disabled
 
-- name: Enable feature BGP
+- name: Enable feature bgp
   ignore_errors: true
   cisco.nxos.nxos_feature:
     feature: bgp
     state: enabled
 
 - block:
-    - name: set multi vrf params
+    - name: Set multi vrf params
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp: &id001
@@ -37,7 +37,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp: *id001
@@ -46,7 +46,7 @@
         that:
           - result.changed == false
 
-    - name: reset multi vrf params
+    - name: Reset multi vrf params
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp: &id003
@@ -66,14 +66,14 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp: *id003
 
     - ansible.builtin.assert: *id004
 
-    - name: set clusterid
+    - name: Set clusterid
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp: &id005
@@ -83,14 +83,14 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp: *id005
 
     - ansible.builtin.assert: *id004
 
-    - name: reset cluster_id
+    - name: Reset cluster_id
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp: &id006
@@ -100,14 +100,14 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp: *id006
 
     - ansible.builtin.assert: *id004
 
-    - name: set confederation
+    - name: Set confederation
       register: result
       cisco.nxos.nxos_bgp: &id007
         asn: 65535
@@ -119,13 +119,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp: *id007
 
     - ansible.builtin.assert: *id004
 
-    - name: reset confederation
+    - name: Reset confederation
       register: result
       cisco.nxos.nxos_bgp: &id008
         asn: 65535
@@ -134,13 +134,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp: *id008
 
     - ansible.builtin.assert: *id004
 
-    - name: set confederation_local_as
+    - name: Set confederation_local_as
       register: result
       cisco.nxos.nxos_bgp: &id009
         asn: 65535
@@ -154,13 +154,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp: *id009
 
     - ansible.builtin.assert: *id004
 
-    - name: reset confederation local_as
+    - name: Reset confederation local_as
       register: result
       cisco.nxos.nxos_bgp: &id010
         asn: 65535
@@ -171,13 +171,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp: *id010
 
     - ansible.builtin.assert: *id004
 
-    - name: set local_as
+    - name: Set local_as
       register: result
       cisco.nxos.nxos_bgp: &id011
         asn: 65535
@@ -187,13 +187,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp: *id011
 
     - ansible.builtin.assert: *id004
 
-    - name: reset local_as
+    - name: Reset local_as
       register: result
       cisco.nxos.nxos_bgp: &id012
         asn: 65535
@@ -203,13 +203,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp: *id012
 
     - ansible.builtin.assert: *id004
 
-    - name: set default vrf params
+    - name: Set default vrf params
       register: result
       cisco.nxos.nxos_bgp: &id013
         asn: 65535
@@ -224,13 +224,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp: *id013
 
     - ansible.builtin.assert: *id004
 
-    - name: reset default vrf params
+    - name: Reset default vrf params
       register: result
       cisco.nxos.nxos_bgp: &id014
         asn: 65535
@@ -242,7 +242,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp: *id014
 

--- a/tests/integration/targets/nxos_bgp/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_bgp/tests/common/sanity.yaml
@@ -17,7 +17,7 @@
     isolate: false
   when: platform is not match("N35")
 
-- name: Enable feature BGP
+- name: Enable feature bgp
   ignore_errors: true
   cisco.nxos.nxos_feature:
     feature: bgp
@@ -31,7 +31,7 @@
     state: absent
 
 - block:
-    - name: Configure BGP defaults
+    - name: Configure bgp defaults
       register: result
       cisco.nxos.nxos_bgp: &id001
         asn: 65535
@@ -42,7 +42,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp: *id001
 
@@ -50,19 +50,19 @@
         that:
           - result.changed == false
 
-    - name: Remove BGP
+    - name: Remove bgp
       register: result
       cisco.nxos.nxos_bgp: *id002
 
     - ansible.builtin.assert: *id003
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp: *id002
 
     - ansible.builtin.assert: *id004
 
-    - name: Configure BGP non defaults
+    - name: Configure bgp non defaults
       register: result
       cisco.nxos.nxos_bgp: &id005
         asn: 65535
@@ -101,19 +101,19 @@
 
     - ansible.builtin.assert: *id003
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp: *id005
 
     - ansible.builtin.assert: *id004
 
-    - name: Remove BGP
+    - name: Remove bgp
       register: result
       cisco.nxos.nxos_bgp: *id002
 
     - ansible.builtin.assert: *id003
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp: *id002
 
@@ -124,7 +124,7 @@
         feature: bgp
         state: disabled
   rescue:
-    - name: Cleanup BGP
+    - name: Cleanup bgp
       ignore_errors: true
       cisco.nxos.nxos_bgp: *id002
 

--- a/tests/integration/targets/nxos_bgp/tests/common/supp_fib.yaml
+++ b/tests/integration/targets/nxos_bgp/tests/common/supp_fib.yaml
@@ -20,20 +20,20 @@
     bgp_suppress_fib_supported: true
   when: imagetag is not search("A8|D1|I2|I4")
 
-- name: Disable feature BGP
+- name: Disable feature bgp
   ignore_errors: true
   cisco.nxos.nxos_feature:
     feature: bgp
     state: disabled
 
-- name: Enable feature BGP
+- name: Enable feature bgp
   ignore_errors: true
   cisco.nxos.nxos_feature:
     feature: bgp
     state: enabled
 
 - block:
-    - name: set bestpath limit
+    - name: Set bestpath limit
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp: &id001
@@ -45,7 +45,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp: *id001
@@ -54,7 +54,7 @@
         that:
           - result.changed == false
 
-    - name: reset bestpath limit
+    - name: Reset bestpath limit
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp: &id003
@@ -64,7 +64,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       when: bgp_best_path_limit
@@ -73,7 +73,7 @@
     - ansible.builtin.assert: *id004
       when: bgp_best_path_limit
 
-    - name: set suppress fib
+    - name: Set suppress fib
       register: result
       cisco.nxos.nxos_bgp: &id005
         asn: 65535
@@ -82,7 +82,7 @@
     - ansible.builtin.assert: *id002
       when: bgp_suppress_fib_supported
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       when: bgp_suppress_fib_supported
       cisco.nxos.nxos_bgp: *id005
@@ -90,7 +90,7 @@
     - ansible.builtin.assert: *id004
       when: bgp_suppress_fib_supported
 
-    - name: reset suppress fib
+    - name: Reset suppress fib
       register: result
       cisco.nxos.nxos_bgp: &id006
         asn: 65535
@@ -99,7 +99,7 @@
     - ansible.builtin.assert: *id002
       when: bgp_suppress_fib_supported
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       when: bgp_suppress_fib_supported
       cisco.nxos.nxos_bgp: *id006

--- a/tests/integration/targets/nxos_bgp_address_family/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_bgp_address_family/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_bgp_address_family/tasks/main.yaml
+++ b/tests/integration/targets/nxos_bgp_address_family/tasks/main.yaml
@@ -1,23 +1,23 @@
 ---
-- name: Enable BGP feature
+- name: Enable bgp feature
   cisco.nxos.nxos_feature:
     feature: bgp
   vars:
     ansible_connection: ansible.netcommon.network_cli
 
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
 
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi
 
   always:
-    - name: Disable BGP feature
+    - name: Disable bgp feature
       cisco.nxos.nxos_feature:
         feature: bgp
         state: disabled

--- a/tests/integration/targets/nxos_bgp_address_family/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bgp_address_family/tasks/nxapi.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_bgp_address_family/tests/common/_remove_config.yaml
+++ b/tests/integration/targets/nxos_bgp_address_family/tests/common/_remove_config.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Remove pre-existing BGP configurations
+- name: Remove pre-existing bgp configurations
   cisco.nxos.nxos_config:
     lines:
       - no router bgp 65536

--- a/tests/integration/targets/nxos_bgp_address_family/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_bgp_address_family/tests/common/deleted.yaml
@@ -6,7 +6,7 @@
 
 - ansible.builtin.include_tasks: _populate_config.yaml
 
-- name: Setup more AFs
+- name: Setup more afs
   cisco.nxos.nxos_config:
     lines:
       - "router bgp 65536"
@@ -18,7 +18,7 @@
     ansible_connection: ansible.netcommon.network_cli
 
 - block:
-    - name: Delete BGP configs handled by this module
+    - name: Delete bgp configs handled by this module
       cisco.nxos.nxos_bgp_address_family:
         config:
           as_number: 65536
@@ -53,7 +53,7 @@
 
     - ansible.builtin.include_tasks: _populate_config.yaml
 
-    - name: Delete all BGP configs handled by this module
+    - name: Delete all bgp configs handled by this module
       cisco.nxos.nxos_bgp_address_family: &id001
         state: deleted
       register: result
@@ -73,7 +73,7 @@
         that:
           - deleted_all['after'] == result['after']
 
-    - name: Delete all BGP configs handled by this module (IDEMPOTENT)
+    - name: Delete all bgp configs handled by this module (idempotent)
       cisco.nxos.nxos_bgp_address_family: *id001
       register: result
 

--- a/tests/integration/targets/nxos_bgp_address_family/tests/common/gathered.yaml
+++ b/tests/integration/targets/nxos_bgp_address_family/tests/common/gathered.yaml
@@ -7,7 +7,7 @@
 - ansible.builtin.include_tasks: _populate_config.yaml
 
 - block:
-    - name: Gather BGP facts using gathered
+    - name: Gather bgp facts using gathered
       register: result
       cisco.nxos.nxos_bgp_address_family:
         state: gathered

--- a/tests/integration/targets/nxos_bgp_address_family/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_bgp_address_family/tests/common/merged.yaml
@@ -57,7 +57,7 @@
           - "{{ merged['after']['address_family'] | symmetric_difference(result['after']['address_family']) |length == 0 }}"
           - merged['after']['as_number'] == result['after']['as_number']
 
-    - name: Merge the provided configuration with the existing running configuration (IDEMPOTENT)
+    - name: Merge the provided configuration with the existing running configuration (idempotent)
       cisco.nxos.nxos_bgp_address_family: *id001
       register: result
 

--- a/tests/integration/targets/nxos_bgp_address_family/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_bgp_address_family/tests/common/overridden.yaml
@@ -7,7 +7,7 @@
 - ansible.builtin.include_tasks: _populate_config.yaml
 
 - block:
-    - name: Override all BGP AF configuration with provided configuration
+    - name: Override all bgp af configuration with provided configuration
       cisco.nxos.nxos_bgp_address_family: &overridden
         config:
           as_number: 65536
@@ -43,7 +43,7 @@
           - "{{ overridden['after']['address_family'] | symmetric_difference(result['after']['address_family']) |length == 0 }}"
           - overridden['after']['as_number'] == result['after']['as_number']
 
-    - name: Replace device configurations of listed OSPF processes with provided configurarions (IDEMPOTENT)
+    - name: Replace device configurations of listed ospf processes with provided configurarions (idempotent)
       register: result
       cisco.nxos.nxos_bgp_address_family: *overridden
 

--- a/tests/integration/targets/nxos_bgp_address_family/tests/common/parsed.yaml
+++ b/tests/integration/targets/nxos_bgp_address_family/tests/common/parsed.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START nxos_bgp_address_family parsed integration tests on connection={{ ansible_connection }}
 
-- name: Parse externally provided BGP config
+- name: Parse externally provided bgp config
   register: result
   cisco.nxos.nxos_bgp_address_family:
     running_config: "{{ lookup('file', './fixtures/parsed.cfg') }}"

--- a/tests/integration/targets/nxos_bgp_address_family/tests/common/rendered.yaml
+++ b/tests/integration/targets/nxos_bgp_address_family/tests/common/rendered.yaml
@@ -45,7 +45,7 @@
     that:
       - "{{ merged['commands'] | symmetric_difference(result['rendered']) |length == 0 }}"
 
-- name: Gather BGP facts
+- name: Gather bgp facts
   cisco.nxos.nxos_bgp_address_family:
     state: gathered
   register: result

--- a/tests/integration/targets/nxos_bgp_address_family/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_bgp_address_family/tests/common/replaced.yaml
@@ -48,7 +48,7 @@
           - "{{ replaced['after']['address_family'] | symmetric_difference(result['after']['address_family']) |length == 0 }}"
           - replaced['after']['as_number'] == result['after']['as_number']
 
-    - name: Replace device configurations of listed OSPF processes with provided configurarions (IDEMPOTENT)
+    - name: Replace device configurations of listed ospf processes with provided configurarions (idempotent)
       register: result
       cisco.nxos.nxos_bgp_address_family: *replaced
 

--- a/tests/integration/targets/nxos_bgp_af/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_bgp_af/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_bgp_af/tasks/main.yaml
+++ b/tests/integration/targets/nxos_bgp_af/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_bgp_af/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bgp_af/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_bgp_af/tests/common/multisite.yaml
+++ b/tests/integration/targets/nxos_bgp_af/tests/common/multisite.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }} nxos_bgp_af multisite sanity test
 
-- name: Enable feature BGP - multisite
+- name: Enable feature bgp - multisite
   ignore_errors: true
   cisco.nxos.nxos_feature:
     feature: bgp
@@ -35,7 +35,7 @@
       - evpn multisite border-gateway 10
 
 - block:
-    - name: Configure BGP_AF Route Target Name
+    - name: Configure bgp_af route target name
       register: result
       cisco.nxos.nxos_bgp_af: &id001
         asn: 65535
@@ -48,7 +48,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp_af: *id001
 
@@ -56,7 +56,7 @@
         that:
           - result.changed == false
 
-    - name: Configure BGP_AF  Route Target Default
+    - name: Configure bgp_af  route target default
       register: result
       cisco.nxos.nxos_bgp_af: &id003
         asn: 65535
@@ -67,13 +67,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp_af: *id003
 
     - ansible.builtin.assert: *id004
 
-    - name: Configure BGP_AF 1 Route Target All
+    - name: Configure bgp_af 1 route target all
       register: result
       cisco.nxos.nxos_bgp_af: &id005
         asn: 65535
@@ -84,13 +84,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp_af: *id005
 
     - ansible.builtin.assert: *id004
 
-    - name: Remove BGP - Route Target
+    - name: Remove bgp - route target
       register: result
       cisco.nxos.nxos_bgp_af:
         asn: 65535

--- a/tests/integration/targets/nxos_bgp_af/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_bgp_af/tests/common/sanity.yaml
@@ -7,7 +7,7 @@
     advertise_l2vpn_evpn: true
   when: platform is search('N9K')
 
-- name: Enable feature BGP
+- name: Enable feature bgp
   ignore_errors: true
   cisco.nxos.nxos_feature:
     feature: bgp
@@ -32,7 +32,7 @@
         lines:
           - nv overlay evpn
 
-    - name: Configure BGP_AF 1
+    - name: Configure bgp_af 1
       register: result
       cisco.nxos.nxos_bgp_af: &id001
         asn: 65535
@@ -46,7 +46,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp_af: *id001
 
@@ -54,7 +54,7 @@
         that:
           - result.changed == false
 
-    - name: Remove BGP
+    - name: Remove bgp
       register: result
       cisco.nxos.nxos_bgp_af:
         asn: 65535
@@ -65,7 +65,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Configure BGP_AF 2
+    - name: Configure bgp_af 2
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_af: &id003
@@ -84,14 +84,14 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_af: *id003
 
     - ansible.builtin.assert: *id004
 
-    - name: Configure BGP_AF def2
+    - name: Configure bgp_af def2
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_af: &id005
@@ -110,14 +110,14 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_af: *id005
 
     - ansible.builtin.assert: *id004
 
-    - name: Remove BGP
+    - name: Remove bgp
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_af: &id008
@@ -129,7 +129,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Configure BGP_AF 3
+    - name: Configure bgp_af 3
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_af: &id006
@@ -152,14 +152,14 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_af: *id006
 
     - ansible.builtin.assert: *id004
 
-    - name: Configure BGP_AF def3
+    - name: Configure bgp_af def3
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_af: &id007
@@ -182,21 +182,21 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_af: *id007
 
     - ansible.builtin.assert: *id004
 
-    - name: Remove BGP
+    - name: Remove bgp
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_af: *id008
 
     - ansible.builtin.assert: *id002
 
-    - name: Configure BGP_AF 4
+    - name: Configure bgp_af 4
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_af: &id009
@@ -210,38 +210,38 @@
         dampening_reuse_time: 2
         dampening_suppress_time: 3
         inject_map:
-          - - lax_inject_map
-            - lax_exist_map
-          - - nyc_inject_map
-            - nyc_exist_map
-            - copy-attributes
-          - - fsd_inject_map
-            - fsd_exist_map
+          -   - lax_inject_map
+              - lax_exist_map
+          -   - nyc_inject_map
+              - nyc_exist_map
+              - copy-attributes
+          -   - fsd_inject_map
+              - fsd_exist_map
         networks:
-          - - 10.0.0.0/16
-            - routemap_LA
-          - - 192.168.1.1/32
-            - Chicago
-          - - 192.168.2.0/24
-          - - 192.168.3.0/24
-            - routemap_NYC
+          -   - 10.0.0.0/16
+              - routemap_LA
+          -   - 192.168.1.1/32
+              - Chicago
+          -   - 192.168.2.0/24
+          -   - 192.168.3.0/24
+              - routemap_NYC
         redistribute:
-          - - direct
-            - rm_direct
-          - - lisp
-            - rm_lisp
+          -   - direct
+              - rm_direct
+          -   - lisp
+              - rm_lisp
         state: present
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_af: *id009
 
     - ansible.builtin.assert: *id004
 
-    - name: Configure BGP_AF 5
+    - name: Configure bgp_af 5
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_af: &id010
@@ -255,25 +255,25 @@
         dampening_reuse_time: 20
         dampening_suppress_time: 30
         inject_map:
-          - - fsd_inject_map
-            - fsd_exist_map
+          -   - fsd_inject_map
+              - fsd_exist_map
         networks:
-          - - 192.168.2.0/24
+          -   - 192.168.2.0/24
         redistribute:
-          - - lisp
-            - rm_lisp
+          -   - lisp
+              - rm_lisp
         state: present
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_af: *id010
 
     - ansible.builtin.assert: *id004
 
-    - name: Configure BGP_AF def5
+    - name: Configure bgp_af def5
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_af: &id011
@@ -293,28 +293,28 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_af: *id011
 
     - ansible.builtin.assert: *id004
 
-    - name: Remove BGP
+    - name: Remove bgp
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_af: *id008
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_af: *id008
 
     - ansible.builtin.assert: *id004
   rescue:
-    - name: Cleanup BGP
+    - name: Cleanup bgp
       ignore_errors: true
       cisco.nxos.nxos_bgp: *id012
   always:

--- a/tests/integration/targets/nxos_bgp_af/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_bgp_af/tests/common/sanity.yaml
@@ -210,26 +210,26 @@
         dampening_reuse_time: 2
         dampening_suppress_time: 3
         inject_map:
-          -   - lax_inject_map
-              - lax_exist_map
-          -   - nyc_inject_map
-              - nyc_exist_map
-              - copy-attributes
-          -   - fsd_inject_map
-              - fsd_exist_map
+          - - lax_inject_map
+            - lax_exist_map
+          - - nyc_inject_map
+            - nyc_exist_map
+            - copy-attributes
+          - - fsd_inject_map
+            - fsd_exist_map
         networks:
-          -   - 10.0.0.0/16
-              - routemap_LA
-          -   - 192.168.1.1/32
-              - Chicago
-          -   - 192.168.2.0/24
-          -   - 192.168.3.0/24
-              - routemap_NYC
+          - - 10.0.0.0/16
+            - routemap_LA
+          - - 192.168.1.1/32
+            - Chicago
+          - - 192.168.2.0/24
+          - - 192.168.3.0/24
+            - routemap_NYC
         redistribute:
-          -   - direct
-              - rm_direct
-          -   - lisp
-              - rm_lisp
+          - - direct
+            - rm_direct
+          - - lisp
+            - rm_lisp
         state: present
 
     - ansible.builtin.assert: *id002
@@ -255,13 +255,13 @@
         dampening_reuse_time: 20
         dampening_suppress_time: 30
         inject_map:
-          -   - fsd_inject_map
-              - fsd_exist_map
+          - - fsd_inject_map
+            - fsd_exist_map
         networks:
-          -   - 192.168.2.0/24
+          - - 192.168.2.0/24
         redistribute:
-          -   - lisp
-              - rm_lisp
+          - - lisp
+            - rm_lisp
         state: present
 
     - ansible.builtin.assert: *id002

--- a/tests/integration/targets/nxos_bgp_global/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_bgp_global/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_bgp_global/tasks/main.yaml
+++ b/tests/integration/targets/nxos_bgp_global/tasks/main.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Enable BGP feature
+- name: Enable bgp feature
   cisco.nxos.nxos_feature:
     feature: bgp
   vars:
@@ -10,18 +10,18 @@
     lines: feature fabric forwarding
 
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
 
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi
 
   always:
-    - name: Disable BGP feature
+    - name: Disable bgp feature
       cisco.nxos.nxos_feature:
         feature: bgp
         state: disabled

--- a/tests/integration/targets/nxos_bgp_global/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bgp_global/tasks/nxapi.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_bgp_global/tests/common/_remove_config.yaml
+++ b/tests/integration/targets/nxos_bgp_global/tests/common/_remove_config.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Remove pre-existing BGP configurations
+- name: Remove pre-existing bgp configurations
   cisco.nxos.nxos_config:
     lines:
       - no router bgp 65536

--- a/tests/integration/targets/nxos_bgp_global/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_bgp_global/tests/common/deleted.yaml
@@ -7,7 +7,7 @@
 - ansible.builtin.include_tasks: _populate_config.yaml
 
 - block:
-    - name: Delete BGP configs handled by this module
+    - name: Delete bgp configs handled by this module
       cisco.nxos.nxos_bgp_global: &id001
         state: deleted
       register: result
@@ -30,7 +30,7 @@
         that:
           - deleted['after'] == result['after']
 
-    - name: Delete BGP configs handled by this module (IDEMPOTENT)
+    - name: Delete bgp configs handled by this module (idempotent)
       register: result
       cisco.nxos.nxos_bgp_global: *id001
 

--- a/tests/integration/targets/nxos_bgp_global/tests/common/deleted_af.yaml
+++ b/tests/integration/targets/nxos_bgp_global/tests/common/deleted_af.yaml
@@ -2,13 +2,13 @@
 - ansible.builtin.debug:
     msg: Start nxos_bgp_global deleted_af integration tests connection={{ ansible_connection}}
 
-- name: Remove pre-existing BGP configurations
+- name: Remove pre-existing bgp configurations
   cisco.nxos.nxos_config: &remove
     lines:
       - no router bgp 65536
   ignore_errors: true
 
-- name: "Setup - 1 (Add neighbor with AF config)"
+- name: "Setup - 1 (add neighbor with af config)"
   cisco.nxos.nxos_config:
     lines:
       - "router bgp 65536"
@@ -26,7 +26,7 @@
       - "  remote-as 65537"
 
 - block:
-    - name: Remove a neighbor having AF configurations (should fail)
+    - name: Remove a neighbor having af configurations (should fail)
       cisco.nxos.nxos_bgp_global: &deleted
         state: deleted
       register: result
@@ -38,11 +38,11 @@
           - result.failed == True
           - "'Neighbor 203.0.113.2 has address-family configurations. Please use the nxos_bgp_neighbor_af module to remove those first.' in result.msg"
 
-    - name: Remove pre-existing BGP configurations
+    - name: Remove pre-existing bgp configurations
       cisco.nxos.nxos_config: *remove
       ignore_errors: true
 
-    - name: "Setup - 2 (Add neighbor with AF config under a VRF)"
+    - name: "Setup - 2 (add neighbor with af config under a vrf)"
       cisco.nxos.nxos_config:
         lines:
           - "router bgp 65536"
@@ -61,7 +61,7 @@
           - "    low-memory exempt"
           - "  neighbor-down fib-accelerate"
 
-    - name: Remove a neighbor under a VRF having AF configurations (should fail)
+    - name: Remove a neighbor under a vrf having af configurations (should fail)
       cisco.nxos.nxos_bgp_global: *deleted
       register: result
       ignore_errors: true
@@ -72,11 +72,11 @@
           - result.failed == True
           - "'VRF site-1 has address-family configurations. Please use the nxos_bgp_af module to remove those first.' in result.msg"
 
-    - name: Remove pre-existing BGP configurations
+    - name: Remove pre-existing bgp configurations
       cisco.nxos.nxos_config: *remove
       ignore_errors: true
 
-    - name: "Setup - 3 (Add a VRF with AF config)"
+    - name: "Setup - 3 (add a vrf with af config)"
       cisco.nxos.nxos_config:
         lines:
           - "router bgp 65536"
@@ -97,7 +97,7 @@
           - "vrf site-2"
           - "  neighbor-down fib-accelerate"
 
-    - name: Remove a neighbor under a VRF having AF configurations (should fail)
+    - name: Remove a neighbor under a vrf having af configurations (should fail)
       cisco.nxos.nxos_bgp_global: *deleted
       register: result
       ignore_errors: true
@@ -109,5 +109,5 @@
           - "'VRF site-1 has address-family configurations. Please use the nxos_bgp_af module to remove those first.' in result.msg"
 
   always:
-    - name: Remove pre-existing BGP configurations
+    - name: Remove pre-existing bgp configurations
       cisco.nxos.nxos_config: *remove

--- a/tests/integration/targets/nxos_bgp_global/tests/common/gathered.yaml
+++ b/tests/integration/targets/nxos_bgp_global/tests/common/gathered.yaml
@@ -7,7 +7,7 @@
 - ansible.builtin.include_tasks: _populate_config.yaml
 
 - block:
-    - name: Gather BGP facts using gathered
+    - name: Gather bgp facts using gathered
       register: result
       cisco.nxos.nxos_bgp_global:
         state: gathered

--- a/tests/integration/targets/nxos_bgp_global/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_bgp_global/tests/common/merged.yaml
@@ -71,7 +71,7 @@
         that:
           - merged['after'] == result['after']
 
-    - name: Merge the provided configuration with the existing running configuration (IDEMPOTENT)
+    - name: Merge the provided configuration with the existing running configuration (idempotent)
       cisco.nxos.nxos_bgp_global: *id001
       register: result
 

--- a/tests/integration/targets/nxos_bgp_global/tests/common/parsed.yaml
+++ b/tests/integration/targets/nxos_bgp_global/tests/common/parsed.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START nxos_bgp_global parsed integration tests on connection={{ ansible_connection }}
 
-- name: Parse externally provided BGP config
+- name: Parse externally provided bgp config
   register: result
   cisco.nxos.nxos_bgp_global:
     running_config: "{{ lookup('file', './fixtures/parsed.cfg') }}"

--- a/tests/integration/targets/nxos_bgp_global/tests/common/purged.yaml
+++ b/tests/integration/targets/nxos_bgp_global/tests/common/purged.yaml
@@ -7,7 +7,7 @@
 - ansible.builtin.include_tasks: _populate_config.yaml
 
 - block:
-    - name: Delete all BGP config from the device
+    - name: Delete all bgp config from the device
       cisco.nxos.nxos_bgp_global: &id001
         state: purged
       register: result
@@ -28,7 +28,7 @@
         that:
           - result['after'] == {}
 
-    - name: Delete all BGP config from the device (IDEMPOTENT)
+    - name: Delete all bgp config from the device (idempotent)
       register: result
       cisco.nxos.nxos_bgp_global: *id001
 

--- a/tests/integration/targets/nxos_bgp_global/tests/common/rendered.yaml
+++ b/tests/integration/targets/nxos_bgp_global/tests/common/rendered.yaml
@@ -60,7 +60,7 @@
     that:
       - merged['commands'] == result['rendered']
 
-- name: Gather BGP facts
+- name: Gather bgp facts
   cisco.nxos.nxos_bgp_global:
     state: gathered
   register: result

--- a/tests/integration/targets/nxos_bgp_global/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_bgp_global/tests/common/replaced.yaml
@@ -7,7 +7,7 @@
 - ansible.builtin.include_tasks: _populate_config.yaml
 
 - block:
-    - name: Replace BGP configuration with provided configuration
+    - name: Replace bgp configuration with provided configuration
       cisco.nxos.nxos_bgp_global: &id001
         config:
           as_number: 65536
@@ -58,7 +58,7 @@
         that:
           - merged['after'] == result['before']
 
-    - name: Replace device configurations of listed OSPF processes with provided configurarions (IDEMPOTENT)
+    - name: Replace device configurations of listed ospf processes with provided configurarions (idempotent)
       register: result
       cisco.nxos.nxos_bgp_global: *id001
 

--- a/tests/integration/targets/nxos_bgp_global/tests/common/replaced_af.yaml
+++ b/tests/integration/targets/nxos_bgp_global/tests/common/replaced_af.yaml
@@ -2,13 +2,13 @@
 - ansible.builtin.debug:
     msg: Start nxos_bgp_global replaced_af integration tests connection={{ ansible_connection}}
 
-- name: Remove pre-existing BGP configurations
+- name: Remove pre-existing bgp configurations
   cisco.nxos.nxos_config: &remove
     lines:
       - no router bgp 65536
   ignore_errors: true
 
-- name: "Setup - 1 (Add neighbor with AF config)"
+- name: "Setup - 1 (add neighbor with af config)"
   cisco.nxos.nxos_config:
     lines:
       - "router bgp 65536"
@@ -26,7 +26,7 @@
       - "  remote-as 65537"
 
 - block:
-    - name: Remove a neighbor having AF configurations (should fail)
+    - name: Remove a neighbor having af configurations (should fail)
       cisco.nxos.nxos_bgp_global:
         config:
           as_number: 65536
@@ -46,11 +46,11 @@
           - result.failed == True
           - "'Neighbor 203.0.113.2 has address-family configurations. Please use the nxos_bgp_neighbor_af module to remove those first.' in result.msg"
 
-    - name: Remove pre-existing BGP configurations
+    - name: Remove pre-existing bgp configurations
       cisco.nxos.nxos_config: *remove
       ignore_errors: true
 
-    - name: "Setup - 2 (Add neighbor with AF config under a VRF)"
+    - name: "Setup - 2 (add neighbor with af config under a vrf)"
       cisco.nxos.nxos_config:
         lines:
           - "router bgp 65536"
@@ -69,7 +69,7 @@
           - "    low-memory exempt"
           - "  neighbor-down fib-accelerate"
 
-    - name: Remove a neighbor under a VRF having AF configurations (should fail)
+    - name: Remove a neighbor under a vrf having af configurations (should fail)
       cisco.nxos.nxos_bgp_global:
         config:
           as_number: 65536
@@ -93,11 +93,11 @@
           - result.failed == True
           - "'Neighbor 203.0.113.2 has address-family configurations. Please use the nxos_bgp_neighbor_af module to remove those first.' in result.msg"
 
-    - name: Remove pre-existing BGP configurations
+    - name: Remove pre-existing bgp configurations
       cisco.nxos.nxos_config: *remove
       ignore_errors: true
 
-    - name: "Setup - 3 (Add a VRF with AF config)"
+    - name: "Setup - 3 (add a vrf with af config)"
       cisco.nxos.nxos_config:
         lines:
           - "router bgp 65536"
@@ -117,7 +117,7 @@
           - "vrf site-2"
           - "  neighbor-down fib-accelerate"
 
-    - name: Remove a VRF having AF configurations (should fail)
+    - name: Remove a vrf having af configurations (should fail)
       cisco.nxos.nxos_bgp_global:
         config:
           as_number: 65536
@@ -142,5 +142,5 @@
           - "'VRF site-1 has address-family configurations. Please use the nxos_bgp_af module to remove those first.' in result.msg"
 
   always:
-    - name: Remove pre-existing BGP configurations
+    - name: Remove pre-existing bgp configurations
       cisco.nxos.nxos_config: *remove

--- a/tests/integration/targets/nxos_bgp_global/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_bgp_global/tests/common/sanity.yaml
@@ -7,7 +7,7 @@
 - ansible.builtin.include_tasks: _populate_config.yaml
 
 - block:
-    - name: Replace BGP configuration with different ASN (should fail)
+    - name: Replace bgp configuration with different asn (should fail)
       cisco.nxos.nxos_bgp_global:
         config:
           as_number: "65538"
@@ -24,7 +24,7 @@
           - result.failed == True
           - "'BGP is already configured with ASN 65536. Please remove it with state purged before configuring new ASN' in result.msg"
 
-    - name: Merge BGP configuration with different ASN (should fail)
+    - name: Merge bgp configuration with different asn (should fail)
       cisco.nxos.nxos_bgp_global:
         config:
           as_number: "65538"

--- a/tests/integration/targets/nxos_bgp_neighbor/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_bgp_neighbor/tasks/main.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_bgp_neighbor/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_bgp_neighbor/tests/common/multisite.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor/tests/common/multisite.yaml
@@ -6,7 +6,7 @@
   ansible.builtin.set_fact:
     intname: "{{ nxos_int1 }}"
 
-- name: "Setup: Disable features - multisite"
+- name: "Setup: disable features - multisite"
   loop:
     - bgp
     - bfd
@@ -16,7 +16,7 @@
     feature: "{{ item }}"
     state: disabled
 
-- name: "Setup: Enable features - multisite"
+- name: "Setup: enable features - multisite"
   loop:
     - bgp
     - bfd
@@ -41,7 +41,7 @@
       - evpn multisite border-gateway 10
 
 - block:
-    - name: Configure BGP neighbor1 - multisite
+    - name: Configure bgp neighbor1 - multisite
       register: result
       cisco.nxos.nxos_bgp_neighbor: &id001
         asn: 65535
@@ -56,7 +56,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp_neighbor: *id001
 
@@ -64,7 +64,7 @@
         that:
           - result.changed == false
 
-    - name: Configure BGP neighbor2 - multisite
+    - name: Configure bgp neighbor2 - multisite
       register: result
       cisco.nxos.nxos_bgp_neighbor: &id003
         asn: 65535
@@ -73,13 +73,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp_neighbor: *id003
 
     - ansible.builtin.assert: *id004
 
-    - name: Configure BGP neighbor3 - multisite
+    - name: Configure bgp neighbor3 - multisite
       register: result
       cisco.nxos.nxos_bgp_neighbor: &id005
         asn: 65535
@@ -88,7 +88,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp_neighbor: *id005
 
@@ -100,7 +100,7 @@
           - no evpn multisite border-gateway 10
   when: multiout is not search("Invalid command")
 
-- name: "Teardown: Disable features"
+- name: "Teardown: disable features"
   loop:
     - bgp
     - bfd

--- a/tests/integration/targets/nxos_bgp_neighbor/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor/tests/common/sanity.yaml
@@ -29,7 +29,7 @@
     remove_private_asr: replace-as
   when: not titanium
 
-- name: "Setup: Disable features"
+- name: "Setup: disable features"
   loop:
     - bgp
     - bfd
@@ -38,7 +38,7 @@
     feature: "{{ item }}"
     state: disabled
 
-- name: "Setup: Enable features"
+- name: "Setup: enable features"
   loop:
     - bgp
     - bfd
@@ -47,7 +47,7 @@
     state: enabled
 
 - block:
-    - name: Configure BGP neighbor1
+    - name: Configure bgp neighbor1
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: &id001
@@ -75,7 +75,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: *id001
@@ -84,7 +84,7 @@
         that:
           - result.changed == false
 
-    - name: Configure BGP neighbor2
+    - name: Configure bgp neighbor2
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: &id003
@@ -110,14 +110,14 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: *id003
 
     - ansible.builtin.assert: *id004
 
-    - name: Remove BGP
+    - name: Remove bgp
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: &id005
@@ -128,14 +128,14 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: *id005
 
     - ansible.builtin.assert: *id004
 
-    - name: Configure BGP neighbor3
+    - name: Configure bgp neighbor3
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: &id006
@@ -148,14 +148,14 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: *id006
 
     - ansible.builtin.assert: *id004
 
-    - name: Configure BGP neighbor4
+    - name: Configure bgp neighbor4
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: &id007
@@ -168,21 +168,21 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: *id007
 
     - ansible.builtin.assert: *id004
 
-    - name: Remove BGP
+    - name: Remove bgp
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: *id005
 
     - ansible.builtin.assert: *id002
 
-    - name: Configure BGP neighbor 3des password
+    - name: Configure bgp neighbor 3des password
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: &id008
@@ -195,21 +195,21 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: *id008
 
     - ansible.builtin.assert: *id004
 
-    - name: Remove BGP
+    - name: Remove bgp
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: *id005
 
     - ansible.builtin.assert: *id002
 
-    - name: Configure BGP neighbor type 7 password
+    - name: Configure bgp neighbor type 7 password
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: &id009
@@ -222,14 +222,14 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: *id009
 
     - ansible.builtin.assert: *id004
 
-    - name: Remove BGP neighbor password
+    - name: Remove bgp neighbor password
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: &id010
@@ -242,21 +242,21 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: *id010
 
     - ansible.builtin.assert: *id004
 
-    - name: Remove BGP
+    - name: Remove bgp
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: *id005
 
     - ansible.builtin.assert: *id002
 
-    - name: Configure BGP neighbor transport type passive
+    - name: Configure bgp neighbor transport type passive
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: &id011
@@ -268,14 +268,14 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: *id011
 
     - ansible.builtin.assert: *id004
 
-    - name: Configure BGP neighbor transport type default
+    - name: Configure bgp neighbor transport type default
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: &id012
@@ -287,14 +287,14 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: *id012
 
     - ansible.builtin.assert: *id004
 
-    - name: Remove BGP
+    - name: Remove bgp
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: &id013
@@ -305,14 +305,14 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_bgp_neighbor: *id013
 
     - ansible.builtin.assert: *id004
 
-    - name: Configure BFD enable
+    - name: Configure bfd enable
       register: result
       cisco.nxos.nxos_bgp_neighbor: &id014
         asn: 65535
@@ -322,13 +322,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check BFD enable Idempotence
+    - name: Check bfd enable idempotence
       register: result
       cisco.nxos.nxos_bgp_neighbor: *id014
 
     - ansible.builtin.assert: *id004
 
-    - name: Configure BFD disable Idempotence
+    - name: Configure bfd disable idempotence
       register: result
       cisco.nxos.nxos_bgp_neighbor: &id015
         asn: 65535
@@ -338,13 +338,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check BFD disable Idempotence
+    - name: Check bfd disable idempotence
       register: result
       cisco.nxos.nxos_bgp_neighbor: *id015
 
     - ansible.builtin.assert: *id004
   always:
-    - name: "Teardown: Disable features"
+    - name: "Teardown: disable features"
       loop:
         - bgp
         - bfd

--- a/tests/integration/targets/nxos_bgp_neighbor_address_family/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_address_family/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_bgp_neighbor_address_family/tasks/main.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_address_family/tasks/main.yaml
@@ -1,23 +1,23 @@
 ---
-- name: Enable BGP feature
+- name: Enable bgp feature
   cisco.nxos.nxos_feature:
     feature: bgp
   vars:
     ansible_connection: ansible.netcommon.network_cli
 
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
 
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi
 
   always:
-    - name: Disable BGP feature
+    - name: Disable bgp feature
       cisco.nxos.nxos_feature:
         feature: bgp
         state: disabled

--- a/tests/integration/targets/nxos_bgp_neighbor_address_family/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_address_family/tasks/nxapi.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_bgp_neighbor_address_family/tests/common/_populate_config.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_address_family/tests/common/_populate_config.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Populate Config
+- name: Populate config
   cisco.nxos.nxos_bgp_neighbor_address_family:
     config:
       as_number: 65536

--- a/tests/integration/targets/nxos_bgp_neighbor_address_family/tests/common/_remove_config.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_address_family/tests/common/_remove_config.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Remove pre-existing BGP configurations
+- name: Remove pre-existing bgp configurations
   cisco.nxos.nxos_config:
     lines:
       - no router bgp 65536

--- a/tests/integration/targets/nxos_bgp_neighbor_address_family/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_address_family/tests/common/deleted.yaml
@@ -7,7 +7,7 @@
 - ansible.builtin.include_tasks: _populate_config.yaml
 
 - block:
-    - name: Delete BGP configs handled by this module
+    - name: Delete bgp configs handled by this module
       cisco.nxos.nxos_bgp_neighbor_address_family:
         config:
           as_number: 65536
@@ -49,7 +49,7 @@
 
     - ansible.builtin.include_tasks: _populate_config.yaml
 
-    - name: Delete all BGP neighbor AF configs handled by this module
+    - name: Delete all bgp neighbor af configs handled by this module
       cisco.nxos.nxos_bgp_neighbor_address_family: &deleted_all
         state: deleted
       register: result
@@ -64,7 +64,7 @@
         that:
           - deleted_all['after'] == result['after']
 
-    - name: Delete all BGP neighbor AF configs (IDEMPOTENT)
+    - name: Delete all bgp neighbor af configs (idempotent)
       cisco.nxos.nxos_bgp_neighbor_address_family: *deleted_all
       register: result
 

--- a/tests/integration/targets/nxos_bgp_neighbor_address_family/tests/common/gathered.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_address_family/tests/common/gathered.yaml
@@ -7,7 +7,7 @@
 - ansible.builtin.include_tasks: _populate_config.yaml
 
 - block:
-    - name: Gather BGP facts using gathered
+    - name: Gather bgp facts using gathered
       register: result
       cisco.nxos.nxos_bgp_neighbor_address_family:
         state: gathered

--- a/tests/integration/targets/nxos_bgp_neighbor_address_family/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_address_family/tests/common/merged.yaml
@@ -66,7 +66,7 @@
           - "{{ merged['after']['vrfs'] | symmetric_difference(result['after']['vrfs']) |length == 0 }}"
           - merged['after']['as_number'] == result['after']['as_number']
 
-    - name: Merge the provided configuration with the existing running configuration (IDEMPOTENT)
+    - name: Merge the provided configuration with the existing running configuration (idempotent)
       cisco.nxos.nxos_bgp_neighbor_address_family: *id001
       register: result
 

--- a/tests/integration/targets/nxos_bgp_neighbor_address_family/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_address_family/tests/common/overridden.yaml
@@ -7,7 +7,7 @@
 - ansible.builtin.include_tasks: _populate_config.yaml
 
 - block:
-    - name: Override all BGP AF configuration with provided configuration
+    - name: Override all bgp af configuration with provided configuration
       cisco.nxos.nxos_bgp_neighbor_address_family: &overridden
         config:
           as_number: 65536
@@ -48,7 +48,7 @@
           - "{{ overridden['after']['vrfs'] | symmetric_difference(result['after']['vrfs']) |length == 0 }}"
           - overridden['after']['as_number'] == result['after']['as_number']
 
-    - name: Override all BGP AF configuration with provided configuration (IDEMPOTENT)
+    - name: Override all bgp af configuration with provided configuration (idempotent)
       register: result
       cisco.nxos.nxos_bgp_neighbor_address_family: *overridden
 

--- a/tests/integration/targets/nxos_bgp_neighbor_address_family/tests/common/parsed.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_address_family/tests/common/parsed.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START nxos_bgp_neighbor_address_family parsed integration tests on connection={{ ansible_connection }}
 
-- name: Parse externally provided BGP config
+- name: Parse externally provided bgp config
   register: result
   cisco.nxos.nxos_bgp_neighbor_address_family:
     running_config: "{{ lookup('file', './fixtures/parsed.cfg') }}"

--- a/tests/integration/targets/nxos_bgp_neighbor_address_family/tests/common/rendered.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_address_family/tests/common/rendered.yaml
@@ -53,7 +53,7 @@
     that:
       - "{{ merged['commands'] | symmetric_difference(result['rendered']) |length == 0 }}"
 
-- name: Gather BGP facts
+- name: Gather bgp facts
   cisco.nxos.nxos_bgp_neighbor_address_family:
     state: gathered
   register: result

--- a/tests/integration/targets/nxos_bgp_neighbor_address_family/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_address_family/tests/common/replaced.yaml
@@ -7,7 +7,7 @@
 - ansible.builtin.include_tasks: _populate_config.yaml
 
 - block:
-    - name: Replace specified neighbor AFs with given configuration
+    - name: Replace specified neighbor afs with given configuration
       cisco.nxos.nxos_bgp_neighbor_address_family: &replaced
         config:
           as_number: 65536
@@ -63,7 +63,7 @@
           - "{{ replaced['after']['vrfs'] | symmetric_difference(result['after']['vrfs']) |length == 0 }}"
           - replaced['after']['as_number'] == result['after']['as_number']
 
-    - name: Replace device configurations of listed OSPF processes with provided configurarions (IDEMPOTENT)
+    - name: Replace device configurations of listed ospf processes with provided configurarions (idempotent)
       register: result
       cisco.nxos.nxos_bgp_neighbor_address_family: *replaced
 

--- a/tests/integration/targets/nxos_bgp_neighbor_af/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_af/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_bgp_neighbor_af/tasks/main.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_af/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_bgp_neighbor_af/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_af/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_bgp_neighbor_af/tests/common/multisite.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_af/tests/common/multisite.yaml
@@ -7,13 +7,13 @@
     soft_reconfiguration_ina: always
   when: imagetag is not search("D1|N1")
 
-- name: Disable feature BGP - multisite
+- name: Disable feature bgp - multisite
   ignore_errors: true
   cisco.nxos.nxos_feature:
     feature: bgp
     state: disabled
 
-- name: Enable feature BGP - multisite
+- name: Enable feature bgp - multisite
   ignore_errors: true
   cisco.nxos.nxos_feature:
     feature: bgp
@@ -39,13 +39,13 @@
       - evpn multisite border-gateway 10
 
 - block:
-    - name: Configure eBGP - multisite
+    - name: Configure ebgp - multisite
       cisco.nxos.nxos_bgp_neighbor:
         asn: 65535
         neighbor: 192.0.2.3
         remote_as: 2
 
-    - name: Configure BGP neighbor - multisite
+    - name: Configure bgp neighbor - multisite
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: &id001
         asn: 65535
@@ -60,7 +60,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: *id001
 
@@ -68,7 +68,7 @@
         that:
           - result.changed == false
 
-    - name: Configure BGP neighbor 1 - multisite
+    - name: Configure bgp neighbor 1 - multisite
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: &id003
         asn: 65535
@@ -81,7 +81,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: *id003
 

--- a/tests/integration/targets/nxos_bgp_neighbor_af/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_af/tests/common/sanity.yaml
@@ -7,20 +7,20 @@
     soft_reconfiguration_ina: always
   when: imagetag is not search("D1|N1")
 
-- name: Disable feature BGP
+- name: Disable feature bgp
   ignore_errors: true
   cisco.nxos.nxos_feature: &id013
     feature: bgp
     state: disabled
 
-- name: Enable feature BGP
+- name: Enable feature bgp
   ignore_errors: true
   cisco.nxos.nxos_feature:
     feature: bgp
     state: enabled
 
 - block:
-    - name: Configure BGP neighbor address-family
+    - name: Configure bgp neighbor address-family
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: &id001
         asn: 65535
@@ -55,7 +55,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: *id001
 
@@ -63,7 +63,7 @@
         that:
           - result.changed == false
 
-    - name: Configure BGP neighbor address-family def1
+    - name: Configure bgp neighbor address-family def1
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: &id003
         asn: 65535
@@ -94,13 +94,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: *id003
 
     - ansible.builtin.assert: *id004
 
-    - name: "Setup: Remove BGP config"
+    - name: "Setup: remove bgp config"
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: &id005
         asn: 65535
@@ -111,13 +111,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: *id005
 
     - ansible.builtin.assert: *id004
 
-    - name: Configure BGP neighbor address-family
+    - name: Configure bgp neighbor address-family
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: &id006
         asn: 65535
@@ -138,13 +138,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: *id006
 
     - ansible.builtin.assert: *id004
 
-    - name: Configure BGP neighbor address-family def2
+    - name: Configure bgp neighbor address-family def2
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: &id007
         asn: 65535
@@ -163,32 +163,32 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: *id007
 
     - ansible.builtin.assert: *id004
 
-    - name: "Setup: Remove BGP config"
+    - name: "Setup: remove bgp config"
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: *id005
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: *id005
 
     - ansible.builtin.assert: *id004
 
-    - name: Configure eBGP
+    - name: Configure ebgp
       cisco.nxos.nxos_bgp_neighbor:
         asn: 65535
         vrf: blue
         neighbor: 192.0.2.3
         remote_as: 2
 
-    - name: Configure BGP neighbor 3
+    - name: Configure bgp neighbor 3
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: &id008
         asn: 65535
@@ -207,13 +207,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: *id008
 
     - ansible.builtin.assert: *id004
 
-    - name: Configure BGP neighbor def3
+    - name: Configure bgp neighbor def3
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: &id009
         asn: 65535
@@ -230,13 +230,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: *id009
 
     - ansible.builtin.assert: *id004
 
-    - name: "Setup: Remove BGP config"
+    - name: "Setup: remove bgp config"
       register: result
       cisco.nxos.nxos_bgp: &id012
         asn: 65535
@@ -244,13 +244,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Configure BGP neighbor af route_reflector_client
+    - name: Configure bgp neighbor af route_reflector_client
       cisco.nxos.nxos_bgp_neighbor:
         asn: 65535
         neighbor: 192.0.2.2
         remote_as: 65535
 
-    - name: Configure BGP neighbor 4
+    - name: Configure bgp neighbor 4
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: &id010
         asn: 65535
@@ -261,13 +261,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: *id010
 
     - ansible.builtin.assert: *id004
 
-    - name: Configure BGP neighbor def4
+    - name: Configure bgp neighbor def4
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: &id011
         asn: 65535
@@ -278,13 +278,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_bgp_neighbor_af: *id011
 
     - ansible.builtin.assert: *id004
   always:
-    - name: Cleanup BGP
+    - name: Cleanup bgp
       ignore_errors: true
       cisco.nxos.nxos_bgp: *id012
 

--- a/tests/integration/targets/nxos_command/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_command/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_command/tasks/main.yaml
+++ b/tests/integration/targets/nxos_command/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_command/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_command/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_command/tests/cli/cli_command.yaml
+++ b/tests/integration/targets/nxos_command/tests/cli/cli_command.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START cli/cli_command.yaml on connection={{ ansible_connection }}
 
-- name: get output for single command
+- name: Get output for single command
   register: result
   ansible.netcommon.cli_command:
     command: show version
@@ -12,7 +12,7 @@
       - result.changed == false
       - result.stdout is defined
 
-- name: send invalid command
+- name: Send invalid command
   register: result
   ignore_errors: true
   ansible.netcommon.cli_command:

--- a/tests/integration/targets/nxos_command/tests/cli/contains.yaml
+++ b/tests/integration/targets/nxos_command/tests/cli/contains.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START common/contains.yaml on connection={{ ansible_connection }}
 
-- name: test contains operator
+- name: Test contains operator
   register: result
   cisco.nxos.nxos_command:
     commands:

--- a/tests/integration/targets/nxos_command/tests/cli/sanity.yaml
+++ b/tests/integration/targets/nxos_command/tests/cli/sanity.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START cli/sanity.yaml on connection={{ ansible_connection }}
 
-- name: Disable feature BGP
+- name: Disable feature bgp
   cisco.nxos.nxos_feature:
     feature: bgp
     state: disabled
@@ -19,12 +19,12 @@
         that:
           - result.failed == true
 
-    - name: Enable feature BGP
+    - name: Enable feature bgp
       cisco.nxos.nxos_feature:
         feature: bgp
         state: enabled
 
-    - name: Configure BGP defaults
+    - name: Configure bgp defaults
       register: result
       cisco.nxos.nxos_bgp:
         asn: 65535

--- a/tests/integration/targets/nxos_command/tests/common/bad_operator.yaml
+++ b/tests/integration/targets/nxos_command/tests/common/bad_operator.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START common/bad_operator.yaml on connection={{ ansible_connection }}
 
-- name: test bad operator
+- name: Test bad operator
   register: result
   ignore_errors: true
   cisco.nxos.nxos_command:

--- a/tests/integration/targets/nxos_command/tests/common/equal.yaml
+++ b/tests/integration/targets/nxos_command/tests/common/equal.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START common/equal.yaml on connection={{ ansible_connection }}
 
-- name: test eq operator
+- name: Test eq operator
   register: result
   cisco.nxos.nxos_command:
     commands:
@@ -15,7 +15,7 @@
     that:
       - result.changed == false
 
-- name: test == operator
+- name: Test == operator
   register: result
   cisco.nxos.nxos_command:
     commands:

--- a/tests/integration/targets/nxos_command/tests/common/greaterthan.yaml
+++ b/tests/integration/targets/nxos_command/tests/common/greaterthan.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START common/greaterthan.yaml on connection={{ ansible_connection }}
 
-- name: test gt operator
+- name: Test gt operator
   register: result
   cisco.nxos.nxos_command:
     commands:
@@ -15,7 +15,7 @@
     that:
       - result.changed == false
 
-- name: test > operator
+- name: Test > operator
   register: result
   cisco.nxos.nxos_command:
     commands:

--- a/tests/integration/targets/nxos_command/tests/common/greaterthanorequal.yaml
+++ b/tests/integration/targets/nxos_command/tests/common/greaterthanorequal.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START common/greaterthanorequal.yaml on connection={{ ansible_connection }}
 
-- name: test ge operator
+- name: Test ge operator
   register: result
   cisco.nxos.nxos_command:
     commands:
@@ -15,7 +15,7 @@
     that:
       - result.changed == false
 
-- name: test >= operator
+- name: Test >= operator
   register: result
   cisco.nxos.nxos_command:
     commands:

--- a/tests/integration/targets/nxos_command/tests/common/invalid.yaml
+++ b/tests/integration/targets/nxos_command/tests/common/invalid.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START common/invalid.yaml on connection={{ ansible_connection }}
 
-- name: run invalid command
+- name: Run invalid command
   register: result
   ignore_errors: true
   cisco.nxos.nxos_command:
@@ -13,7 +13,7 @@
     that:
       - result.failed == true
 
-- name: run commands that include invalid command
+- name: Run commands that include invalid command
   register: result
   ignore_errors: true
   cisco.nxos.nxos_command:

--- a/tests/integration/targets/nxos_command/tests/common/lessthan.yaml
+++ b/tests/integration/targets/nxos_command/tests/common/lessthan.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START common/lessthan.yaml on connection={{ ansible_connection }}
 
-- name: test lt operator
+- name: Test lt operator
   register: result
   cisco.nxos.nxos_command:
     commands:
@@ -15,7 +15,7 @@
     that:
       - result.changed == false
 
-- name: test < operator
+- name: Test < operator
   register: result
   cisco.nxos.nxos_command:
     commands:

--- a/tests/integration/targets/nxos_command/tests/common/lessthanorequal.yaml
+++ b/tests/integration/targets/nxos_command/tests/common/lessthanorequal.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START common/lessthanorequal.yaml on connection={{ ansible_connection }}
 
-- name: test le operator
+- name: Test le operator
   register: result
   cisco.nxos.nxos_command:
     commands:
@@ -15,7 +15,7 @@
     that:
       - result.changed == false
 
-- name: test <= operator
+- name: Test <= operator
   register: result
   cisco.nxos.nxos_command:
     commands:

--- a/tests/integration/targets/nxos_command/tests/common/not_comparison_operator.yaml
+++ b/tests/integration/targets/nxos_command/tests/common/not_comparison_operator.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START common/not_comparison_operator.yaml on connection={{ ansible_connection }}
 
-- name: test 'not' keyword in wait_for
+- name: Test 'not' keyword in wait_for
   register: result
   cisco.nxos.nxos_command:
     commands:

--- a/tests/integration/targets/nxos_command/tests/common/notequal.yaml
+++ b/tests/integration/targets/nxos_command/tests/common/notequal.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START common/notequal.yaml on connection={{ ansible_connection }}
 
-- name: test neq operator
+- name: Test neq operator
   register: result
   cisco.nxos.nxos_command:
     commands:
@@ -16,7 +16,7 @@
       - result.changed == false
       - result.stdout is defined
 
-- name: test != operator
+- name: Test != operator
   register: result
   cisco.nxos.nxos_command:
     commands:

--- a/tests/integration/targets/nxos_command/tests/common/output.yaml
+++ b/tests/integration/targets/nxos_command/tests/common/output.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START common/output.yaml on connection={{ ansible_connection }}
 
-- name: get output for single command
+- name: Get output for single command
   register: result
   cisco.nxos.nxos_command:
     commands:
@@ -12,7 +12,7 @@
     that:
       - result.changed == false
 
-- name: get output for multiple commands
+- name: Get output for multiple commands
   register: result
   cisco.nxos.nxos_command:
     commands:

--- a/tests/integration/targets/nxos_command/tests/common/timeout.yaml
+++ b/tests/integration/targets/nxos_command/tests/common/timeout.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START common/timeout.yaml on connection={{ ansible_connection }}
 
-- name: test bad condition
+- name: Test bad condition
   register: result
   ignore_errors: true
   cisco.nxos.nxos_command:

--- a/tests/integration/targets/nxos_command/tests/nxapi/contains.yaml
+++ b/tests/integration/targets/nxos_command/tests/nxapi/contains.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START common/contains.yaml on connection={{ ansible_connection }}
 
-- name: test contains operator
+- name: Test contains operator
   register: result
   cisco.nxos.nxos_command:
     commands:

--- a/tests/integration/targets/nxos_command/tests/nxapi/sanity.yaml
+++ b/tests/integration/targets/nxos_command/tests/nxapi/sanity.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START nxapi/sanity.yaml on connection={{ ansible_connection }}
 
-- name: Disable feature BGP
+- name: Disable feature bgp
   cisco.nxos.nxos_feature:
     feature: bgp
     state: disabled
@@ -19,12 +19,12 @@
         that:
           - result.failed == true
 
-    - name: Enable feature BGP
+    - name: Enable feature bgp
       cisco.nxos.nxos_feature:
         feature: bgp
         state: enabled
 
-    - name: Configure BGP defaults
+    - name: Configure bgp defaults
       register: result
       cisco.nxos.nxos_bgp:
         asn: 65535

--- a/tests/integration/targets/nxos_config/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_config/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_config/tasks/cli_config.yaml
+++ b/tests/integration/targets/nxos_config/tasks/cli_config.yaml
@@ -1,16 +1,16 @@
 ---
-- name: collect all cli_config test cases
+- name: Collect all cli_config test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli_config"
     patterns: "{{ testcase }}.yaml"
   register: test_cases
   delegate_to: localhost
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case (connection=ansible.netcommon.network_cli)
+- name: Run test case (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_config/tasks/main.yaml
+++ b/tests/integration/targets/nxos_config/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
 
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_config/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_config/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_config/tasks/redirection.yaml
+++ b/tests/integration/targets/nxos_config/tasks/redirection.yaml
@@ -1,16 +1,16 @@
 ---
-- name: collect all redirection cli test cases
+- name: Collect all redirection cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/redirection/cli"
     patterns: "{{ testcase }}.yaml"
   register: shortname_test_cases
   delegate_to: localhost
 
-- name: set test_items for redirection
+- name: Set test_items for redirection
   ansible.builtin.set_fact:
     test_items: "{{ shortname_test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case (connection=ansible.netcommon.network_cli)
+- name: Run test case (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_config/tests/cli/diff.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli/diff.yaml
@@ -2,11 +2,11 @@
 - ansible.builtin.debug:
     msg: START cli/diff.yaml on connection={{ ansible_connection }}
 
-- name: setup hostname
+- name: Setup hostname
   cisco.nxos.nxos_config:
     lines: hostname switch
 
-- name: nxos_config diff against retrieved config
+- name: Nxos_config diff against retrieved config
   diff: true
   register: result
   cisco.nxos.nxos_config:
@@ -18,7 +18,7 @@
       - "'hostname an-nxos9k-01.ansible.com' in result['diff']['after']"
       - "'hostname switch' in result['diff']['before']"
 
-- name: nxos_config diff against provided running_config
+- name: Nxos_config diff against provided running_config
   diff: true
   register: result
   cisco.nxos.nxos_config:

--- a/tests/integration/targets/nxos_config/tests/cli/multilevel.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli/multilevel.yaml
@@ -2,22 +2,22 @@
 - ansible.builtin.debug:
     msg: START cli/mulitlevel.yaml
 
-- name: get config
+- name: Get config
   register: config
   cisco.nxos.nxos_command:
     commands: show running-config
 
-- name: enable feature bgp
+- name: Enable feature bgp
   when: "'feature bgp' not in config.stdout[0]"
   cisco.nxos.nxos_config:
     lines: feature bgp
 
-- name: remove bgp
+- name: Remove bgp
   when: "'router bgp 1' in config.stdout[0]"
   cisco.nxos.nxos_config:
     lines: no router bgp 1
 
-- name: configure multi level command
+- name: Configure multi level command
   register: result
   cisco.nxos.nxos_config:
     lines: maximum-paths 14
@@ -32,7 +32,7 @@
       - "'address-family ipv4 unicast' in result.updates"
       - "'maximum-paths 14' in result.updates"
 
-- name: check multi level command
+- name: Check multi level command
   register: result
   cisco.nxos.nxos_config:
     lines: maximum-paths 14
@@ -44,7 +44,7 @@
     that:
       - result.changed == false
 
-- name: teardown
+- name: Teardown
   cisco.nxos.nxos_config:
     lines:
       - no feature bgp

--- a/tests/integration/targets/nxos_config/tests/cli/sublevel.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli/sublevel.yaml
@@ -2,12 +2,12 @@
 - ansible.builtin.debug:
     msg: START cli/sublevel.yaml
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     lines: no ip access-list test
     match: none
 
-- name: configure sub level command
+- name: Configure sub level command
   register: result
   cisco.nxos.nxos_config:
     lines: 10 permit ip any any log
@@ -19,7 +19,7 @@
       - "'ip access-list test' in result.updates"
       - "'10 permit ip any any log' in result.updates"
 
-- name: configure sub level command idempotent check
+- name: Configure sub level command idempotent check
   register: result
   cisco.nxos.nxos_config:
     lines: 10 permit ip any any log
@@ -29,7 +29,7 @@
     that:
       - result.changed == false
 
-- name: teardown
+- name: Teardown
   cisco.nxos.nxos_config:
     lines: no ip access-list test
     match: none

--- a/tests/integration/targets/nxos_config/tests/cli/sublevel_exact.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli/sublevel_exact.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START cli/sublevel_exact.yaml
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     commands:
       - 10 permit ip 192.0.2.1/32 any log
@@ -14,7 +14,7 @@
     before: no ip access-list test
     match: none
 
-- name: configure sub level command using exact match
+- name: Configure sub level command using exact match
   register: result
   cisco.nxos.nxos_config:
     commands:
@@ -35,7 +35,7 @@
       - "'40 permit ip 192.0.2.4/32 any log' in result.updates"
       - "'50 permit ip 192.0.2.5/32 any log' not in result.updates"
 
-- name: check sub level command using exact match
+- name: Check sub level command using exact match
   register: result
   cisco.nxos.nxos_config:
     lines:
@@ -51,7 +51,7 @@
     that:
       - result.changed == false
 
-- name: teardown
+- name: Teardown
   cisco.nxos.nxos_config:
     lines: no ip access-list test
     match: none

--- a/tests/integration/targets/nxos_config/tests/cli/sublevel_strict.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli/sublevel_strict.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START cli/sublevel_strict.yaml
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     commands:
       - 10 permit ip 192.0.2.1/32 any log
@@ -14,7 +14,7 @@
     before: no ip access-list test
     match: none
 
-- name: configure sub level command using strict match
+- name: Configure sub level command using strict match
   register: result
   cisco.nxos.nxos_config:
     lines:
@@ -37,7 +37,7 @@
       - "'40 permit ip 192.0.2.4/32 any log' in result.updates"
       - "'50 permit ip 192.0.2.5/32 any log' not in result.updates"
 
-- name: check sub level command using strict match
+- name: Check sub level command using strict match
   register: result
   cisco.nxos.nxos_config:
     lines:
@@ -52,7 +52,7 @@
     that:
       - result.changed == false
 
-- name: teardown
+- name: Teardown
   cisco.nxos.nxos_config:
     commands: no ip access-list test
     match: none

--- a/tests/integration/targets/nxos_config/tests/cli/toplevel_after.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli/toplevel_after.yaml
@@ -2,14 +2,14 @@
 - ansible.builtin.debug:
     msg: START cli/toplevel_after.yaml
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     lines:
       - snmp-server contact ansible
       - hostname switch
     match: none
 
-- name: configure top level command with before
+- name: Configure top level command with before
   register: result
   cisco.nxos.nxos_config:
     lines: hostname foo
@@ -21,7 +21,7 @@
       - "'hostname foo' in result.updates"
       - "'snmp-server contact bar' in result.updates"
 
-- name: configure top level command with before idempotent check
+- name: Configure top level command with before idempotent check
   register: result
   cisco.nxos.nxos_config:
     lines: hostname foo
@@ -31,7 +31,7 @@
     that:
       - result.changed == false
 
-- name: teardown
+- name: Teardown
   cisco.nxos.nxos_config:
     lines:
       - no snmp-server contact

--- a/tests/integration/targets/nxos_config/tests/cli/toplevel_before.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli/toplevel_before.yaml
@@ -2,14 +2,14 @@
 - ansible.builtin.debug:
     msg: START cli/toplevel_before.yaml
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     lines:
       - snmp-server contact ansible
       - hostname switch
     match: none
 
-- name: configure top level command with before
+- name: Configure top level command with before
   register: result
   cisco.nxos.nxos_config:
     lines: hostname foo
@@ -21,7 +21,7 @@
       - "'hostname foo' in result.updates"
       - "'snmp-server contact bar' in result.updates"
 
-- name: configure top level command with before idempotent check
+- name: Configure top level command with before idempotent check
   register: result
   cisco.nxos.nxos_config:
     lines: hostname foo
@@ -31,7 +31,7 @@
     that:
       - result.changed == false
 
-- name: teardown
+- name: Teardown
   cisco.nxos.nxos_config:
     lines:
       - no snmp-server contact

--- a/tests/integration/targets/nxos_config/tests/cli_config/cli_backup.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli_config/cli_backup.yaml
@@ -11,7 +11,7 @@
     can_become: false
   when: platform is search('N9K') and (major_version is version('10.', 'ge'))
 
-- name: delete configurable backup file path
+- name: Delete configurable backup file path
   ansible.builtin.file:
     path: "{{ item }}"
     state: absent
@@ -19,20 +19,20 @@
     - "{{ role_path }}/backup_test_dir/"
     - "{{ role_path }}/backup/backup.cfg"
 
-- name: collect any backup files
+- name: Collect any backup files
   ansible.builtin.find:
     paths: "{{ role_path }}/backup"
     pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   connection: local
 
-- name: delete backup files
+- name: Delete backup files
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: absent
   with_items: "{{backup_files.files|default([])}}"
 
-- name: take config backup
+- name: Take config backup
   become: "{{ can_become }}"
   register: result
   ansible.netcommon.cli_config:
@@ -42,7 +42,7 @@
     that:
       - result.changed == true
 
-- name: collect any backup files
+- name: Collect any backup files
   ansible.builtin.find:
     paths: "{{ role_path }}/backup"
     pattern: "{{ inventory_hostname_short }}_config*"
@@ -53,7 +53,7 @@
     that:
       - backup_files.files is defined
 
-- name: take configuration backup in custom filename and directory path
+- name: Take configuration backup in custom filename and directory path
   become: "{{ can_become }}"
   register: result
   ansible.netcommon.cli_config:
@@ -66,7 +66,7 @@
     that:
       - result.changed == true
 
-- name: check if the backup file-1 exist
+- name: Check if the backup file-1 exist
   ansible.builtin.find:
     paths: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}/backup.cfg"
   register: backup_file
@@ -76,7 +76,7 @@
     that:
       - backup_file.files is defined
 
-- name: take configuration backup in custom filename
+- name: Take configuration backup in custom filename
   become: "{{ can_become }}"
   register: result
   ansible.netcommon.cli_config:
@@ -88,7 +88,7 @@
     that:
       - result.changed == true
 
-- name: check if the backup file-2 exist
+- name: Check if the backup file-2 exist
   ansible.builtin.find:
     paths: "{{ role_path }}/backup/backup.cfg"
   register: backup_file
@@ -98,7 +98,7 @@
     that:
       - backup_file.files is defined
 
-- name: take configuration backup in custom path and default filename
+- name: Take configuration backup in custom path and default filename
   become: "{{ can_become }}"
   register: result
   ansible.netcommon.cli_config:
@@ -110,7 +110,7 @@
     that:
       - result.changed == true
 
-- name: check if the backup file-3 exist
+- name: Check if the backup file-3 exist
   ansible.builtin.find:
     paths: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
     pattern: "{{ inventory_hostname_short }}_config*"

--- a/tests/integration/targets/nxos_config/tests/cli_config/cli_basic.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli_config/cli_basic.yaml
@@ -2,12 +2,12 @@
 - ansible.builtin.debug:
     msg: START cli_config/cli_basic.yaml on connection={{ ansible_connection }}
 
-- name: setup
+- name: Setup
   ansible.netcommon.cli_config: &id002
     config: "interface loopback1\nno description\nno shutdown\n"
     diff_match: none
 
-- name: configure device with config
+- name: Configure device with config
   register: result
   ansible.netcommon.cli_config: &id001
     config: "{{ lookup('template', 'basic/config.j2') }}"
@@ -24,10 +24,10 @@
     that:
       - result.changed == false
 
-- name: remove config
+- name: Remove config
   ansible.netcommon.cli_config: *id002
 
-- name: configure device with config
+- name: Configure device with config
   register: result
   ansible.netcommon.cli_config:
     config: "{{ lookup('template', 'basic/config.j2') }}"
@@ -37,7 +37,7 @@
     that:
       - result.changed == true
 
-- name: teardown
+- name: Teardown
   ansible.netcommon.cli_config: *id002
 
 - ansible.builtin.debug:

--- a/tests/integration/targets/nxos_config/tests/cli_config/cli_block_replace.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli_config/cli_block_replace.yaml
@@ -2,12 +2,12 @@
 - ansible.builtin.debug:
     msg: START cli_config/cli_block_replace.yaml on connection={{ ansible_connection }}
 
-- name: setup - remove configuration
+- name: Setup - remove configuration
   ansible.netcommon.cli_config: &id002
     config: no ip access-list test
     diff_match: none
 
-- name: block replace
+- name: Block replace
   register: result
   ansible.netcommon.cli_config: &id001
     config: "{{ lookup('template', 'basic/configblock.j2') }}"
@@ -17,7 +17,7 @@
     that:
       - result.changed == true
 
-- name: block replace (Idempotence)
+- name: Block replace (idempotence)
   register: result
   ansible.netcommon.cli_config: *id001
 
@@ -25,7 +25,7 @@
     that:
       - result.changed == false
 
-- name: teardown
+- name: Teardown
   ansible.netcommon.cli_config: *id002
 
 - ansible.builtin.debug:

--- a/tests/integration/targets/nxos_config/tests/cli_config/cli_exact_match.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli_config/cli_exact_match.yaml
@@ -2,12 +2,12 @@
 - ansible.builtin.debug:
     msg: START cli_config/cli_exact_match.yaml on connection={{ ansible_connection }}
 
-- name: setup - remove configuration
+- name: Setup - remove configuration
   ansible.netcommon.cli_config:
     config: "{{ lookup('template', 'basic/setupexact.j2') }}"
     diff_match: none
 
-- name: configure using exact match
+- name: Configure using exact match
   register: result
   ansible.netcommon.cli_config:
     config: "{{ lookup('template', 'basic/configexact1.j2') }}"
@@ -17,7 +17,7 @@
     that:
       - result.changed == true
 
-- name: check using exact match
+- name: Check using exact match
   register: result
   ansible.netcommon.cli_config:
     config: "{{ lookup('template', 'basic/configexact2.j2') }}"
@@ -26,7 +26,7 @@
     that:
       - result.changed == false
 
-- name: teardown
+- name: Teardown
   ansible.netcommon.cli_config:
     config: no ip access-list test
     diff_match: none

--- a/tests/integration/targets/nxos_config/tests/cli_config/cli_strict_match.yaml
+++ b/tests/integration/targets/nxos_config/tests/cli_config/cli_strict_match.yaml
@@ -2,12 +2,12 @@
 - ansible.builtin.debug:
     msg: START cli_config/cli_strict_match.yaml on connection={{ ansible_connection }}
 
-- name: setup - remove configuration
+- name: Setup - remove configuration
   ansible.netcommon.cli_config:
     config: "{{ lookup('template', 'basic/setupstrict.j2') }}"
     diff_match: none
 
-- name: configure using strict match
+- name: Configure using strict match
   register: result
   ansible.netcommon.cli_config:
     config: "{{ lookup('template', 'basic/configstrict1.j2') }}"
@@ -18,7 +18,7 @@
     that:
       - result.changed == true
 
-- name: teardown
+- name: Teardown
   ansible.netcommon.cli_config:
     config: no ip access-list test
     diff_match: none

--- a/tests/integration/targets/nxos_config/tests/common/backup.yaml
+++ b/tests/integration/targets/nxos_config/tests/common/backup.yaml
@@ -6,7 +6,7 @@
   ansible.builtin.set_fact:
     intname: "{{ nxos_int1 }}"
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     commands:
       - no description
@@ -15,20 +15,20 @@
       - interface {{ intname }}
     match: none
 
-- name: collect any backup files
+- name: Collect any backup files
   ansible.builtin.find: &id001
     paths: "{{ role_path }}/backup"
     pattern: "{{ inventory_hostname_short }}_config*"
   connection: local
   register: backup_files
 
-- name: delete backup files
+- name: Delete backup files
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: absent
   with_items: "{{backup_files.files|default([])}}"
 
-- name: configure device with config
+- name: Configure device with config
   register: result
   cisco.nxos.nxos_config:
     commands:
@@ -43,7 +43,7 @@
       - result.changed == true
       - result.updates is defined
 
-- name: collect any backup files
+- name: Collect any backup files
   ansible.builtin.find: *id001
   connection: local
   register: backup_files
@@ -52,7 +52,7 @@
     that:
       - backup_files.files is defined
 
-- name: delete configurable backup file path
+- name: Delete configurable backup file path
   ansible.builtin.file:
     path: "{{ item }}"
     state: absent
@@ -60,7 +60,7 @@
     - "{{ role_path }}/backup_test_dir/"
     - "{{ role_path }}/backup/backup.cfg"
 
-- name: take configuration backup in custom filename and directory path
+- name: Take configuration backup in custom filename and directory path
   register: result
   cisco.nxos.nxos_config:
     backup: true
@@ -72,7 +72,7 @@
     that:
       - result.changed == true
 
-- name: check if the backup file-1 exist
+- name: Check if the backup file-1 exist
   ansible.builtin.find:
     paths: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}/backup.cfg"
   register: backup_file
@@ -82,7 +82,7 @@
     that:
       - backup_file.files is defined
 
-- name: take configuration backup in custom filename
+- name: Take configuration backup in custom filename
   register: result
   cisco.nxos.nxos_config:
     backup: true
@@ -93,7 +93,7 @@
     that:
       - result.changed == true
 
-- name: check if the backup file-2 exist
+- name: Check if the backup file-2 exist
   ansible.builtin.find:
     paths: "{{ role_path }}/backup/backup.cfg"
   register: backup_file
@@ -103,7 +103,7 @@
     that:
       - backup_file.files is defined
 
-- name: take configuration backup in custom path and default filename
+- name: Take configuration backup in custom path and default filename
   register: result
   cisco.nxos.nxos_config:
     backup: true
@@ -114,7 +114,7 @@
     that:
       - result.changed == true
 
-- name: check if the backup file-3 exist
+- name: Check if the backup file-3 exist
   ansible.builtin.find:
     paths: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
     pattern: "{{ inventory_hostname_short }}_config*"

--- a/tests/integration/targets/nxos_config/tests/common/defaults.yaml
+++ b/tests/integration/targets/nxos_config/tests/common/defaults.yaml
@@ -6,7 +6,7 @@
   ansible.builtin.set_fact:
     intname: "{{ nxos_int1 }}"
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     commands:
       - no description
@@ -15,7 +15,7 @@
       - interface {{ intname }}
     match: none
 
-- name: configure device with defaults included
+- name: Configure device with defaults included
   register: result
   cisco.nxos.nxos_config:
     commands:
@@ -33,7 +33,7 @@
       - result.changed == true
       - result.updates is defined
 
-- name: check device with defaults included
+- name: Check device with defaults included
   register: result
   cisco.nxos.nxos_config:
     commands:

--- a/tests/integration/targets/nxos_config/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_config/tests/common/sanity.yaml
@@ -2,12 +2,12 @@
 - ansible.builtin.debug:
     msg: START common/sanity.yaml on connection={{ ansible_connection }}
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     lines: ip access-list test
     match: none
 
-- name: nxos_config sanity test
+- name: Nxos_config sanity test
   cisco.nxos.nxos_config:
     lines:
       - 10 permit ip 192.0.2.1/32 any log
@@ -19,7 +19,7 @@
     before: no ip access-list test
     match: exact
 
-- name: nxos_config sanity test - replace block
+- name: Nxos_config sanity test - replace block
   cisco.nxos.nxos_config:
     lines:
       - 10 permit ip 192.0.2.1/32 any log
@@ -30,7 +30,7 @@
     before: no ip access-list test
     replace: block
 
-- name: teardown
+- name: Teardown
   cisco.nxos.nxos_config:
     lines: no ip access-list test
     match: none
@@ -38,18 +38,18 @@
 - ansible.builtin.debug:
     msg: Verify https://github.com/ansible/ansible/issues/50635
 
-- name: PUT INTERFACE INTO DEFAULT STATE
+- name: Put interface into default state
   cisco.nxos.nxos_config:
     lines:
       - default interface {{ nxos_int1 }}
 
-- name: MAKE INTERFACE A SWITCHPORT
+- name: Make interface a switchport
   cisco.nxos.nxos_config:
     lines:
       - switchport
     parents: interface {{ nxos_int1 }}
 
-- name: CONFIGURE EDGE TRUNK TYPE
+- name: Configure edge trunk type
   register: result
   cisco.nxos.nxos_config: &id001
     lines:
@@ -62,7 +62,7 @@
     that:
       - result.changed == true
 
-- name: IDEMPOTENCE CHECK
+- name: Idempotence check
   register: result
   cisco.nxos.nxos_config: *id001
 

--- a/tests/integration/targets/nxos_config/tests/common/save.yaml
+++ b/tests/integration/targets/nxos_config/tests/common/save.yaml
@@ -6,7 +6,7 @@
   ansible.builtin.set_fact:
     intname: "{{ nxos_int1 }}"
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     commands:
       - no description
@@ -15,7 +15,7 @@
       - interface {{ intname }}
     match: none
 
-- name: save config
+- name: Save config
   register: result
   cisco.nxos.nxos_config:
     save_when: always
@@ -24,7 +24,7 @@
     that:
       - result.changed == true
 
-- name: save should always run
+- name: Save should always run
   register: result
   cisco.nxos.nxos_config:
     save_when: always

--- a/tests/integration/targets/nxos_config/tests/common/src_basic.yaml
+++ b/tests/integration/targets/nxos_config/tests/common/src_basic.yaml
@@ -6,7 +6,7 @@
   ansible.builtin.set_fact:
     intname: loopback1
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     commands:
       - no description
@@ -15,7 +15,7 @@
       - interface {{ intname }}
     match: none
 
-- name: configure device with config
+- name: Configure device with config
   register: result
   cisco.nxos.nxos_config:
     src: basic/config.j2
@@ -26,7 +26,7 @@
       - result.changed == true
       - result.updates is defined
 
-- name: check device with config
+- name: Check device with config
   register: result
   cisco.nxos.nxos_config:
     src: basic/config.j2

--- a/tests/integration/targets/nxos_config/tests/common/src_invalid.yaml
+++ b/tests/integration/targets/nxos_config/tests/common/src_invalid.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START common/src_invalid.yaml on connection={{ ansible_connection }}
 
-- name: configure with invalid src
+- name: Configure with invalid src
   register: result
   ignore_errors: true
   cisco.nxos.nxos_config:

--- a/tests/integration/targets/nxos_config/tests/common/src_match_none.yaml
+++ b/tests/integration/targets/nxos_config/tests/common/src_match_none.yaml
@@ -6,7 +6,7 @@
   ansible.builtin.set_fact:
     intname: "{{ nxos_int1 }}"
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     commands:
       - no description
@@ -15,7 +15,7 @@
       - interface {{ intname }}
     match: none
 
-- name: configure device with config
+- name: Configure device with config
   register: result
   cisco.nxos.nxos_config:
     commands:
@@ -31,7 +31,7 @@
       - result.changed == true
       - result.updates is defined
 
-- name: check device with config
+- name: Check device with config
   register: result
   cisco.nxos.nxos_config:
     commands:

--- a/tests/integration/targets/nxos_config/tests/common/sublevel_block.yaml
+++ b/tests/integration/targets/nxos_config/tests/common/sublevel_block.yaml
@@ -2,13 +2,13 @@
 - ansible.builtin.debug:
     msg: START common/sublevel_block.yaml on connection={{ ansible_connection }}
 
-- name: setup
+- name: Setup
   ignore_errors: true
   cisco.nxos.nxos_config: &id001
     lines: no ip access-list test
     match: none
 
-- name: configure sub level command using block replace
+- name: Configure sub level command using block replace
   register: result
   cisco.nxos.nxos_config:
     lines:
@@ -28,7 +28,7 @@
       - "'30 permit ip 192.0.2.3/32 any log' in result.updates"
       - "'40 permit ip 192.0.2.4/32 any log' in result.updates"
 
-- name: check sub level command using block replace
+- name: Check sub level command using block replace
   register: result
   cisco.nxos.nxos_config:
     lines:
@@ -43,7 +43,7 @@
     that:
       - result.changed == false
 
-- name: teardown
+- name: Teardown
   cisco.nxos.nxos_config: *id001
 
 - ansible.builtin.debug:

--- a/tests/integration/targets/nxos_config/tests/common/toplevel.yaml
+++ b/tests/integration/targets/nxos_config/tests/common/toplevel.yaml
@@ -2,12 +2,12 @@
 - ansible.builtin.debug:
     msg: START common/toplevel.yaml on connection={{ ansible_connection }}
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     lines: hostname switch
     match: none
 
-- name: configure top level command
+- name: Configure top level command
   register: result
   cisco.nxos.nxos_config:
     lines: hostname foo
@@ -17,7 +17,7 @@
       - result.changed == true
       - "'hostname foo' in result.updates"
 
-- name: configure top level command idempotent check
+- name: Configure top level command idempotent check
   register: result
   cisco.nxos.nxos_config:
     lines: hostname foo
@@ -26,7 +26,7 @@
     that:
       - result.changed == false
 
-- name: teardown
+- name: Teardown
   cisco.nxos.nxos_config:
     lines: hostname switch
     match: none

--- a/tests/integration/targets/nxos_config/tests/common/toplevel_nonidempotent.yaml
+++ b/tests/integration/targets/nxos_config/tests/common/toplevel_nonidempotent.yaml
@@ -2,12 +2,12 @@
 - ansible.builtin.debug:
     msg: START common/nonidempotent.yaml on connection={{ ansible_connection }}
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     lines: hostname switch
     match: none
 
-- name: configure top level command
+- name: Configure top level command
   register: result
   cisco.nxos.nxos_config:
     lines: hostname foo
@@ -18,7 +18,7 @@
       - result.changed == true
       - "'hostname foo' in result.updates"
 
-- name: configure top level command idempotent check
+- name: Configure top level command idempotent check
   register: result
   cisco.nxos.nxos_config:
     lines: hostname foo
@@ -28,7 +28,7 @@
     that:
       - result.changed == true
 
-- name: teardown
+- name: Teardown
   cisco.nxos.nxos_config:
     lines: hostname switch
     match: none

--- a/tests/integration/targets/nxos_config/tests/nxapi/multilevel.yaml
+++ b/tests/integration/targets/nxos_config/tests/nxapi/multilevel.yaml
@@ -2,12 +2,12 @@
 - ansible.builtin.debug:
     msg: START nxapi/mulitlevel.yaml
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     lines: feature bgp
     match: none
 
-- name: configure multi level command
+- name: Configure multi level command
   register: result
   cisco.nxos.nxos_config:
     lines: maximum-paths 14
@@ -22,7 +22,7 @@
       - "'address-family ipv4 unicast' in result.updates"
       - "'maximum-paths 14' in result.updates"
 
-- name: test multi level command
+- name: Test multi level command
   register: result
   cisco.nxos.nxos_config:
     lines: maximum-paths 14
@@ -34,7 +34,7 @@
     that:
       - result.changed == false
 
-- name: teardown
+- name: Teardown
   cisco.nxos.nxos_config:
     lines: no feature bgp
     match: none

--- a/tests/integration/targets/nxos_config/tests/nxapi/sublevel.yaml
+++ b/tests/integration/targets/nxos_config/tests/nxapi/sublevel.yaml
@@ -2,13 +2,13 @@
 - ansible.builtin.debug:
     msg: START nxapi/sublevel.yaml
 
-- name: setup
+- name: Setup
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines: no ip access-list test
     match: none
 
-- name: configure sub level command
+- name: Configure sub level command
   register: result
   cisco.nxos.nxos_config:
     lines: 10 permit ip any any log
@@ -20,7 +20,7 @@
       - "'ip access-list test' in result.updates"
       - "'10 permit ip any any log' in result.updates"
 
-- name: configure sub level command idempotent check
+- name: Configure sub level command idempotent check
   register: result
   cisco.nxos.nxos_config:
     lines: 10 permit ip any any log
@@ -30,7 +30,7 @@
     that:
       - result.changed == false
 
-- name: teardown
+- name: Teardown
   cisco.nxos.nxos_config:
     lines: no ip access-list test
     match: none

--- a/tests/integration/targets/nxos_config/tests/nxapi/sublevel_exact.yaml
+++ b/tests/integration/targets/nxos_config/tests/nxapi/sublevel_exact.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START nxapi/sublevel_exact.yaml
 
-- name: setup
+- name: Setup
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines:
@@ -14,7 +14,7 @@
     parents: ip access-list test
     match: none
 
-- name: configure sub level command using exact match
+- name: Configure sub level command using exact match
   register: result
   cisco.nxos.nxos_config:
     lines:
@@ -37,7 +37,7 @@
       - "'40 permit ip 192.0.2.4/32 any log' in result.updates"
       - "'50 permit ip 192.0.2.5/32 any log' not in result.updates"
 
-- name: check sub level command using exact match
+- name: Check sub level command using exact match
   register: result
   cisco.nxos.nxos_config:
     lines:
@@ -52,7 +52,7 @@
     that:
       - result.changed == false
 
-- name: teardown
+- name: Teardown
   cisco.nxos.nxos_config:
     lines: no ip access-list test
     match: none

--- a/tests/integration/targets/nxos_config/tests/nxapi/sublevel_strict.yaml
+++ b/tests/integration/targets/nxos_config/tests/nxapi/sublevel_strict.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START nxapi/sublevel_strict.yaml
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     lines:
       - 10 permit ip 192.0.2.1/32 any log
@@ -13,7 +13,7 @@
     parents: ip access-list test
     match: none
 
-- name: configure sub level command using strict match
+- name: Configure sub level command using strict match
   register: result
   cisco.nxos.nxos_config:
     lines:
@@ -36,7 +36,7 @@
       - "'40 permit ip 192.0.2.4/32 any log' in result.updates"
       - "'50 permit ip 192.0.2.5/32 any log' not in result.updates"
 
-- name: check sub level command using strict match
+- name: Check sub level command using strict match
   register: result
   cisco.nxos.nxos_config:
     lines:
@@ -51,7 +51,7 @@
     that:
       - result.changed == false
 
-- name: teardown
+- name: Teardown
   cisco.nxos.nxos_config:
     lines: no ip access-list test
     match: none

--- a/tests/integration/targets/nxos_config/tests/nxapi/toplevel_after.yaml
+++ b/tests/integration/targets/nxos_config/tests/nxapi/toplevel_after.yaml
@@ -2,14 +2,14 @@
 - ansible.builtin.debug:
     msg: START nxapi/toplevel_after.yaml
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     lines:
       - snmp-server contact ansible
       - hostname switch
     match: none
 
-- name: configure top level command with before
+- name: Configure top level command with before
   register: result
   cisco.nxos.nxos_config:
     lines: hostname foo
@@ -21,7 +21,7 @@
       - "'hostname foo' in result.updates"
       - "'snmp-server contact bar' in result.updates"
 
-- name: configure top level command with before idempotent check
+- name: Configure top level command with before idempotent check
   register: result
   cisco.nxos.nxos_config:
     lines: hostname foo
@@ -31,7 +31,7 @@
     that:
       - result.changed == false
 
-- name: teardown
+- name: Teardown
   cisco.nxos.nxos_config:
     lines:
       - no snmp-server contact ansible

--- a/tests/integration/targets/nxos_config/tests/nxapi/toplevel_before.yaml
+++ b/tests/integration/targets/nxos_config/tests/nxapi/toplevel_before.yaml
@@ -2,14 +2,14 @@
 - ansible.builtin.debug:
     msg: START nxapi/toplevel_before.yaml
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     lines:
       - snmp-server contact ansible
       - hostname switch
     match: none
 
-- name: configure top level command with before
+- name: Configure top level command with before
   register: result
   cisco.nxos.nxos_config:
     lines: hostname foo
@@ -21,7 +21,7 @@
       - "'hostname foo' in result.updates"
       - "'snmp-server contact bar' in result.updates"
 
-- name: configure top level command with before idempotent check
+- name: Configure top level command with before idempotent check
   register: result
   cisco.nxos.nxos_config:
     lines: hostname foo
@@ -31,7 +31,7 @@
     that:
       - result.changed == false
 
-- name: teardown
+- name: Teardown
   cisco.nxos.nxos_config:
     lines:
       - no snmp-server contact ansible

--- a/tests/integration/targets/nxos_config/tests/redirection/cli/shortname.yaml
+++ b/tests/integration/targets/nxos_config/tests/redirection/cli/shortname.yaml
@@ -13,7 +13,7 @@
       - result.changed == true
       - result.updates is defined
 
-- name: use module alias to take configuration backup
+- name: Use module alias to take configuration backup
   register: result
   cisco.nxos.config:
     backup: true
@@ -25,7 +25,7 @@
     that:
       - result.changed == true
 
-- name: check if the backup file-4 exist
+- name: Check if the backup file-4 exist
   ansible.builtin.find:
     paths: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}/backup_with_alias.cfg"
   register: backup_file

--- a/tests/integration/targets/nxos_devicealias/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_devicealias/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_devicealias/tasks/main.yaml
+++ b/tests/integration/targets/nxos_devicealias/tasks/main.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Check platform type and skip if not MDS
+- name: Check platform type and skip if not mds
   register: result
   cisco.nxos.nxos_command:
     commands: show version | grep MDS
@@ -8,12 +8,12 @@
   ansible.builtin.set_fact:
     skip_test: false
 
-- name: Set skip_test flag to true if not MDS
+- name: Set skip_test flag to true if not mds
   ansible.builtin.set_fact:
     skip_test: true
   when: result.stdout[0] is not search('MDS')
 
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags: cli
   when: not skip_test

--- a/tests/integration/targets/nxos_devicealias/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_devicealias/tests/common/sanity.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }} nxos_devicealias sanity test
 
-- name: Setup - Remove device alias if configured
+- name: Setup - remove device alias if configured
   ignore_errors: true
   cisco.nxos.nxos_devicealias: &id002
     da:
@@ -32,7 +32,7 @@
           - result.commands == ["terminal dont-ask", "device-alias database", "device-alias name ansible_test1_add pwwn 57:bb:cc:dd:ee:ff:11:67", "device-alias name
             ansible_test2_add pwwn 65:22:21:20:19:18:1a:0d", "device-alias commit", "no terminal dont-ask"]
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_devicealias: *id001
 

--- a/tests/integration/targets/nxos_evpn_global/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_evpn_global/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_evpn_global/tasks/main.yaml
+++ b/tests/integration/targets/nxos_evpn_global/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_evpn_global/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_evpn_global/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_evpn_global/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_evpn_global/tests/common/sanity.yaml
@@ -30,7 +30,7 @@
         that:
           - result.changed == true
 
-    - name: CHECK IDEMPOTENCE - enable nv overlay evpn
+    - name: Check idempotence - enable nv overlay evpn
       register: result
       cisco.nxos.nxos_evpn_global: *id001
 
@@ -45,7 +45,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: CHECK DEMPOTENCE - Disable nv overlay evpn
+    - name: Check dempotence - disable nv overlay evpn
       register: result
       cisco.nxos.nxos_evpn_global: *id003
 
@@ -55,11 +55,11 @@
     - ansible.builtin.debug:
         msg: connection={{ ansible_connection }} nxos_evpn_global sanity test - FALURE ENCOUNTERED
   always:
-    - name: Cleanup - Disable nv overlay evpn
+    - name: Cleanup - disable nv overlay evpn
       ignore_errors: true
       cisco.nxos.nxos_config: *id005
 
-    - name: Cleanup - Disable feature nv overlay
+    - name: Cleanup - disable feature nv overlay
       ignore_errors: true
       cisco.nxos.nxos_feature: *id006
 

--- a/tests/integration/targets/nxos_evpn_vni/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_evpn_vni/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_evpn_vni/tasks/main.yaml
+++ b/tests/integration/targets/nxos_evpn_vni/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_evpn_vni/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_evpn_vni/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_evpn_vni/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_evpn_vni/tests/common/sanity.yaml
@@ -14,7 +14,7 @@
     match: none
 
 - block:
-    - name: Enable feature BGP
+    - name: Enable feature bgp
       cisco.nxos.nxos_feature:
         feature: bgp
         state: enabled
@@ -42,7 +42,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_evpn_vni: *id001
 
@@ -60,7 +60,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_evpn_vni: *id003
 
@@ -76,13 +76,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_evpn_vni: *id005
 
     - ansible.builtin.assert: *id004
 
-    - name: remove nxos_evpn_vni
+    - name: Remove nxos_evpn_vni
       register: result
       cisco.nxos.nxos_evpn_vni: &id006
         vni: 6000
@@ -90,7 +90,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_evpn_vni: *id006
 

--- a/tests/integration/targets/nxos_facts/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_facts/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_facts/tasks/main.yaml
+++ b/tests/integration/targets/nxos_facts/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_facts/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_facts/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_facts/tests/common/all_facts.yaml
+++ b/tests/integration/targets/nxos_facts/tests/common/all_facts.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }}/all_facts.yaml
 
-- name: test getting all facts
+- name: Test getting all facts
   register: result
   cisco.nxos.nxos_facts:
     gather_subset:

--- a/tests/integration/targets/nxos_facts/tests/common/default_facts.yaml
+++ b/tests/integration/targets/nxos_facts/tests/common/default_facts.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }}/default_facts.yaml
 
-- name: test getting default facts
+- name: Test getting default facts
   register: result
   cisco.nxos.nxos_facts:
 

--- a/tests/integration/targets/nxos_facts/tests/common/invalid_subset.yaml
+++ b/tests/integration/targets/nxos_facts/tests/common/invalid_subset.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }}/invalid_subset.yaml
 
-- name: test invalid subset (foobar)
+- name: Test invalid subset (foobar)
   register: result
   ignore_errors: true
   cisco.nxos.nxos_facts:

--- a/tests/integration/targets/nxos_facts/tests/common/not_hardware.yaml
+++ b/tests/integration/targets/nxos_facts/tests/common/not_hardware.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }}/not_hardware_facts.yaml
 
-- name: test not hardware
+- name: Test not hardware
   register: result
   cisco.nxos.nxos_facts:
     gather_subset:

--- a/tests/integration/targets/nxos_facts/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_facts/tests/common/sanity.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }} nxos_facts sanity test
 
-- name: nxos_facts gather hardware facts
+- name: Nxos_facts gather hardware facts
   register: result
   cisco.nxos.nxos_facts:
     gather_subset: hardware
@@ -17,7 +17,7 @@
       - result.ansible_facts.ansible_net_memfree_mb > 1
       - result.ansible_facts.ansible_net_memtotal_mb > 1
 
-- name: nxos_facts gather config facts
+- name: Nxos_facts gather config facts
   register: result
   cisco.nxos.nxos_facts:
     gather_subset: config
@@ -30,7 +30,7 @@
       - "'interfaces' not in result.ansible_facts.ansible_net_gather_subset"
       - result.ansible_facts.ansible_net_config is defined
 
-- name: nxos_facts gather config and hardware facts
+- name: Nxos_facts gather config and hardware facts
   register: result
   cisco.nxos.nxos_facts:
     gather_subset:
@@ -48,7 +48,7 @@
       - result.ansible_facts.ansible_net_memfree_mb > 1
       - result.ansible_facts.ansible_net_memtotal_mb > 1
 
-- name: nxos_facts gather features facts
+- name: Nxos_facts gather features facts
   register: result
   cisco.nxos.nxos_facts:
     gather_subset: features

--- a/tests/integration/targets/nxos_feature/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_feature/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_feature/tasks/main.yaml
+++ b/tests/integration/targets/nxos_feature/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_feature/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_feature/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_feature/tests/common/configure.yaml
+++ b/tests/integration/targets/nxos_feature/tests/common/configure.yaml
@@ -2,14 +2,14 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }}/configure.yaml
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config: &teardown
     lines:
       - no feature bgp
       - no feature fabric forwarding
     match: none
 
-- name: enable bgp
+- name: Enable bgp
   register: result
   cisco.nxos.nxos_feature:
     feature: bgp
@@ -19,7 +19,7 @@
     that:
       - result.changed == true
 
-- name: verify bgp
+- name: Verify bgp
   register: result
   cisco.nxos.nxos_feature:
     feature: bgp
@@ -29,7 +29,7 @@
     that:
       - result.changed == false
 
-- name: disable bgp
+- name: Disable bgp
   register: result
   cisco.nxos.nxos_feature:
     feature: bgp
@@ -39,7 +39,7 @@
     that:
       - result.changed == true
 
-- name: verify bgp
+- name: Verify bgp
   register: result
   cisco.nxos.nxos_feature:
     feature: bgp
@@ -49,7 +49,7 @@
     that:
       - result.changed == false
 
-- name: verify fabric forwarding
+- name: Verify fabric forwarding
   register: result
   cisco.nxos.nxos_feature:
     feature: fabric forwarding
@@ -60,7 +60,7 @@
       - result.changed == True
       - "'feature fabric forwarding' in result.commands"
 
-- name: verify fabric forwarding (IDEMPOTENT)
+- name: Verify fabric forwarding (idempotent)
   register: result
   cisco.nxos.nxos_feature:
     feature: fabric forwarding
@@ -70,7 +70,7 @@
     that:
       - result.changed == False
 
-- name: verify fabric forwarding disable
+- name: Verify fabric forwarding disable
   register: result
   cisco.nxos.nxos_feature:
     feature: fabric forwarding
@@ -81,7 +81,7 @@
       - result.changed == True
       - "'no feature fabric forwarding' in result.commands"
 
-- name: verify fabric forwarding disabled (IDEMPOTENT)
+- name: Verify fabric forwarding disabled (idempotent)
   register: result
   cisco.nxos.nxos_feature:
     feature: fabric forwarding
@@ -91,7 +91,7 @@
     that:
       - result.changed == False
 
-- name: teardown
+- name: Teardown
   cisco.nxos.nxos_config: *teardown
 
 - ansible.builtin.debug:

--- a/tests/integration/targets/nxos_feature/tests/common/invalid.yaml
+++ b/tests/integration/targets/nxos_feature/tests/common/invalid.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }}/invalid.yaml
 
-- name: configure invalid feature name
+- name: Configure invalid feature name
   register: result
   ignore_errors: true
   cisco.nxos.nxos_feature:

--- a/tests/integration/targets/nxos_file_copy/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_file_copy/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_file_copy/tasks/main.yaml
+++ b/tests/integration/targets/nxos_file_copy/tasks/main.yaml
@@ -4,7 +4,7 @@
     commands: show interface mgmt 0 | json
   register: result
 
-- name: Store mgmt interface IP address
+- name: Store mgmt interface ip address
   ansible.builtin.set_fact:
     mgmt0_ip: "{{ result['stdout'][0]['TABLE_interface']['ROW_interface']['eth_ip_addr'] }}"
 
@@ -20,12 +20,12 @@
     configured_password: "{{ temp_passwd }}"
 
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
 
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_file_copy/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_file_copy/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_file_copy/tests/cli/input_validation.yaml
+++ b/tests/integration/targets/nxos_file_copy/tests/cli/input_validation.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START nxos_file_copy input_validation test
 
-- name: Input Validation - param should be type <path>
+- name: Input validation - param should be type <path>
   register: result
   ignore_errors: true
   cisco.nxos.nxos_file_copy:
@@ -13,7 +13,7 @@
     that:
       - not result is search('argument remote_file is of type')
 
-- name: Input Validation - param should be type <int>
+- name: Input validation - param should be type <int>
   register: result
   ignore_errors: true
   cisco.nxos.nxos_file_copy:
@@ -23,7 +23,7 @@
     that:
       - result is search("argument 'file_pull_timeout' is of type .* and we were unable to convert to int")
 
-- name: Input Validation - param should be type <bool>
+- name: Input validation - param should be type <bool>
   register: result
   ignore_errors: true
   cisco.nxos.nxos_file_copy:
@@ -33,7 +33,7 @@
     that:
       - result is search("argument 'file_pull' is of type .* and we were unable to convert to bool")
 
-- name: Input Validation - param <file_pull> <remote_file> dependency
+- name: Input validation - param <file_pull> <remote_file> dependency
   register: result
   ignore_errors: true
   cisco.nxos.nxos_file_copy:
@@ -43,7 +43,7 @@
     that:
       - result is search("file_pull is True but all of the following are missing: remote_file, remote_scp_server")
 
-- name: Input Validation - param <file_pull> <remote_scp_server> dependency
+- name: Input validation - param <file_pull> <remote_scp_server> dependency
   register: result
   ignore_errors: true
   cisco.nxos.nxos_file_copy:
@@ -54,7 +54,7 @@
     that:
       - result is search("file_pull is True but all of the following are missing: remote_file, remote_scp_server")
 
-- name: Input Validation - remote_scp_server params together
+- name: Input validation - remote_scp_server params together
   register: result
   ignore_errors: true
   cisco.nxos.nxos_file_copy:
@@ -64,7 +64,7 @@
     that:
       - result is search('parameters are required together: remote_scp_server, remote_scp_server_user')
 
-- name: Input Validation - param <file_pull_protocol> should only accept strings, which are included in choices
+- name: Input validation - param <file_pull_protocol> should only accept strings, which are included in choices
   register: result
   ignore_errors: true
   cisco.nxos.nxos_file_copy:

--- a/tests/integration/targets/nxos_file_copy/tests/cli/negative.yaml
+++ b/tests/integration/targets/nxos_file_copy/tests/cli/negative.yaml
@@ -20,7 +20,7 @@
     that:
       - result is search('Invalid nxos filesystem invalid_media_type:')
 
-- name: Attempt to copy source file that does not exist on Ansible controller
+- name: Attempt to copy source file that does not exist on ansible controller
   register: result
   ignore_errors: true
   cisco.nxos.nxos_file_copy:

--- a/tests/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
+++ b/tests/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
@@ -11,7 +11,7 @@
   ansible.builtin.set_fact:
     sftp_root_dir: "{% if major_version is version('9.2', 'ge') %}/bootflash{% else %}/{% endif %}"
 
-- name: Setup - Remove existing file
+- name: Setup - remove existing file
   ignore_errors: true
   cisco.nxos.nxos_command: &id002
     commands:
@@ -23,17 +23,17 @@
       - rmdir dir1/dir2
       - rmdir dir1
 
-- name: Setup - Turn on feature scp-server
+- name: Setup - turn on feature scp-server
   cisco.nxos.nxos_feature:
     feature: scp-server
     state: enabled
 
-- name: Setup - Turn on feature sftp-server
+- name: Setup - turn on feature sftp-server
   cisco.nxos.nxos_feature:
     feature: sftp-server
     state: enabled
 
-- name: Setup - Backup admin password if ansible_user is not admin
+- name: Setup - backup admin password if ansible_user is not admin
   cisco.nxos.nxos_command:
     commands:
       - command: show running-config | include "username admin password"
@@ -41,14 +41,14 @@
   no_log: true
   when: ansible_user != "admin"
 
-- name: Setup - Change admin password if ansible_user is not admin
+- name: Setup - change admin password if ansible_user is not admin
   cisco.nxos.nxos_user:
     name: admin
     configured_password: "{{ temp_passwd }}"
   when: ansible_user != "admin"
 
 - block:
-    - name: Copy {{ test_source_file }} file from Ansible controller to bootflash
+    - name: Copy {{ test_source_file }} file from ansible controller to bootflash
       register: result
       cisco.nxos.nxos_file_copy: &id001
         local_file: "{{ role_path }}/fixtures/{{ test_source_file }}"
@@ -64,7 +64,7 @@
 
           - "'Sent: File copied to remote device.' in result.transfer_status"
 
-    - name: Idempotence - Copy {{ test_source_file }} file from Ansible controller to bootflash
+    - name: Idempotence - copy {{ test_source_file }} file from ansible controller to bootflash
       register: result
       cisco.nxos.nxos_file_copy: *id001
 
@@ -72,11 +72,11 @@
         that:
           - result.changed == false
 
-    - name: Setup - Remove existing file
+    - name: Setup - remove existing file
       register: result
       cisco.nxos.nxos_command: *id002
 
-    - name: Copy {{ test_source_file }} file from Ansible controller to bootflash renamed as {{ test_destination_file }}
+    - name: Copy {{ test_source_file }} file from ansible controller to bootflash renamed as {{ test_destination_file }}
       register: result
       cisco.nxos.nxos_file_copy: &id003
         local_file: "{{ role_path }}/fixtures/{{ test_source_file }}"
@@ -92,7 +92,7 @@
           - "'{{ test_destination_file }}' in result.remote_file"
           - "'Sent: File copied to remote device.' in result.transfer_status"
 
-    - name: Idempotence - Copy {{ test_source_file }} file from Ansible controller to bootflash renamed as {{ test_destination_file }}
+    - name: Idempotence - copy {{ test_source_file }} file from ansible controller to bootflash renamed as {{ test_destination_file }}
       register: result
       cisco.nxos.nxos_file_copy: *id003
 

--- a/tests/integration/targets/nxos_gir/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_gir/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_gir/tasks/main.yaml
+++ b/tests/integration/targets/nxos_gir/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_gir/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_gir/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_gir/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_gir/tests/common/sanity.yaml
@@ -30,7 +30,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_gir: *id001
 
@@ -46,7 +46,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_gir: *id003
 
@@ -59,7 +59,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_gir: *id005
 
@@ -73,7 +73,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_gir: *id006
 

--- a/tests/integration/targets/nxos_gir_profile_management/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_gir_profile_management/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_gir_profile_management/tasks/main.yaml
+++ b/tests/integration/targets/nxos_gir_profile_management/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_gir_profile_management/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_gir_profile_management/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_gir_profile_management/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_gir_profile_management/tests/common/sanity.yaml
@@ -2,19 +2,19 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }} nxos_gir_profile_management sanity test
 
-- name: Setup - Remove maintenace mode profiles
+- name: Setup - remove maintenace mode profiles
   ignore_errors: true
   cisco.nxos.nxos_gir_profile_management: &id005
     mode: maintenance
     state: absent
 
-- name: Setup - Remove normal mode profiles
+- name: Setup - remove normal mode profiles
   ignore_errors: true
   cisco.nxos.nxos_gir_profile_management: &id006
     mode: normal
     state: absent
 
-- name: Setup - Turn on feature eigrp
+- name: Setup - turn on feature eigrp
   ignore_errors: true
   cisco.nxos.nxos_feature:
     feature: eigrp
@@ -34,7 +34,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence - Create maintenace mode profile
+    - name: Check idempotence - create maintenace mode profile
       register: result
       cisco.nxos.nxos_gir_profile_management: *id001
 
@@ -53,7 +53,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence - Create normal mode profile
+    - name: Check idempotence - create normal mode profile
       register: result
       cisco.nxos.nxos_gir_profile_management: *id003
 
@@ -65,7 +65,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence - Remove maintenance mode profile
+    - name: Check idempotence - remove maintenance mode profile
       register: result
       cisco.nxos.nxos_gir_profile_management: *id005
 
@@ -77,7 +77,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence - Remove normal mode profile
+    - name: Check idempotence - remove normal mode profile
       register: result
       cisco.nxos.nxos_gir_profile_management: *id006
 

--- a/tests/integration/targets/nxos_hostname/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_hostname/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_hostname/tasks/main.yaml
+++ b/tests/integration/targets/nxos_hostname/tasks/main.yaml
@@ -14,12 +14,12 @@
   when: hname_result.stdout[0] != ""
 
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli.yaml
 
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_hostname/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_hostname/tasks/nxapi.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_hostname/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_hostname/tests/common/deleted.yaml
@@ -24,7 +24,7 @@
         that:
           - result['after'] == {}
 
-    - name: Delete hostname configuration (IDEMPOTENT)
+    - name: Delete hostname configuration (idempotent)
       cisco.nxos.nxos_hostname: *del
       register: result
 

--- a/tests/integration/targets/nxos_hostname/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_hostname/tests/common/merged.yaml
@@ -25,7 +25,7 @@
         that:
           - merged['after'] == result['after']
 
-    - name: Merge the provided configuration with the existing running configuration (IDEMPOTENT)
+    - name: Merge the provided configuration with the existing running configuration (idempotent)
       cisco.nxos.nxos_hostname: *id001
       register: result
 

--- a/tests/integration/targets/nxos_hostname/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_hostname/tests/common/overridden.yaml
@@ -26,7 +26,7 @@
         that:
           - merged['after'] == result['after']
 
-    - name: Override hostname configuration with provided configuration (IDEMPOTENT)
+    - name: Override hostname configuration with provided configuration (idempotent)
       cisco.nxos.nxos_hostname: *id001
       register: result
 

--- a/tests/integration/targets/nxos_hostname/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_hostname/tests/common/replaced.yaml
@@ -26,7 +26,7 @@
         that:
           - merged['after'] == result['after']
 
-    - name: Replace device configurations with provided configurations (IDEMPOTENT)
+    - name: Replace device configurations with provided configurations (idempotent)
       cisco.nxos.nxos_hostname: *id001
       register: result
 

--- a/tests/integration/targets/nxos_hsrp/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_hsrp/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_hsrp/tasks/main.yaml
+++ b/tests/integration/targets/nxos_hsrp/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
   always:
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_hsrp/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_hsrp/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_hsrp/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_hsrp/tests/common/sanity.yaml
@@ -16,7 +16,7 @@
         feature: hsrp
         state: enabled
 
-    - name: change int1 mode
+    - name: Change int1 mode
       cisco.nxos.nxos_config:
         commands:
           - no switchport
@@ -24,7 +24,7 @@
           - interface {{ intname1 }}
         match: none
 
-    - name: change int2 mode
+    - name: Change int2 mode
       cisco.nxos.nxos_config:
         commands:
           - no switchport
@@ -32,7 +32,7 @@
           - interface {{ intname2 }}
         match: none
 
-    - name: configure nxos_hsrp
+    - name: Configure nxos_hsrp
       register: result
       cisco.nxos.nxos_hsrp: &id001
         group: 1000
@@ -48,7 +48,7 @@
         that:
           - result.changed == true
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_hsrp: *id001
 
@@ -56,7 +56,7 @@
         that:
           - result.changed == false
 
-    - name: configure group 100
+    - name: Configure group 100
       register: result
       cisco.nxos.nxos_hsrp: &id003
         group: 100
@@ -70,13 +70,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_hsrp: *id003
 
     - ansible.builtin.assert: *id004
 
-    - name: change group 100
+    - name: Change group 100
       register: result
       cisco.nxos.nxos_hsrp: &id005
         group: 100
@@ -90,13 +90,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_hsrp: *id005
 
     - ansible.builtin.assert: *id004
 
-    - name: configure group 200
+    - name: Configure group 200
       register: result
       cisco.nxos.nxos_hsrp: &id006
         group: 200
@@ -108,13 +108,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_hsrp: *id006
 
     - ansible.builtin.assert: *id004
 
-    - name: change group 200
+    - name: Change group 200
       register: result
       cisco.nxos.nxos_hsrp: &id007
         group: 200
@@ -126,13 +126,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_hsrp: *id007
 
     - ansible.builtin.assert: *id004
 
-    - name: remove nxos_hsrp
+    - name: Remove nxos_hsrp
       register: result
       cisco.nxos.nxos_hsrp: &id008
         group: 1000
@@ -141,7 +141,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Remove Idempotence
+    - name: Remove idempotence
       register: result
       cisco.nxos.nxos_hsrp: *id008
 

--- a/tests/integration/targets/nxos_hsrp_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_hsrp_interfaces/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_hsrp_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/nxos_hsrp_interfaces/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_hsrp_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_hsrp_interfaces/tasks/nxapi.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_hsrp_interfaces/tests/common/_populate_config.yaml
+++ b/tests/integration/targets/nxos_hsrp_interfaces/tests/common/_populate_config.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Populate Config - 1
+- name: Populate config - 1
   cisco.nxos.nxos_config:
     lines:
       - "feature hsrp"
@@ -8,7 +8,7 @@
       - "  no switchport"
       - "  hsrp bfd"
 
-- name: Populate Config - 2
+- name: Populate config - 2
   cisco.nxos.nxos_config:
     lines:
       - "interface {{ nxos_int2 }}"

--- a/tests/integration/targets/nxos_hsrp_interfaces/tests/common/_remove_config.yaml
+++ b/tests/integration/targets/nxos_hsrp_interfaces/tests/common/_remove_config.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Remove Config
+- name: Remove config
   cisco.nxos.nxos_config:
     lines:
       - "no feature bfd"

--- a/tests/integration/targets/nxos_hsrp_interfaces/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_hsrp_interfaces/tests/common/deleted.yaml
@@ -16,7 +16,7 @@
 - block:
     - ansible.builtin.include_tasks: _remove_config.yaml
 
-    - name: setup2
+    - name: Setup2
       cisco.nxos.nxos_config:
         lines:
           - "feature bfd"
@@ -25,13 +25,13 @@
           - "  no switchport"
           - "  hsrp bfd"
 
-    - name: setup3
+    - name: Setup3
       cisco.nxos.nxos_config:
         lines:
           - "interface {{ test_int2 }}"
           - "  no switchport"
 
-    - name: deleted
+    - name: Deleted
       register: result
       cisco.nxos.nxos_hsrp_interfaces: &id001
         config:

--- a/tests/integration/targets/nxos_hsrp_interfaces/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_hsrp_interfaces/tests/common/merged.yaml
@@ -16,7 +16,7 @@
 - block:
     - ansible.builtin.include_tasks: _remove_config.yaml
 
-    - name: setup2
+    - name: Setup2
       cisco.nxos.nxos_config:
         lines:
           - "feature bfd"
@@ -25,7 +25,7 @@
           - "  no switchport"
           - "  hsrp bfd"
 
-    - name: setup3
+    - name: Setup3
       cisco.nxos.nxos_config:
         lines:
           - "interface {{ test_int2 }}"
@@ -52,7 +52,7 @@
           - "!min"
         gather_network_resources: hsrp_interfaces
 
-    - name: Idempotence - Merged
+    - name: Idempotence - merged
       register: result
       cisco.nxos.nxos_hsrp_interfaces: *id001
 

--- a/tests/integration/targets/nxos_hsrp_interfaces/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_hsrp_interfaces/tests/common/overridden.yaml
@@ -16,7 +16,7 @@
 - block:
     - ansible.builtin.include_tasks: _remove_config.yaml
 
-    - name: setup2
+    - name: Setup2
       cisco.nxos.nxos_config:
         lines:
           - "feature bfd"
@@ -24,7 +24,7 @@
           - "interface {{ test_int1 }}"
           - "  no switchport"
 
-    - name: setup3
+    - name: Setup3
       cisco.nxos.nxos_config:
         lines:
           - "interface {{ test_int2 }}"
@@ -46,7 +46,7 @@
           - result.commands[3] == 'hsrp bfd'
         msg: "Assert failed. 'result.commands': {{ result.commands }}"
 
-    - name: Idempotence - Overridden
+    - name: Idempotence - overridden
       register: result
       cisco.nxos.nxos_hsrp_interfaces: *id001
 

--- a/tests/integration/targets/nxos_hsrp_interfaces/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_hsrp_interfaces/tests/common/replaced.yaml
@@ -16,7 +16,7 @@
 - block:
     - ansible.builtin.include_tasks: _remove_config.yaml
 
-    - name: setup2
+    - name: Setup2
       cisco.nxos.nxos_config:
         lines:
           - "feature bfd"
@@ -25,7 +25,7 @@
           - "  no switchport"
           - "  hsrp bfd"
 
-    - name: setup3
+    - name: Setup3
       cisco.nxos.nxos_config:
         lines:
           - "interface {{ test_int2 }}"
@@ -45,7 +45,7 @@
           - "'no hsrp bfd' in result.commands"
         msg: "Assert failed. 'result.commands': {{ result.commands }}"
 
-    - name: Idempotence - Replaced
+    - name: Idempotence - replaced
       register: result
       cisco.nxos.nxos_hsrp_interfaces: *id001
 

--- a/tests/integration/targets/nxos_igmp/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_igmp/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_igmp/tasks/main.yaml
+++ b/tests/integration/targets/nxos_igmp/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_igmp/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_igmp/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_igmp/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_igmp/tests/common/sanity.yaml
@@ -20,7 +20,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence - Configure igmp interface with non-default values
+    - name: Check idempotence - configure igmp interface with non-default values
       register: result
       cisco.nxos.nxos_igmp: *id001
 
@@ -38,7 +38,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence - Configure igmp with defaults
+    - name: Check idempotence - configure igmp with defaults
       register: result
       cisco.nxos.nxos_igmp: *id003
 
@@ -55,7 +55,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence - Configure igmp with state default
+    - name: Check idempotence - configure igmp with state default
       register: result
       cisco.nxos.nxos_igmp: *id005
 

--- a/tests/integration/targets/nxos_igmp_interface/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_igmp_interface/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_igmp_interface/tasks/main.yaml
+++ b/tests/integration/targets/nxos_igmp_interface/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_igmp_interface/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_igmp_interface/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_igmp_interface/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_igmp_interface/tests/common/sanity.yaml
@@ -11,7 +11,7 @@
     restart: true
   when: platform is not match("N35")
 
-- name: Enable feature PIM
+- name: Enable feature pim
   ignore_errors: true
   cisco.nxos.nxos_feature:
     feature: pim
@@ -25,7 +25,7 @@
     match: none
 
 - block:
-    - name: put interface in L3 and enable PIM
+    - name: Put interface in l3 and enable pim
       cisco.nxos.nxos_config:
         commands:
           - no switchport
@@ -59,7 +59,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence - Configure igmp interface with non-default values
+    - name: Check idempotence - configure igmp interface with non-default values
       register: result
       cisco.nxos.nxos_igmp_interface: *id001
 
@@ -92,13 +92,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence - Configure igmp interface with some default values
+    - name: Check idempotence - configure igmp interface with some default values
       register: result
       cisco.nxos.nxos_igmp_interface: *id003
 
     - ansible.builtin.assert: *id004
 
-    - name: restart igmp
+    - name: Restart igmp
       cisco.nxos.nxos_igmp_interface:
         interface: "{{ intname }}"
         restart: "{{restart|default(omit)}}"
@@ -112,7 +112,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence - Configure igmp interface with default oif_ps
+    - name: Check idempotence - configure igmp interface with default oif_ps
       register: result
       cisco.nxos.nxos_igmp_interface: *id005
 
@@ -131,7 +131,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence - Configure igmp interface with oif_routemap
+    - name: Check idempotence - configure igmp interface with oif_routemap
       register: result
       cisco.nxos.nxos_igmp_interface: *id006
 
@@ -145,7 +145,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence - Configure igmp interface with default state
+    - name: Check idempotence - configure igmp interface with default state
       register: result
       cisco.nxos.nxos_igmp_interface: *id007
 
@@ -159,7 +159,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence - Configure igmp interface with absent state
+    - name: Check idempotence - configure igmp interface with absent state
       register: result
       cisco.nxos.nxos_igmp_interface: *id008
 
@@ -175,7 +175,7 @@
           - default interface {{ intname }}
         match: none
 
-    - name: Disable feature PIM
+    - name: Disable feature pim
       ignore_errors: true
       cisco.nxos.nxos_feature:
         feature: pim

--- a/tests/integration/targets/nxos_igmp_snooping/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_igmp_snooping/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_igmp_snooping/tasks/main.yaml
+++ b/tests/integration/targets/nxos_igmp_snooping/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_igmp_snooping/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_igmp_snooping/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_install_os/tasks/httpapi.yaml
+++ b/tests/integration/targets/nxos_install_os/tasks/httpapi.yaml
@@ -1,16 +1,16 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (ansible_connection=ansible.netcommon.httpapi)
+- name: Run test cases (ansible_connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_install_os/tasks/network_cli.yaml
+++ b/tests/integration/targets/nxos_install_os/tasks/network_cli.yaml
@@ -1,16 +1,16 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (ansible_connection=ansible.netcommon.network_cli)
+- name: Run test cases (ansible_connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_install_os/tasks/upgrade/copy_kick_system_images.yaml
+++ b/tests/integration/targets/nxos_install_os/tasks/upgrade/copy_kick_system_images.yaml
@@ -10,7 +10,7 @@
 
 - ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/enable_scp_server.yaml
 
-- name: Remove SSH known_hosts file before scp of image file
+- name: Remove ssh known_hosts file before scp of image file
   ignore_errors: true
   cisco.nxos.nxos_command:
     commands: run bash rm /var/home/admin/.ssh/known_hosts

--- a/tests/integration/targets/nxos_install_os/tasks/upgrade/delete_files.yaml
+++ b/tests/integration/targets/nxos_install_os/tasks/upgrade/delete_files.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Delete Files To Make Room On Bootflash
+- name: Delete files to make room on bootflash
   ignore_errors: true
   with_items: "{{ delete_image_list }}"
   cisco.nxos.nxos_config:

--- a/tests/integration/targets/nxos_install_os/tasks/upgrade/enable_scp_server.yaml
+++ b/tests/integration/targets/nxos_install_os/tasks/upgrade/enable_scp_server.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Setup - Turn on feature scp-server
+- name: Setup - turn on feature scp-server
   cisco.nxos.nxos_feature:
     feature: scp-server
     state: enabled

--- a/tests/integration/targets/nxos_install_os/tasks/upgrade/install_os.yaml
+++ b/tests/integration/targets/nxos_install_os/tasks/upgrade/install_os.yaml
@@ -13,7 +13,7 @@
 
 - ansible.builtin.meta: reset_connection
 
-- name: Check installed OS for newly installed version {{ tv }}
+- name: Check installed os for newly installed version {{ tv }}
   register: output
   cisco.nxos.nxos_command:
     commands:

--- a/tests/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml
+++ b/tests/integration/targets/nxos_install_os/tasks/upgrade/install_system.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Install OS image {{ si }}
+- name: Install os image {{ si }}
   check_mode: "{{ checkmode }}"
   register: result
   when: not force
@@ -17,7 +17,7 @@
       - no boot system
     match: line
 
-- name: Set OS image {{ si }} boot pointers
+- name: Set os image {{ si }} boot pointers
   when: force
   cisco.nxos.nxos_config:
     lines:

--- a/tests/integration/targets/nxos_install_os/tasks/upgrade/install_with_kick.yaml
+++ b/tests/integration/targets/nxos_install_os/tasks/upgrade/install_with_kick.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Install OS image {{ si }}
+- name: Install os image {{ si }}
   check_mode: "{{ checkmode }}"
   register: result
   when: not force
@@ -8,7 +8,7 @@
     kickstart_image_file: "{{ ki }}"
     issu: "{{ issu }}"
 
-- name: Set OS image {{ si }} boot pointers
+- name: Set os image {{ si }} boot pointers
   when: force
   cisco.nxos.nxos_config:
     lines:

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade.yaml
@@ -41,7 +41,7 @@
   ansible.builtin.set_fact:
     ki: n3000-uk9-kickstart.6.0.2.U6.1a.bin
 
-- name: Upgrade to U6.1a
+- name: Upgrade to u6.1a
   ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
 
 - name: Set a fact for 'si'
@@ -52,7 +52,7 @@
   ansible.builtin.set_fact:
     ki: n3000-uk9-kickstart.6.0.2.U6.2a.bin
 
-- name: Upgrade to U6.2a
+- name: Upgrade to u6.2a
   ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
 
 - name: Set a fact for 'si'
@@ -63,14 +63,14 @@
   ansible.builtin.set_fact:
     ki: n3000-s2-kickstart.8.0.1.bin
 
-- name: Upgrade to U6.3a
+- name: Upgrade to u6.3a
   ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
 
 - name: Set a fact for 'si'
   ansible.builtin.set_fact:
     si: nxos.7.0.3.I7.2.bin
 
-- name: Upgrade to 7.0.3.I7.2
+- name: Upgrade to 7.0.3.i7.2
   ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
 
 - ansible.builtin.debug:

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_greensboro.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_greensboro.yaml
@@ -37,5 +37,5 @@
   ansible.builtin.set_fact:
     si: nxos.7.0.3.I7.4.bin
 
-- name: Upgrade N3172 Device to Greensboro Release Image
+- name: Upgrade n3172 device to greensboro release image
   ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_u61a.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_u61a.yaml
@@ -41,5 +41,5 @@
   ansible.builtin.set_fact:
     ki: n3000-uk9-kickstart.6.0.2.U6.1a.bin
 
-- name: Upgrade N3500 Device to U61a Release Image
+- name: Upgrade n3500 device to u61a release image
   ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_u62a.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_u62a.yaml
@@ -41,5 +41,5 @@
   ansible.builtin.set_fact:
     ki: n3000-uk9-kickstart.6.0.2.U6.2a.bin
 
-- name: Upgrade N3500 Device to U62a Release Image
+- name: Upgrade n3500 device to u62a release image
   ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_u63a.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_u63a.yaml
@@ -41,5 +41,5 @@
   ansible.builtin.set_fact:
     ki: n3000-uk9-kickstart.6.0.2.U6.3a.bin
 
-- name: Upgrade N3500 Device to U63a Release Image
+- name: Upgrade n3500 device to u63a release image
   ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n35_62a88.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n35_62a88.yaml
@@ -41,5 +41,5 @@
   ansible.builtin.set_fact:
     ki: n3500-uk9-kickstart.6.0.2.A8.8.bin
 
-- name: Upgrade N3500 Device to A8_8 Release Image
+- name: Upgrade n3500 device to a8_8 release image
   ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n35_greensboro.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n35_greensboro.yaml
@@ -37,5 +37,5 @@
   ansible.builtin.set_fact:
     si: nxos.7.0.3.I7.4.bin
 
-- name: Upgrade N3500 Device to Greensboro Release Image
+- name: Upgrade n3500 device to greensboro release image
   ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n5k_730_N11.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n5k_730_N11.yaml
@@ -40,5 +40,5 @@
   ansible.builtin.set_fact:
     ki: n6000-uk9-kickstart.7.3.0.N1.1.bin
 
-- name: Upgrade N5k Device to 7.3(0)N1(1) Release Image
+- name: Upgrade n5k device to 7.3(0)n1(1) release image
   ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n5k_733_N11.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n5k_733_N11.yaml
@@ -40,5 +40,5 @@
   ansible.builtin.set_fact:
     ki: n6000-uk9-kickstart.7.3.3.N1.1.bin
 
-- name: Upgrade N5k Device to 7.3(3)N1(1) Release Image
+- name: Upgrade n5k device to 7.3(3)n1(1) release image
   ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n7k_atherton.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n7k_atherton.yaml
@@ -40,5 +40,5 @@
   ansible.builtin.set_fact:
     ki: n7000-s2-kickstart.8.0.1.bin
 
-- name: Upgrade N7k Device to Atherton Release Image
+- name: Upgrade n7k device to atherton release image
   ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n7k_helsinki.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n7k_helsinki.yaml
@@ -40,5 +40,5 @@
   ansible.builtin.set_fact:
     ki: n7000-s2-kickstart.7.3.0.D1.1.bin
 
-- name: Upgrade N7k Device to Helsinki Release Image
+- name: Upgrade n7k device to helsinki release image
   ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n9k_greensboro.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n9k_greensboro.yaml
@@ -46,5 +46,5 @@
   ansible.builtin.set_fact:
     si: nxos.7.0.3.I7.4.bin
 
-- name: Upgrade N9k Device to Greensboro Release Image
+- name: Upgrade n9k device to greensboro release image
   ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n9k_greensboro_force.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n9k_greensboro_force.yaml
@@ -46,5 +46,5 @@
   ansible.builtin.set_fact:
     si: nxos.7.0.3.I7.4.bin
 
-- name: Upgrade N9k Device to Greensboro Release Image
+- name: Upgrade n9k device to greensboro release image
   ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n9k_hamilton.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n9k_hamilton.yaml
@@ -44,5 +44,5 @@
   ansible.builtin.set_fact:
     si: nxos.9.2.1.bin
 
-- name: Upgrade N9k Device to Hamilton Release Image
+- name: Upgrade n9k device to hamilton release image
   ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_interface/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_interface/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_interface/tasks/main.yaml
+++ b/tests/integration/targets/nxos_interface/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_interface/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_interface/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_interface/tests/common/intent.yaml
+++ b/tests/integration/targets/nxos_interface/tests/common/intent.yaml
@@ -10,7 +10,7 @@
   ansible.builtin.set_fact:
     testint2: "{{ nxos_int2 }}"
 
-- name: "Setup: Put interfaces into a default state"
+- name: "Setup: put interfaces into a default state"
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines:
@@ -49,7 +49,7 @@
       - "'tx_rate gt(10000)' in result.failed_conditions"
       - "'rx_rate lt(0)' in result.failed_conditions"
 
-- name: aggregate definition of interface
+- name: Aggregate definition of interface
   register: result
   cisco.nxos.nxos_interface:
     aggregate:
@@ -63,7 +63,7 @@
     that:
       - result.changed == true
 
-- name: "TearDown: Put interfaces into a default state"
+- name: "Teardown: put interfaces into a default state"
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines:

--- a/tests/integration/targets/nxos_interface/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_interface/tests/common/sanity.yaml
@@ -6,19 +6,19 @@
   ansible.builtin.set_fact:
     testint: "{{ nxos_int1 }}"
 
-- name: "Setup: Enable feature interface-vlan"
+- name: "Setup: enable feature interface-vlan"
   ignore_errors: true
   cisco.nxos.nxos_feature:
     feature: interface-vlan
     state: enabled
 
-- name: "Setup: Put interface {{ testint }} into a default state"
+- name: "Setup: put interface {{ testint }} into a default state"
   ignore_errors: true
   cisco.nxos.nxos_config: &id008
     lines:
       - default interface {{ testint }}
 
-- name: "Setup: Remove possibly existing vlan interfaces"
+- name: "Setup: remove possibly existing vlan interfaces"
   ignore_errors: true
   cisco.nxos.nxos_config: &id009
     lines:
@@ -41,7 +41,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_interface: *id001
 
@@ -60,13 +60,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_interface: *id003
 
     - ansible.builtin.assert: *id004
 
-    - name: Create VLAN Interfaces
+    - name: Create vlan interfaces
       with_items: &id005
         - os_svi_int: vlan2
           os_svi_desc: SVI_VLAN2
@@ -86,7 +86,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Configure Required SVI
+    - name: Configure required svi
       register: result
       cisco.nxos.nxos_l3_interface: &id007
         aggregate:
@@ -104,14 +104,14 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Create VLAN Interfaces Idempotence Check
+    - name: Create vlan interfaces idempotence check
       with_items: *id005
       register: result
       cisco.nxos.nxos_interface: *id006
 
     - ansible.builtin.assert: *id004
 
-    - name: Configure Required SVI Idempotence Check
+    - name: Configure required svi idempotence check
       register: result
       cisco.nxos.nxos_l3_interface: *id007
 
@@ -124,7 +124,7 @@
     - name: Remove vlan interfaces
       cisco.nxos.nxos_config: *id009
 
-    - name: "Setup: Disable feature interface-vlan"
+    - name: "Setup: disable feature interface-vlan"
       ignore_errors: true
       cisco.nxos.nxos_feature:
         feature: interface-vlan

--- a/tests/integration/targets/nxos_interface/tests/common/set_state_absent.yaml
+++ b/tests/integration/targets/nxos_interface/tests/common/set_state_absent.yaml
@@ -2,12 +2,12 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }}/set_state_absent.yaml
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     lines:
       - interface Loopback1
 
-- name: set state=absent
+- name: Set state=absent
   register: result
   cisco.nxos.nxos_interface:
     interface: Loopback1
@@ -17,7 +17,7 @@
     that:
       - result.changed == true
 
-- name: verify state=absent
+- name: Verify state=absent
   register: result
   cisco.nxos.nxos_interface:
     interface: Loopback1

--- a/tests/integration/targets/nxos_interface/tests/common/set_state_present.yaml
+++ b/tests/integration/targets/nxos_interface/tests/common/set_state_present.yaml
@@ -2,13 +2,13 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }}/set_state_present.yaml
 
-- name: setup
+- name: Setup
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines:
       - no interface Loopback1
 
-- name: set state=present
+- name: Set state=present
   register: result
   cisco.nxos.nxos_interface:
     interface: Loopback1
@@ -19,7 +19,7 @@
     that:
       - result.changed == true
 
-- name: verify state=present
+- name: Verify state=present
   register: result
   cisco.nxos.nxos_interface:
     interface: Loopback1

--- a/tests/integration/targets/nxos_interface/tests/common/sub_int.yaml
+++ b/tests/integration/targets/nxos_interface/tests/common/sub_int.yaml
@@ -12,7 +12,7 @@
     name: "{{ testint }}.20"
     state: absent
 
-- name: Setup - Ensure the interface is layer3
+- name: Setup - ensure the interface is layer3
   cisco.nxos.nxos_interface:
     name: "{{ testint }}"
     mode: layer3
@@ -29,7 +29,7 @@
     that:
       - result.changed == true
 
-- name: Create sub-interface (Idempotence)
+- name: Create sub-interface (idempotence)
   register: result
   cisco.nxos.nxos_interface: *id001
 
@@ -49,7 +49,7 @@
     that:
       - result.changed == true
 
-- name: Create sub-interface (Idempotence)
+- name: Create sub-interface (idempotence)
   register: result
   cisco.nxos.nxos_interface: *id002
 
@@ -65,7 +65,7 @@
     that:
       - result.changed == true
 
-- name: Remove sub-interface (Idempotence)
+- name: Remove sub-interface (idempotence)
   register: result
   cisco.nxos.nxos_interface: *id003
 

--- a/tests/integration/targets/nxos_interface_ospf/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_interface_ospf/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_interface_ospf/tasks/main.yaml
+++ b/tests/integration/targets/nxos_interface_ospf/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
   always:
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_interface_ospf/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_interface_ospf/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
@@ -6,7 +6,7 @@
   ansible.builtin.set_fact:
     testint: "{{ nxos_int1 }}"
 
-- name: Setup - Disable features
+- name: Setup - disable features
   loop:
     - ospf
     - bfd
@@ -15,7 +15,7 @@
     feature: "{{ item }}"
     state: disabled
 
-- name: Setup - Enable features
+- name: Setup - enable features
   loop:
     - ospf
     - bfd
@@ -47,7 +47,7 @@
       - no interface loopback77
 
 - block:
-    - name: configure ospf interface
+    - name: Configure ospf interface
       register: result
       cisco.nxos.nxos_interface_ospf: &id001
         interface: "{{ nxos_int1|upper }}"
@@ -65,7 +65,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_interface_ospf: *id001
 
@@ -88,13 +88,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_interface_ospf: *id003
 
     - ansible.builtin.assert: *id004
 
-    - name: default properties
+    - name: Default properties
       register: result
       cisco.nxos.nxos_interface_ospf: &id005
         interface: "{{ testint }}"
@@ -108,7 +108,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_interface_ospf: *id005
 
@@ -129,7 +129,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_interface_ospf: *id006
 
@@ -150,13 +150,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_interface_ospf: *id007
 
     - ansible.builtin.assert: *id004
 
-    - name: create port-channel and loopback interfaces
+    - name: Create port-channel and loopback interfaces
       cisco.nxos.nxos_config:
         commands:
           - interface port-channel10
@@ -175,7 +175,7 @@
         parents:
           - interface {{ item }}
 
-    - name: configure ospf interface port-channel10
+    - name: Configure ospf interface port-channel10
       register: result
       cisco.nxos.nxos_interface_ospf: &id008
         interface: Port-channel10
@@ -189,13 +189,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence for port-channel10
+    - name: Check idempotence for port-channel10
       register: result
       cisco.nxos.nxos_interface_ospf: *id008
 
     - ansible.builtin.assert: *id004
 
-    - name: configure ospf interface port-channel11 using lower case name
+    - name: Configure ospf interface port-channel11 using lower case name
       register: result
       cisco.nxos.nxos_interface_ospf: &id009
         interface: port-channel11
@@ -209,13 +209,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence for port-channel11
+    - name: Check idempotence for port-channel11
       register: result
       cisco.nxos.nxos_interface_ospf: *id009
 
     - ansible.builtin.assert: *id004
 
-    - name: configure ospf interface loopback55
+    - name: Configure ospf interface loopback55
       register: result
       cisco.nxos.nxos_interface_ospf: &id010
         interface: LOOPBACK55
@@ -228,13 +228,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence for loopback55
+    - name: Check idempotence for loopback55
       register: result
       cisco.nxos.nxos_interface_ospf: *id010
 
     - ansible.builtin.assert: *id004
 
-    - name: configure ospf interface loopback77 using lower case name
+    - name: Configure ospf interface loopback77 using lower case name
       register: result
       cisco.nxos.nxos_interface_ospf: &id011
         interface: loopback77
@@ -247,13 +247,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence for loopback77
+    - name: Check idempotence for loopback77
       register: result
       cisco.nxos.nxos_interface_ospf: *id011
 
     - ansible.builtin.assert: *id004
 
-    - name: remove ospf interface config
+    - name: Remove ospf interface config
       register: result
       cisco.nxos.nxos_interface_ospf: &id012
         interface: "{{ testint }}"
@@ -268,7 +268,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_interface_ospf: *id012
 

--- a/tests/integration/targets/nxos_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_interfaces/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/nxos_interfaces/tasks/main.yaml
@@ -4,12 +4,12 @@
     lines: "no system default switchport\nsystem default switchport shutdown\n"
   connection: ansible.netcommon.network_cli
 
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_interfaces/tasks/nxapi.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_interfaces/tests/common/_remove_config.yaml
+++ b/tests/integration/targets/nxos_interfaces/tests/common/_remove_config.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Remove Config
+- name: Remove config
   cisco.nxos.nxos_config:
     lines:
       - "default interface {{ nxos_int1 }}"

--- a/tests/integration/targets/nxos_interfaces/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_interfaces/tests/common/deleted.yaml
@@ -11,16 +11,16 @@
   ansible.builtin.set_fact:
     test_shutdown: "{{ platform is search('N3[5KL]|N[56]K|titanium') }}"
 
-- name: "setup0: clean up (interfaces) attributes on all interfaces"
+- name: "Setup0: clean up (interfaces) attributes on all interfaces"
   cisco.nxos.nxos_interfaces:
     state: deleted
 
-- name: setup1
+- name: Setup1
   cisco.nxos.nxos_config: &id002
     lines: "default interface {{ test_int1 }}"
 
 - block:
-    - name: setup2
+    - name: Setup2
       cisco.nxos.nxos_config:
         lines:
           - "interface {{ test_int1 }}"
@@ -34,7 +34,7 @@
           - "!min"
         gather_network_resources: interfaces
 
-    - name: deleted
+    - name: Deleted
       register: result
       cisco.nxos.nxos_interfaces: &id001
         state: deleted
@@ -62,5 +62,5 @@
           - result.commands|length == 0
       when: test_shutdown
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_config: *id002

--- a/tests/integration/targets/nxos_interfaces/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_interfaces/tests/common/merged.yaml
@@ -13,7 +13,7 @@
   when: platform is not search('N3[5KL]|N[56]K|titanium')
 
 - block:
-    - name: setup
+    - name: Setup
       cisco.nxos.nxos_config: &id002
         lines:
           - "default interface {{ test_int1 }}"
@@ -50,7 +50,7 @@
         that:
           - ansible_facts.network_resources.interfaces|symmetric_difference(result.after)|length == 0
 
-    - name: Idempotence - Merged
+    - name: Idempotence - merged
       register: result
       cisco.nxos.nxos_interfaces: *id001
 
@@ -85,5 +85,5 @@
           - result.commands|length == 2
 
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_config: *id002

--- a/tests/integration/targets/nxos_interfaces/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_interfaces/tests/common/overridden.yaml
@@ -8,7 +8,7 @@
     test_int2: "{{ nxos_int2 }}"
 
 - block:
-    - name: setup1
+    - name: Setup1
       cisco.nxos.nxos_config: &id003
         lines:
           - "default interface {{ test_int1 }}"

--- a/tests/integration/targets/nxos_interfaces/tests/common/purged.yaml
+++ b/tests/integration/targets/nxos_interfaces/tests/common/purged.yaml
@@ -3,7 +3,7 @@
     msg: "Start nxos_interfaces purged integration tests connection={{ ansible_connection }}"
 
 - block:
-    - name: setup2
+    - name: Setup2
       cisco.nxos.nxos_config:
         lines:
           - "interface {{ nxos_int1 }}.100"
@@ -28,7 +28,7 @@
           - result.commands|length == 2
           - result.changed == True
 
-    - name: Purge virtual interfaces from running-config (IDEMPOTENT)
+    - name: Purge virtual interfaces from running-config (idempotent)
       cisco.nxos.nxos_interfaces: *purged
       register: result
 

--- a/tests/integration/targets/nxos_interfaces/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_interfaces/tests/common/replaced.yaml
@@ -8,7 +8,7 @@
     test_int2: "{{ nxos_int2 }}"
 
 - block:
-    - name: setup1
+    - name: Setup1
       cisco.nxos.nxos_config: &id003
         lines:
           - "default interface {{ test_int1 }}"

--- a/tests/integration/targets/nxos_interfaces/tests/common/rtt.yaml
+++ b/tests/integration/targets/nxos_interfaces/tests/common/rtt.yaml
@@ -5,7 +5,7 @@
 - ansible.builtin.include_tasks: _remove_config.yaml
 
 - block:
-    - name: Apply the provided configuration (Base config)
+    - name: Apply the provided configuration (base config)
       register: base_config
       cisco.nxos.nxos_interfaces:
         config:

--- a/tests/integration/targets/nxos_l2_interface/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_l2_interface/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_l2_interface/tasks/main.yaml
+++ b/tests/integration/targets/nxos_l2_interface/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_l2_interface/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_l2_interface/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_l2_interface/tests/common/agg.yaml
+++ b/tests/integration/targets/nxos_l2_interface/tests/common/agg.yaml
@@ -14,7 +14,7 @@
   cisco.nxos.nxos_vlan:
     vlan_range: 6,15
 
-- name: Setup - Ensure interfaces are layer2
+- name: Setup - ensure interfaces are layer2
   cisco.nxos.nxos_interface:
     aggregate:
       - name: "{{ intname1 }}"
@@ -22,7 +22,7 @@
       - name: "{{ intname2 }}"
     mode: layer2
 
-- name: Setup - Remove interface aggregate before testing
+- name: Setup - remove interface aggregate before testing
   cisco.nxos.nxos_l2_interface:
     aggregate:
       - name: "{{ intname1 }}"
@@ -34,7 +34,7 @@
         access_vlan: 15
     state: absent
 
-- name: Sleep for 2 seconds on Fretta Platform
+- name: Sleep for 2 seconds on fretta platform
   ansible.builtin.wait_for: timeout=2
   when: platform is match("N9K-F")
 
@@ -55,11 +55,11 @@
         that:
           - result.changed == true
 
-    - name: Sleep for 2 seconds on Fretta Platform
+    - name: Sleep for 2 seconds on fretta platform
       ansible.builtin.wait_for: timeout=2
       when: platform is match("N9K-F")
 
-    - name: Configure interface for access_vlan aggregate(Idempotence)
+    - name: Configure interface for access_vlan aggregate(idempotence)
       register: result
       cisco.nxos.nxos_l2_interface: *id001
 
@@ -84,11 +84,11 @@
         that:
           - result.changed == true
 
-    - name: Sleep for 2 seconds on Fretta Platform
+    - name: Sleep for 2 seconds on fretta platform
       ansible.builtin.wait_for: timeout=2
       when: platform is match("N9K-F")
 
-    - name: Remove interface aggregate(Idempotence)
+    - name: Remove interface aggregate(idempotence)
       register: result
       cisco.nxos.nxos_l2_interface: *id002
 
@@ -96,7 +96,7 @@
         that:
           - result.changed == false
   always:
-    - name: remove vlans
+    - name: Remove vlans
       ignore_errors: true
       cisco.nxos.nxos_vlan:
         vlan_range: 6,15

--- a/tests/integration/targets/nxos_l2_interface/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_l2_interface/tests/common/sanity.yaml
@@ -16,7 +16,7 @@
     lines:
       - default interface {{ intname }}
 
-- name: Setup - Ensure interface is layer2
+- name: Setup - ensure interface is layer2
   cisco.nxos.nxos_interface:
     interface: "{{ intname }}"
     mode: layer2
@@ -42,11 +42,11 @@
         that:
           - result.changed == true
 
-    - name: Sleep for 2 seconds on Fretta Platform
+    - name: Sleep for 2 seconds on fretta platform
       ansible.builtin.wait_for: timeout=2
       when: platform is match("N9K-F")
 
-    - name: access vlan Idempotence
+    - name: Access vlan idempotence
       register: result
       cisco.nxos.nxos_l2_interface: *id001
 
@@ -64,7 +64,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: trunk vlan Idempotence
+    - name: Trunk vlan idempotence
       register: result
       cisco.nxos.nxos_l2_interface: *id003
 
@@ -80,7 +80,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: tag vlan Idempotence
+    - name: Tag vlan idempotence
       register: result
       cisco.nxos.nxos_l2_interface: *id005
 
@@ -96,7 +96,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence Remove full trunk vlan range 2-50
+    - name: Check idempotence remove full trunk vlan range 2-50
       register: result
       cisco.nxos.nxos_l2_interface: *id006
 
@@ -108,7 +108,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence Reconfigure interface trunk port and ensure 2-50 are being tagged
+    - name: Check idempotence reconfigure interface trunk port and ensure 2-50 are being tagged
       register: result
       cisco.nxos.nxos_l2_interface: *id005
 
@@ -124,31 +124,31 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence Remove partial trunk vlan range 30-4094 are removed
+    - name: Check idempotence remove partial trunk vlan range 30-4094 are removed
       register: result
       cisco.nxos.nxos_l2_interface: *id007
 
     - ansible.builtin.assert: *id004
 
-    - name: put interface default state
+    - name: Put interface default state
       register: result
       cisco.nxos.nxos_l2_interface: *id008
 
     - ansible.builtin.assert: *id002
 
-    - name: default state idempotence
+    - name: Default state idempotence
       register: result
       cisco.nxos.nxos_l2_interface: *id008
 
     - ansible.builtin.assert: *id004
   always:
-    - name: remove vlans
+    - name: Remove vlans
       ignore_errors: true
       cisco.nxos.nxos_vlan:
         vlan_range: 5-10,20
         state: absent
 
-    - name: default interface
+    - name: Default interface
       ignore_errors: true
       cisco.nxos.nxos_config: *id009
 

--- a/tests/integration/targets/nxos_l2_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_l2_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tasks/main.yaml
@@ -1,9 +1,9 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_l2_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tasks/nxapi.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/deleted.yaml
@@ -7,7 +7,7 @@
     test_int1: "{{ nxos_int1 }}"
     test_int2: "{{ nxos_int2 }}"
 
-- name: setup1
+- name: Setup1
   ignore_errors: true
   cisco.nxos.nxos_config: &id002
     lines:
@@ -15,14 +15,14 @@
       - "default interface {{ test_int2 }}"
 
 - block:
-    - name: setup2
+    - name: Setup2
       cisco.nxos.nxos_config:
         lines:
           - "switchport"
           - "switchport trunk native vlan 10"
         parents: "interface {{ test_int1 }}"
 
-    - name: setup3
+    - name: Setup3
       cisco.nxos.nxos_config:
         lines:
           - "switchport"
@@ -37,7 +37,7 @@
           - "!min"
         gather_network_resources: l2_interfaces
 
-    - name: deleted
+    - name: Deleted
       register: result
       cisco.nxos.nxos_l2_interfaces: &id001
         state: deleted
@@ -62,6 +62,6 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       ignore_errors: true
       cisco.nxos.nxos_config: *id002

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/merged.yaml
@@ -6,14 +6,14 @@
   ansible.builtin.set_fact:
     test_int1: "{{ nxos_int1 }}"
 
-- name: setup1
+- name: Setup1
   ignore_errors: true
   cisco.nxos.nxos_config: &id003
     lines:
       - "default interface {{ test_int1 }}"
 
 - block:
-    - name: setup2
+    - name: Setup2
       cisco.nxos.nxos_config:
         lines:
           - "interface {{ test_int1 }}"
@@ -49,7 +49,7 @@
         that:
           - ansible_facts.network_resources.l2_interfaces|symmetric_difference(result.after) == []
 
-    - name: Idempotence - Merged
+    - name: Idempotence - merged
       register: result
       cisco.nxos.nxos_l2_interfaces: *id001
 
@@ -96,6 +96,6 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       ignore_errors: true
       cisco.nxos.nxos_config: *id003

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/overridden.yaml
@@ -7,7 +7,7 @@
     test_int1: "{{ nxos_int1 }}"
     test_int2: "{{ nxos_int2 }}"
 
-- name: setup1
+- name: Setup1
   ignore_errors: true
   cisco.nxos.nxos_config: &id003
     lines:
@@ -15,14 +15,14 @@
       - "default interface {{ test_int2 }}"
 
 - block:
-    - name: setup2
+    - name: Setup2
       cisco.nxos.nxos_config:
         lines:
           - "switchport"
           - "switchport trunk allowed vlan 11"
         parents: "interface {{ test_int1 }}"
 
-    - name: setup3
+    - name: Setup3
       cisco.nxos.nxos_config:
         lines:
           - "switchport"
@@ -63,7 +63,7 @@
         that:
           - ansible_facts.network_resources.l2_interfaces|symmetric_difference(result.after) == []
 
-    - name: Idempotence - Overridden
+    - name: Idempotence - overridden
       register: result
       cisco.nxos.nxos_l2_interfaces: *id002
 
@@ -72,6 +72,6 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       ignore_errors: true
       cisco.nxos.nxos_config: *id003

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/replaced.yaml
@@ -7,7 +7,7 @@
     test_int1: "{{ nxos_int1 }}"
     test_int2: "{{ nxos_int2 }}"
 
-- name: setup1
+- name: Setup1
   ignore_errors: true
   cisco.nxos.nxos_config: &id003
     lines:
@@ -15,14 +15,14 @@
       - "default interface {{ test_int2 }}"
 
 - block:
-    - name: setup2
+    - name: Setup2
       cisco.nxos.nxos_config:
         lines:
           - "switchport"
           - "switchport access vlan 5"
         parents: "interface {{ test_int1 }}"
 
-    - name: setup3
+    - name: Setup3
       cisco.nxos.nxos_config:
         lines:
           - "switchport"
@@ -69,7 +69,7 @@
         that:
           - ansible_facts.network_resources.l2_interfaces|symmetric_difference(result.after) == []
 
-    - name: Idempotence - Replaced
+    - name: Idempotence - replaced
       register: result
       cisco.nxos.nxos_l2_interfaces: *id002
 
@@ -78,6 +78,6 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       ignore_errors: true
       cisco.nxos.nxos_config: *id003

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/rtt.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/rtt.yaml
@@ -5,7 +5,7 @@
 - ansible.builtin.include_tasks: _remove_config.yaml
 
 - block:
-    - name: Prepare interfaces (switch to L2)
+    - name: Prepare interfaces (switch to l2)
       cisco.nxos.nxos_interfaces:
         config:
           - name: "{{ nxos_int1 }}"
@@ -16,7 +16,7 @@
             mode: layer2
         state: merged
 
-    - name: Apply the provided configuration (Base config)
+    - name: Apply the provided configuration (base config)
       register: base_config
       cisco.nxos.nxos_l2_interfaces:
         config:

--- a/tests/integration/targets/nxos_l3_interface/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_l3_interface/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_l3_interface/tasks/main.yaml
+++ b/tests/integration/targets/nxos_l3_interface/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_l3_interface/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_l3_interface/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_l3_interface/tests/cli/sanity.yaml
+++ b/tests/integration/targets/nxos_l3_interface/tests/cli/sanity.yaml
@@ -19,7 +19,7 @@
     ipv6_address: 33:db::2/8
   when: ipv6_supported
 
-- name: Setup - remove address from interface prior to testing(Part1)
+- name: Setup - remove address from interface prior to testing(part1)
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines:
@@ -27,7 +27,7 @@
     parents: no switchport
     before: interface {{ testint2 }}
 
-- name: Setup - remove address from interface prior to testing(Part2)
+- name: Setup - remove address from interface prior to testing(part2)
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines:
@@ -36,7 +36,7 @@
     parents: no switchport
     before: interface {{ testint3 }}
 
-- name: Setup - Ensure interfaces are layer3
+- name: Setup - ensure interfaces are layer3
   cisco.nxos.nxos_interface:
     aggregate:
       - name: "{{ testint2 }}"
@@ -54,7 +54,7 @@
     that:
       - result.changed == true
 
-- name: Configure ipv4 address to interface(Idempotence)
+- name: Configure ipv4 address to interface(idempotence)
   register: result
   cisco.nxos.nxos_l3_interface: *id001
 
@@ -73,7 +73,7 @@
     that:
       - result.changed == true
 
-- name: Remove ipv4 address from interface(Idempotence)
+- name: Remove ipv4 address from interface(idempotence)
   register: result
   cisco.nxos.nxos_l3_interface: *id002
 
@@ -96,7 +96,7 @@
     that:
       - result.changed == true
 
-- name: Configure address to interfaces aggregate(Idempotence)
+- name: Configure address to interfaces aggregate(idempotence)
   register: result
   cisco.nxos.nxos_l3_interface: *id003
 
@@ -120,7 +120,7 @@
     that:
       - result.changed == true
 
-- name: Remove address from interfaces aggregate(Idempotence)
+- name: Remove address from interfaces aggregate(idempotence)
   register: result
   cisco.nxos.nxos_l3_interface: *id004
 

--- a/tests/integration/targets/nxos_l3_interface/tests/nxapi/sanity.yaml
+++ b/tests/integration/targets/nxos_l3_interface/tests/nxapi/sanity.yaml
@@ -19,7 +19,7 @@
     ipv6_address: 33:db::2/8
   when: ipv6_supported
 
-- name: Setup - Remove address from interfaces aggregate
+- name: Setup - remove address from interfaces aggregate
   ignore_errors: true
   cisco.nxos.nxos_l3_interface:
     aggregate:
@@ -31,7 +31,7 @@
         ipv6: "{{ ipv6_address }}"
     state: absent
 
-- name: Setup - Ensure interfaces are layer3
+- name: Setup - ensure interfaces are layer3
   cisco.nxos.nxos_interface:
     aggregate:
       - name: "{{ testint2 }}"
@@ -49,7 +49,7 @@
     that:
       - result.changed == true
 
-- name: Configure ipv4 address to interface(Idempotence)
+- name: Configure ipv4 address to interface(idempotence)
   register: result
   cisco.nxos.nxos_l3_interface: *id001
 
@@ -68,7 +68,7 @@
     that:
       - result.changed == true
 
-- name: Remove ipv4 address from interface(Idempotence)
+- name: Remove ipv4 address from interface(idempotence)
   register: result
   cisco.nxos.nxos_l3_interface: *id002
 
@@ -91,7 +91,7 @@
     that:
       - result.changed == true
 
-- name: Configure address to interfaces aggregate(Idempotence)
+- name: Configure address to interfaces aggregate(idempotence)
   register: result
   cisco.nxos.nxos_l3_interface: *id003
 
@@ -115,7 +115,7 @@
     that:
       - result.changed == true
 
-- name: Remove address from interfaces aggregate(Idempotence)
+- name: Remove address from interfaces aggregate(idempotence)
   register: result
   cisco.nxos.nxos_l3_interface: *id004
 

--- a/tests/integration/targets/nxos_l3_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_l3_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tasks/main.yaml
@@ -4,11 +4,11 @@
     rsvd_intf: "{{ rsvd_intf|default('mgmt0') }}"
 
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_l3_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tasks/nxapi.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_l3_interfaces/tests/common/_remove_config.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tests/common/_remove_config.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Remove Config
+- name: Remove config
   cisco.nxos.nxos_config:
     lines:
       - "default interface {{ nxos_int1 }}"

--- a/tests/integration/targets/nxos_l3_interfaces/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tests/common/deleted.yaml
@@ -9,7 +9,7 @@
 
 - ansible.builtin.include_tasks: _remove_config.yaml
 
-- name: setup1
+- name: Setup1
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines:
@@ -19,7 +19,7 @@
       - "  no switchport"
 
 - block:
-    - name: setup3
+    - name: Setup3
       cisco.nxos.nxos_config:
         lines:
           - "interface {{ subint3 }}"
@@ -35,7 +35,7 @@
           - "!min"
         gather_network_resources: l3_interfaces
 
-    - name: deleted
+    - name: Deleted
       register: result
       cisco.nxos.nxos_l3_interfaces: &id001
         config:
@@ -62,7 +62,7 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       ignore_errors: true
       cisco.nxos.nxos_config:
         lines:

--- a/tests/integration/targets/nxos_l3_interfaces/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tests/common/merged.yaml
@@ -9,7 +9,7 @@
 
 - ansible.builtin.include_tasks: _remove_config.yaml
 
-- name: setup1
+- name: Setup1
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines:
@@ -52,7 +52,7 @@
         that:
           - result.after|symmetric_difference(ansible_facts.network_resources.l3_interfaces) == []
 
-    - name: Idempotence - Merged
+    - name: Idempotence - merged
       register: result
       cisco.nxos.nxos_l3_interfaces: *id001
 
@@ -61,7 +61,7 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown sub-interface
+    - name: Teardown sub-interface
       ignore_errors: true
       cisco.nxos.nxos_config:
         lines:

--- a/tests/integration/targets/nxos_l3_interfaces/tests/common/multisite.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tests/common/multisite.yaml
@@ -32,7 +32,7 @@
       - evpn multisite border-gateway 10
 
 - block:
-    - name: setup1 - deleted
+    - name: Setup1 - deleted
       ignore_errors: true
       cisco.nxos.nxos_config:
         lines:
@@ -41,7 +41,7 @@
           - "interface {{ test_int3 }}"
           - "  no switchport"
 
-    - name: setup3 - deleted
+    - name: Setup3 - deleted
       cisco.nxos.nxos_config:
         lines:
           - "interface {{ test_int3 }}"
@@ -57,7 +57,7 @@
           - "!min"
         gather_network_resources: l3_interfaces
 
-    - name: deleted
+    - name: Deleted
       register: result
       cisco.nxos.nxos_l3_interfaces: &id001
         config:
@@ -86,7 +86,7 @@
 
     - ansible.builtin.include_tasks: _remove_config.yaml
 
-    - name: setup1 - merged
+    - name: Setup1 - merged
       ignore_errors: true
       cisco.nxos.nxos_config:
         lines:
@@ -128,7 +128,7 @@
         that:
           - result.after|symmetric_difference(ansible_facts.network_resources.l3_interfaces) == []
 
-    - name: Idempotence - Merged
+    - name: Idempotence - merged
       register: result
       cisco.nxos.nxos_l3_interfaces: *id002
 
@@ -139,7 +139,7 @@
 
     - ansible.builtin.include_tasks: _remove_config.yaml
 
-    - name: setup1 - replaced
+    - name: Setup1 - replaced
       ignore_errors: true
       cisco.nxos.nxos_config:
         lines:
@@ -148,7 +148,7 @@
           - "interface {{ test_int3 }}"
           - "  no switchport"
 
-    - name: setup3 - replaced
+    - name: Setup3 - replaced
       cisco.nxos.nxos_config:
         lines:
           - "interface {{ test_int3 }}"
@@ -198,7 +198,7 @@
         that:
           - result.after|symmetric_difference(ansible_facts.network_resources.l3_interfaces) == []
 
-    - name: Idempotence - Replaced
+    - name: Idempotence - replaced
       register: result
       cisco.nxos.nxos_l3_interfaces: *id004
 
@@ -209,7 +209,7 @@
 
     - ansible.builtin.include_tasks: _remove_config.yaml
 
-    - name: setup1 - overidden
+    - name: Setup1 - overidden
       ignore_errors: true
       cisco.nxos.nxos_config: &id007
         lines:
@@ -222,7 +222,7 @@
         - "{{ test_int2 }}"
         - "{{ test_int3 }}"
 
-    - name: setup3 - overidden
+    - name: Setup3 - overidden
       cisco.nxos.nxos_config:
         lines:
           - "interface {{ test_int1 }}"
@@ -239,7 +239,7 @@
           - "!min"
         gather_network_resources: l3_interfaces
 
-    - name: Store reserved interface IP config
+    - name: Store reserved interface ip config
       ansible.builtin.set_fact:
         mgmt: "{{ ansible_facts.network_resources.l3_interfaces|selectattr('name', 'equalto', rsvd_intf)|list }}"
         overriden_config:
@@ -276,7 +276,7 @@
         that:
           - result.after|symmetric_difference(ansible_facts.network_resources.l3_interfaces) == []
 
-    - name: Idempotence - Overridden
+    - name: Idempotence - overridden
       register: result
       cisco.nxos.nxos_l3_interfaces: *id006
 
@@ -285,7 +285,7 @@
           - result.changed == false
           - result.commands|length == 0
 
-    - name: teardown - overdidden
+    - name: Teardown - overdidden
       ignore_errors: true
       cisco.nxos.nxos_config: *id007
       loop:

--- a/tests/integration/targets/nxos_l3_interfaces/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tests/common/overridden.yaml
@@ -10,7 +10,7 @@
     test_int2: "{{ nxos_int2 }}"
     test_int3: "{{ nxos_int3 }}"
 
-- name: setup1
+- name: Setup1
   ignore_errors: true
   cisco.nxos.nxos_config: &id003
     lines:
@@ -24,7 +24,7 @@
     - "{{ test_int3 }}"
 
 - block:
-    - name: setup3
+    - name: Setup3
       cisco.nxos.nxos_config:
         lines:
           - "interface {{ test_int1 }}"
@@ -39,7 +39,7 @@
           - "!min"
         gather_network_resources: l3_interfaces
 
-    - name: Store reserved interface IP config
+    - name: Store reserved interface ip config
       ansible.builtin.set_fact:
         mgmt: "{{ ansible_facts.network_resources.l3_interfaces|selectattr('name', 'equalto', rsvd_intf)|list }}"
         overriden_config:
@@ -72,7 +72,7 @@
         that:
           - result.after|symmetric_difference(ansible_facts.network_resources.l3_interfaces) == []
 
-    - name: Idempotence - Overridden
+    - name: Idempotence - overridden
       register: result
       cisco.nxos.nxos_l3_interfaces: *id002
 
@@ -81,7 +81,7 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       ignore_errors: true
       cisco.nxos.nxos_config: *id003
       loop:

--- a/tests/integration/targets/nxos_l3_interfaces/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tests/common/replaced.yaml
@@ -9,7 +9,7 @@
 
 - ansible.builtin.include_tasks: _remove_config.yaml
 
-- name: setup1
+- name: Setup1
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines:
@@ -19,7 +19,7 @@
       - "  no switchport"
 
 - block:
-    - name: setup3
+    - name: Setup3
       cisco.nxos.nxos_config:
         lines:
           - "interface {{ subint3 }}"
@@ -69,7 +69,7 @@
         that:
           - result.after|symmetric_difference(ansible_facts.network_resources.l3_interfaces) == []
 
-    - name: Idempotence - Replaced
+    - name: Idempotence - replaced
       register: result
       cisco.nxos.nxos_l3_interfaces: *id002
 
@@ -97,7 +97,7 @@
           - "'ip redirects' in result.commands"
       when: platform is match('N[3567]')
 
-    - name: Idempotence - Replaced with no attrs specified
+    - name: Idempotence - replaced with no attrs specified
       register: result
       cisco.nxos.nxos_l3_interfaces: *id003
 
@@ -106,7 +106,7 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown sub-interface
+    - name: Teardown sub-interface
       ignore_errors: true
       cisco.nxos.nxos_config:
         lines:

--- a/tests/integration/targets/nxos_l3_interfaces/tests/common/rtt.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tests/common/rtt.yaml
@@ -5,7 +5,7 @@
 - ansible.builtin.include_tasks: _remove_config.yaml
 
 - block:
-    - name: Prepare interfaces (switch to L3)
+    - name: Prepare interfaces (switch to l3)
       cisco.nxos.nxos_interfaces:
         config:
           - name: "{{ nxos_int1 }}"
@@ -16,7 +16,7 @@
             mode: layer3
         state: merged
 
-    - name: Apply the provided configuration (Base config)
+    - name: Apply the provided configuration (base config)
       register: base_config
       cisco.nxos.nxos_l3_interfaces:
         config:
@@ -44,7 +44,7 @@
         gather_network_resources:
           - l3_interfaces
 
-    - name: Set reserved interface IP config and config to revert
+    - name: Set reserved interface ip config and config to revert
       ansible.builtin.set_fact:
         mgmt: "{{ ansible_facts.network_resources.l3_interfaces|selectattr('name', 'equalto', rsvd_intf)|list }}"
         config_to_revert:

--- a/tests/integration/targets/nxos_lacp/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_lacp/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_lacp/tasks/main.yaml
+++ b/tests/integration/targets/nxos_lacp/tasks/main.yaml
@@ -1,9 +1,9 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_lacp/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_lacp/tasks/nxapi.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_lacp/tests/common/_remove_config.yaml
+++ b/tests/integration/targets/nxos_lacp/tests/common/_remove_config.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Remove existing LACP config
+- name: Remove existing lacp config
   cisco.nxos.nxos_config:
     lines:
       - "no lacp system-priority"

--- a/tests/integration/targets/nxos_lacp/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_lacp/tests/common/deleted.yaml
@@ -27,7 +27,7 @@
           - "!min"
         gather_network_resources: lacp
 
-    - name: deleted
+    - name: Deleted
       register: result
       cisco.nxos.nxos_lacp: &id002
         state: deleted
@@ -65,7 +65,7 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_feature:
         feature: lacp
         state: disabled

--- a/tests/integration/targets/nxos_lacp/tests/common/gathered.yaml
+++ b/tests/integration/targets/nxos_lacp/tests/common/gathered.yaml
@@ -21,7 +21,7 @@
   always:
     - ansible.builtin.include_tasks: _remove_config.yaml
 
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_feature:
         feature: lacp
         state: disabled

--- a/tests/integration/targets/nxos_lacp/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_lacp/tests/common/merged.yaml
@@ -51,7 +51,7 @@
         that:
           - ansible_facts.network_resources.lacp == result.after
 
-    - name: Idempotence - Merged
+    - name: Idempotence - merged
       register: result
       cisco.nxos.nxos_lacp: *id001
 
@@ -60,7 +60,7 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_feature:
         feature: lacp
         state: disabled

--- a/tests/integration/targets/nxos_lacp/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_lacp/tests/common/replaced.yaml
@@ -67,7 +67,7 @@
           - ansible_facts.network_resources.lacp == result.after
       when: platform is search('N9K') and imagetag is not search('I[2-6]')
 
-    - name: Idempotence - Replaced
+    - name: Idempotence - replaced
       register: result
       cisco.nxos.nxos_lacp: *id002
 
@@ -98,7 +98,7 @@
           - "'lacp system-priority 1' in result.commands"
       when: platform is search('N9K') and imagetag is not search('I[2-6]')
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_feature:
         feature: lacp
         state: disabled

--- a/tests/integration/targets/nxos_lacp_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_lacp_interfaces/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_lacp_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/nxos_lacp_interfaces/tasks/main.yaml
@@ -1,9 +1,9 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_lacp_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_lacp_interfaces/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_lacp_interfaces/tests/common/_populate_config.yaml
+++ b/tests/integration/targets/nxos_lacp_interfaces/tests/common/_populate_config.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Populate Config
+- name: Populate config
   cisco.nxos.nxos_config:
     lines:
       - "feature lacp"

--- a/tests/integration/targets/nxos_lacp_interfaces/tests/common/_remove_config.yaml
+++ b/tests/integration/targets/nxos_lacp_interfaces/tests/common/_remove_config.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Remove Config
+- name: Remove config
   cisco.nxos.nxos_config:
     lines:
       - "no interface port-channel5"

--- a/tests/integration/targets/nxos_lacp_interfaces/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_lacp_interfaces/tests/common/deleted.yaml
@@ -7,7 +7,7 @@
     mode: delay
   when: platform is not search('N3K|N5K|N6K|N7K') and imagetag is not search('A8|I2') and image_version is not search ('9.2') and chassis_type is not search('C95')
 
-- name: setup1
+- name: Setup1
   cisco.nxos.nxos_config: &id002
     lines:
       - "no interface port-channel5"
@@ -15,7 +15,7 @@
       - "no feature lacp"
 
 - block:
-    - name: setup2
+    - name: Setup2
       cisco.nxos.nxos_config:
         lines:
           - "feature lacp"
@@ -24,7 +24,7 @@
           - "interface port-channel10"
           - "  lacp max-bundle 10"
 
-    - name: setup3 - L2 for mode command
+    - name: Setup3 - l2 for mode command
       when: mode is defined
       cisco.nxos.nxos_config:
         lines:
@@ -39,7 +39,7 @@
           - "!min"
         gather_network_resources: lacp_interfaces
 
-    - name: deleted
+    - name: Deleted
       register: result
       cisco.nxos.nxos_lacp_interfaces: &id001
         state: deleted
@@ -69,5 +69,5 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_config: *id002

--- a/tests/integration/targets/nxos_lacp_interfaces/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_lacp_interfaces/tests/common/merged.yaml
@@ -7,7 +7,7 @@
     mode: delay
   when: platform is not search('N3K|N5K|N6K|N7K') and imagetag is not search('A8|I2') and image_version is not search ('9.2') and chassis_type is not search('C95')
 
-- name: setup1
+- name: Setup1
   cisco.nxos.nxos_config: &id002
     lines:
       - "no interface port-channel5"
@@ -15,12 +15,12 @@
       - "no feature lacp"
 
 - block:
-    - name: setup2
+    - name: Setup2
       cisco.nxos.nxos_config:
         lines:
           - "feature lacp"
 
-    - name: setup3 - L2 for mode command
+    - name: Setup3 - l2 for mode command
       when: mode is defined
       cisco.nxos.nxos_config:
         lines:
@@ -67,7 +67,7 @@
         that:
           - ansible_facts.network_resources.lacp_interfaces|symmetric_difference(result.after)|length == 0
 
-    - name: Idempotence - Merged
+    - name: Idempotence - merged
       register: result
       cisco.nxos.nxos_lacp_interfaces: *id001
 
@@ -76,5 +76,5 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_config: *id002

--- a/tests/integration/targets/nxos_lacp_interfaces/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_lacp_interfaces/tests/common/overridden.yaml
@@ -7,7 +7,7 @@
     mode: delay
   when: platform is not search('N3K|N5K|N6K|N7K') and imagetag is not search('A8|I2') and image_version is not search ('9.2') and chassis_type is not search('C95')
 
-- name: setup1
+- name: Setup1
   cisco.nxos.nxos_config: &id003
     lines:
       - "no interface port-channel5"
@@ -16,7 +16,7 @@
       - "no feature lacp"
 
 - block:
-    - name: setup2
+    - name: Setup2
       cisco.nxos.nxos_config:
         lines:
           - "feature lacp"
@@ -25,7 +25,7 @@
           - "interface port-channel5"
           - "  lacp max-bundle 10"
 
-    - name: setup3 - L2 for mode command
+    - name: Setup3 - l2 for mode command
       when: mode is defined
       cisco.nxos.nxos_config:
         lines:
@@ -72,7 +72,7 @@
         that:
           - ansible_facts.network_resources.lacp_interfaces|symmetric_difference(result.after)|length == 0
 
-    - name: Idempotence - Overridden
+    - name: Idempotence - overridden
       register: result
       cisco.nxos.nxos_lacp_interfaces: *id002
 
@@ -81,5 +81,5 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_config: *id003

--- a/tests/integration/targets/nxos_lacp_interfaces/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_lacp_interfaces/tests/common/replaced.yaml
@@ -7,14 +7,14 @@
     mode: delay
   when: platform is not search('N3K|N5K|N6K|N7K') and imagetag is not search('A8|I2') and image_version is not search ('9.2') and chassis_type is not search('C95')
 
-- name: setup1
+- name: Setup1
   cisco.nxos.nxos_config: &id003
     lines:
       - "no interface port-channel10"
       - "no feature lacp"
 
 - block:
-    - name: setup2
+    - name: Setup2
       cisco.nxos.nxos_config:
         lines:
           - "feature lacp"
@@ -60,7 +60,7 @@
         that:
           - ansible_facts.network_resources.lacp_interfaces|symmetric_difference(result.after)|length == 0
 
-    - name: Idempotence - Replaced
+    - name: Idempotence - replaced
       register: result
       cisco.nxos.nxos_lacp_interfaces: *id002
 
@@ -69,5 +69,5 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_config: *id003

--- a/tests/integration/targets/nxos_lag_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_lag_interfaces/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_lag_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/nxos_lag_interfaces/tasks/main.yaml
@@ -4,11 +4,11 @@
     lines: "system default switchport"
   connection: ansible.netcommon.network_cli
 
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_lag_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_lag_interfaces/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_lag_interfaces/tests/common/_populate_config.yaml
+++ b/tests/integration/targets/nxos_lag_interfaces/tests/common/_populate_config.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Populate Config
+- name: Populate config
   cisco.nxos.nxos_config:
     lines:
       - "feature lacp"

--- a/tests/integration/targets/nxos_lag_interfaces/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_lag_interfaces/tests/common/deleted.yaml
@@ -12,7 +12,7 @@
 
 - ansible.builtin.include_tasks: _remove_config.yaml
 
-- name: enable feature lacp
+- name: Enable feature lacp
   cisco.nxos.nxos_feature:
     feature: lacp
 
@@ -26,14 +26,14 @@
           - channel-group 10
         parents: "{{ item }}"
 
-    - name: Gather LAG interfaces facts
+    - name: Gather lag interfaces facts
       cisco.nxos.nxos_facts: &id001
         gather_subset:
           - "!all"
           - "!min"
         gather_network_resources: lag_interfaces
 
-    - name: deleted
+    - name: Deleted
       register: result
       cisco.nxos.nxos_lag_interfaces: &id002
         state: deleted
@@ -42,7 +42,7 @@
         that:
           - ansible_facts.network_resources.lag_interfaces|symmetric_difference(result.before)|length == 0
 
-    - name: Gather LAG interfaces post facts
+    - name: Gather lag interfaces post facts
       cisco.nxos.nxos_facts: *id001
 
     - ansible.builtin.assert:
@@ -61,7 +61,7 @@
   always:
     - ansible.builtin.include_tasks: _remove_config.yaml
 
-    - name: disable feature lacp
+    - name: Disable feature lacp
       cisco.nxos.nxos_feature:
         feature: lacp
         state: disabled

--- a/tests/integration/targets/nxos_lag_interfaces/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_lag_interfaces/tests/common/merged.yaml
@@ -23,7 +23,7 @@
       - no interface port-channel 19
       - no interface port-channel 20
 
-- name: setup2
+- name: Setup2
   cisco.nxos.nxos_lag_interfaces: &id003
     state: deleted
 
@@ -45,7 +45,7 @@
           - result.before|length == 0
           - result.changed == true
 
-    - name: Gather LAG interfaces facts
+    - name: Gather lag interfaces facts
       cisco.nxos.nxos_facts:
         gather_subset:
           - "!all"
@@ -56,7 +56,7 @@
         that:
           - ansible_facts.network_resources.lag_interfaces|symmetric_difference(result.after)|length == 0
 
-    - name: Idempotence - Merged
+    - name: Idempotence - merged
       register: result
       cisco.nxos.nxos_lag_interfaces: *id001
 
@@ -70,7 +70,7 @@
         lines:
           - interface port-channel 11
 
-    - name: Merged - No Members
+    - name: Merged - no members
       register: result
       cisco.nxos.nxos_lag_interfaces: &id002
         config:
@@ -86,7 +86,7 @@
         that:
           - result.changed == true
 
-    - name: Idempotence - Merged - No Members
+    - name: Idempotence - merged - no members
       register: result
       cisco.nxos.nxos_lag_interfaces: *id002
 

--- a/tests/integration/targets/nxos_lag_interfaces/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_lag_interfaces/tests/common/overridden.yaml
@@ -8,11 +8,11 @@
     test_int2: "{{ nxos_int2 }}"
     test_int3: "{{ nxos_int3 }}"
 
-- name: enable feature lacp
+- name: Enable feature lacp
   cisco.nxos.nxos_feature:
     feature: lacp
 
-- name: setup1
+- name: Setup1
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines:
@@ -20,12 +20,12 @@
       - no interface port-channel 19
       - no interface port-channel 20
 
-- name: setup2
+- name: Setup2
   cisco.nxos.nxos_lag_interfaces: &id003
     state: deleted
 
 - block:
-    - name: setup3
+    - name: Setup3
       ignore_errors: true
       loop:
         - interface {{ test_int1 }}
@@ -35,7 +35,7 @@
           - channel-group 10
         parents: "{{ item }}"
 
-    - name: Gather LAG interfaces facts
+    - name: Gather lag interfaces facts
       cisco.nxos.nxos_facts: &id001
         gather_subset:
           - "!all"
@@ -56,14 +56,14 @@
           - ansible_facts.network_resources.lag_interfaces|symmetric_difference(result.before)|length == 0
           - result.changed == true
 
-    - name: Gather LAG interfaces post facts
+    - name: Gather lag interfaces post facts
       cisco.nxos.nxos_facts: *id001
 
     - ansible.builtin.assert:
         that:
           - ansible_facts.network_resources.lag_interfaces|symmetric_difference(result.after)|length == 0
 
-    - name: Idempotence - Overridden
+    - name: Idempotence - overridden
       register: result
       cisco.nxos.nxos_lag_interfaces: *id002
 
@@ -71,13 +71,13 @@
         that:
           - result.changed == false
 
-    - name: Create Port-Channel20
+    - name: Create port-channel20
       cisco.nxos.nxos_interfaces:
         config:
           - name: port-channel20
             description: Ansible Resource LAG
 
-    - name: Add first member to Port-Channel using overridden
+    - name: Add first member to port-channel using overridden
       cisco.nxos.nxos_lag_interfaces:
         config:
           - name: port-channel20
@@ -99,7 +99,7 @@
       ignore_errors: true
       cisco.nxos.nxos_lag_interfaces: *id003
 
-    - name: disable feature lacp
+    - name: Disable feature lacp
       cisco.nxos.nxos_feature:
         feature: lacp
         state: disabled

--- a/tests/integration/targets/nxos_lag_interfaces/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_lag_interfaces/tests/common/replaced.yaml
@@ -10,11 +10,11 @@
   ansible.builtin.set_fact:
     test_int2: "{{ nxos_int2 }}"
 
-- name: enable feature lacp
+- name: Enable feature lacp
   cisco.nxos.nxos_feature:
     feature: lacp
 
-- name: setup1
+- name: Setup1
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines:
@@ -23,12 +23,12 @@
       - no interface port-channel 19
       - no interface port-channel 20
 
-- name: setup2
+- name: Setup2
   cisco.nxos.nxos_lag_interfaces: &id003
     state: deleted
 
 - block:
-    - name: setup3
+    - name: Setup3
       ignore_errors: true
       loop:
         - interface {{ test_int1 }}
@@ -38,7 +38,7 @@
           - channel-group 10
         parents: "{{ item }}"
 
-    - name: Gather LAG interfaces facts
+    - name: Gather lag interfaces facts
       cisco.nxos.nxos_facts: &id001
         gather_subset:
           - "!all"
@@ -59,14 +59,14 @@
         that:
           - ansible_facts.network_resources.lag_interfaces|symmetric_difference(result.before)|length == 0
 
-    - name: Gather LAG interfaces post facts
+    - name: Gather lag interfaces post facts
       cisco.nxos.nxos_facts: *id001
 
     - ansible.builtin.assert:
         that:
           - ansible_facts.network_resources.lag_interfaces|symmetric_difference(result.after)|length == 0
 
-    - name: Idempotence - Replaced
+    - name: Idempotence - replaced
       register: result
       cisco.nxos.nxos_lag_interfaces: *id002
 
@@ -74,11 +74,11 @@
         that:
           - result.changed == false
   always:
-    - name: teardown1
+    - name: Teardown1
       ignore_errors: true
       cisco.nxos.nxos_lag_interfaces: *id003
 
-    - name: disable feature lacp
+    - name: Disable feature lacp
       cisco.nxos.nxos_feature:
         feature: lacp
         state: disabled

--- a/tests/integration/targets/nxos_linkagg/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_linkagg/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_linkagg/tasks/main.yaml
+++ b/tests/integration/targets/nxos_linkagg/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_linkagg/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_linkagg/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_linkagg/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_linkagg/tests/common/sanity.yaml
@@ -10,19 +10,19 @@
   ansible.builtin.set_fact:
     testint2: "{{ nxos_int2 }}"
 
-- name: Enable feature LACP
+- name: Enable feature lacp
   ignore_errors: true
   cisco.nxos.nxos_feature:
     feature: lacp
     state: enabled
 
-- name: setup - remove config used in test(part1)
+- name: Setup - remove config used in test(part1)
   cisco.nxos.nxos_config:
     lines:
       - no interface port-channel 20
       - no interface port-channel 100
 
-- name: setup - remove config used in test(part2)
+- name: Setup - remove config used in test(part2)
   ignore_errors: true
   loop:
     - interface {{ testint1 }}
@@ -32,7 +32,7 @@
       - no channel-group 20
     parents: "{{ item }}"
 
-- name: Put interface in L2 mode
+- name: Put interface in l2 mode
   when: platform is match("N35")
   cisco.nxos.nxos_interface:
     aggregate:
@@ -41,7 +41,7 @@
       - name: "{{testint2}}"
     mode: layer2
 
-- name: create linkagg
+- name: Create linkagg
   register: result
   cisco.nxos.nxos_linkagg: &id001
     group: 20
@@ -52,7 +52,7 @@
       - result.changed == true
       - '"interface port-channel 20" in result.commands'
 
-- name: create linkagg(Idempotence)
+- name: Create linkagg(idempotence)
   register: result
   cisco.nxos.nxos_linkagg: *id001
 
@@ -60,7 +60,7 @@
     that:
       - result.changed == false
 
-- name: set link aggregation group to members declaratively
+- name: Set link aggregation group to members declaratively
   register: result
   cisco.nxos.nxos_linkagg: &id002
     group: 20
@@ -78,7 +78,7 @@
       - '"interface {{ testint2 }}" in result.commands'
       - '"channel-group 20 force mode active" in result.commands'
 
-- name: set link aggregation group to members(Idempotence)
+- name: Set link aggregation group to members(idempotence)
   register: result
   cisco.nxos.nxos_linkagg: *id002
 
@@ -86,7 +86,7 @@
     that:
       - result.changed == false
 
-- name: remove link aggregation group from member declaratively
+- name: Remove link aggregation group from member declaratively
   register: result
   cisco.nxos.nxos_linkagg: &id003
     group: 20
@@ -101,7 +101,7 @@
       - '"interface {{ testint1 }}" in result.commands'
       - '"no channel-group 20" in result.commands'
 
-- name: remove link aggregation group from member(Idempotence)
+- name: Remove link aggregation group from member(idempotence)
   register: result
   cisco.nxos.nxos_linkagg: *id003
 
@@ -109,7 +109,7 @@
     that:
       - result.changed == false
 
-- name: remove linkagg
+- name: Remove linkagg
   register: result
   cisco.nxos.nxos_linkagg: &id004
     group: 20
@@ -120,7 +120,7 @@
       - result.changed == true
       - '"no interface port-channel 20" in result.commands'
 
-- name: remove linkagg(Idempotence)
+- name: Remove linkagg(idempotence)
   register: result
   cisco.nxos.nxos_linkagg: *id004
 
@@ -128,7 +128,7 @@
     that:
       - result.changed == false
 
-- name: create aggregate of linkagg definitions
+- name: Create aggregate of linkagg definitions
   register: result
   cisco.nxos.nxos_linkagg: &id005
     aggregate:
@@ -146,7 +146,7 @@
       - '"interface port-channel 100" in result.commands'
       - '"lacp min-links 4" in result.commands'
 
-- name: create aggregate of linkagg definitions(Idempotence)
+- name: Create aggregate of linkagg definitions(idempotence)
   register: result
   cisco.nxos.nxos_linkagg: *id005
 
@@ -154,7 +154,7 @@
     that:
       - result.changed == false
 
-- name: remove aggregate of linkagg definitions
+- name: Remove aggregate of linkagg definitions
   register: result
   cisco.nxos.nxos_linkagg: &id006
     aggregate:
@@ -171,7 +171,7 @@
       - '"no interface port-channel 20" in result.commands'
       - '"no interface port-channel 100" in result.commands'
 
-- name: remove aggregate of linkagg definitions(Idempotence)
+- name: Remove aggregate of linkagg definitions(idempotence)
   register: result
   cisco.nxos.nxos_linkagg: *id006
 
@@ -179,13 +179,13 @@
     that:
       - result.changed == false
 
-- name: teardown - remove config used in test(part1)
+- name: Teardown - remove config used in test(part1)
   cisco.nxos.nxos_config:
     lines:
       - no interface port-channel 20
       - no interface port-channel 100
 
-- name: teardown - remove config used in test(part2)
+- name: Teardown - remove config used in test(part2)
   ignore_errors: true
   loop:
     - interface {{ testint1 }}
@@ -195,7 +195,7 @@
       - no channel-group 20
     parents: "{{ item }}"
 
-- name: Disable feature LACP
+- name: Disable feature lacp
   cisco.nxos.nxos_feature:
     feature: lacp
     state: disabled

--- a/tests/integration/targets/nxos_lldp/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_lldp/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_lldp/tasks/main.yaml
+++ b/tests/integration/targets/nxos_lldp/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_lldp/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_lldp/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_lldp/tests/cli/sanity.yaml
+++ b/tests/integration/targets/nxos_lldp/tests/cli/sanity.yaml
@@ -2,12 +2,12 @@
 - ansible.builtin.debug:
     msg: START TRANSPORT:CLI nxos_lldp sanity test
 
-- name: Make sure LLDP is not running before tests
+- name: Make sure lldp is not running before tests
   cisco.nxos.nxos_feature:
     feature: lldp
     state: disabled
 
-- name: Enable LLDP service
+- name: Enable lldp service
   register: result
   cisco.nxos.nxos_lldp:
     state: present
@@ -17,7 +17,7 @@
       - result.changed == true
       - '"feature lldp" in result.commands'
 
-- name: Enable LLDP service again (idempotent)
+- name: Enable lldp service again (idempotent)
   register: result
   cisco.nxos.nxos_lldp:
     state: present
@@ -26,7 +26,7 @@
     that:
       - result.changed == false
 
-- name: Disable LLDP service
+- name: Disable lldp service
   register: result
   cisco.nxos.nxos_lldp:
     state: absent
@@ -36,7 +36,7 @@
       - result.changed == true
       - '"no feature lldp" in result.commands'
 
-- name: Disable LLDP service (idempotent)
+- name: Disable lldp service (idempotent)
   register: result
   cisco.nxos.nxos_lldp:
     state: absent

--- a/tests/integration/targets/nxos_lldp/tests/nxapi/sanity.yaml
+++ b/tests/integration/targets/nxos_lldp/tests/nxapi/sanity.yaml
@@ -2,12 +2,12 @@
 - ansible.builtin.debug:
     msg: START TRANSPORT:NXAPI nxos_lldp sanity test
 
-- name: Make sure LLDP is not running before tests
+- name: Make sure lldp is not running before tests
   cisco.nxos.nxos_feature:
     feature: lldp
     state: disabled
 
-- name: Enable LLDP service
+- name: Enable lldp service
   register: result
   cisco.nxos.nxos_lldp:
     state: present
@@ -17,7 +17,7 @@
       - result.changed == true
       - '"feature lldp" in result.commands'
 
-- name: Enable LLDP service again (idempotent)
+- name: Enable lldp service again (idempotent)
   register: result
   cisco.nxos.nxos_lldp:
     state: present
@@ -26,7 +26,7 @@
     that:
       - result.changed == false
 
-- name: Disable LLDP service
+- name: Disable lldp service
   register: result
   cisco.nxos.nxos_lldp:
     state: absent
@@ -36,7 +36,7 @@
       - result.changed == true
       - '"no feature lldp" in result.commands'
 
-- name: Disable LLDP service (idempotent)
+- name: Disable lldp service (idempotent)
   register: result
   cisco.nxos.nxos_lldp:
     state: absent

--- a/tests/integration/targets/nxos_lldp_global/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_lldp_global/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_lldp_global/tasks/main.yaml
+++ b/tests/integration/targets/nxos_lldp_global/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_lldp_global/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_lldp_global/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_lldp_global/tests/common/deleted.yml
+++ b/tests/integration/targets/nxos_lldp_global/tests/common/deleted.yml
@@ -8,12 +8,12 @@
         cfg_port_id: true
       when: platform is not search('N[567]K') and imagetag is not search("I[2345]")
 
-    - name: feature off to cleanup lldp
+    - name: Feature off to cleanup lldp
       cisco.nxos.nxos_feature: &id003
         feature: lldp
         state: disabled
 
-    - name: Enable LLDP feature
+    - name: Enable lldp feature
       cisco.nxos.nxos_feature:
         feature: lldp
         state: enabled
@@ -78,6 +78,6 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_feature: *id003
   when: platform is not search('N35')

--- a/tests/integration/targets/nxos_lldp_global/tests/common/merged.yml
+++ b/tests/integration/targets/nxos_lldp_global/tests/common/merged.yml
@@ -10,7 +10,7 @@
           power_management: false
       when: platform is not search('N5K|N6K|N7K') and imagetag is not search("I[2345]")
 
-    - name: feature off to cleanup lldp
+    - name: Feature off to cleanup lldp
       cisco.nxos.nxos_feature: &id002
         feature: lldp
         state: disabled
@@ -57,7 +57,7 @@
         that:
           - ansible_facts.network_resources.lldp_global == result.after
 
-    - name: Idempotence - Merged
+    - name: Idempotence - merged
       register: result
       cisco.nxos.nxos_lldp_global: *id001
 
@@ -66,6 +66,6 @@
           - result.changed == false
           - result.commands | length == 0
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_feature: *id002
   when: platform is not search('N35')

--- a/tests/integration/targets/nxos_lldp_global/tests/common/replaced.yml
+++ b/tests/integration/targets/nxos_lldp_global/tests/common/replaced.yml
@@ -10,7 +10,7 @@
           power_management: false
       when: platform is not search('N[567]K') and imagetag is not search("I[2345]")
 
-    - name: feature off to cleanup lldp
+    - name: Feature off to cleanup lldp
       cisco.nxos.nxos_feature: &id002
         feature: lldp
         state: disabled
@@ -78,7 +78,7 @@
         that:
           - ansible_facts.network_resources.lldp_global == result.after
 
-    - name: Idempotence - Replaced
+    - name: Idempotence - replaced
       register: result
       cisco.nxos.nxos_lldp_global: *id001
 
@@ -87,6 +87,6 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_feature: *id002
   when: platform is not search('N35')

--- a/tests/integration/targets/nxos_lldp_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_lldp_interfaces/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_lldp_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/nxos_lldp_interfaces/tasks/main.yaml
@@ -1,9 +1,9 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_lldp_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_lldp_interfaces/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_lldp_interfaces/tests/common/deleted.yml
+++ b/tests/integration/targets/nxos_lldp_interfaces/tests/common/deleted.yml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: Start nxos_lldp_interfaces deleted integration tests connection = {{ ansible_connection }}
 
-- name: Enable LLDP feature
+- name: Enable lldp feature
   cisco.nxos.nxos_feature:
     feature: lldp
     state: enabled
@@ -66,7 +66,7 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_feature:
         feature: lldp
         state: disabled

--- a/tests/integration/targets/nxos_lldp_interfaces/tests/common/gathered.yml
+++ b/tests/integration/targets/nxos_lldp_interfaces/tests/common/gathered.yml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: Start nxos_lldp_interfaces gathered integration tests connection={{ansible_connection}}"
 
-- name: Enable LLDP feature
+- name: Enable lldp feature
   cisco.nxos.nxos_feature:
     feature: lldp
     state: enabled
@@ -37,7 +37,7 @@
           - result.changed == false
           - ansible_facts.network_resources.lldp_interfaces == result.gathered
 
-    - name: Idempotence - Gathered
+    - name: Idempotence - gathered
       register: result
       cisco.nxos.nxos_lldp_interfaces: *id001
 
@@ -45,7 +45,7 @@
         that:
           - result.changed == false
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_feature:
         feature: lldp
         state: disabled

--- a/tests/integration/targets/nxos_lldp_interfaces/tests/common/merged.yml
+++ b/tests/integration/targets/nxos_lldp_interfaces/tests/common/merged.yml
@@ -44,7 +44,7 @@
         that:
           - ansible_facts.network_resources.lldp_interfaces == result.after
 
-    - name: Idempotence - Merged
+    - name: Idempotence - merged
       register: result
       cisco.nxos.nxos_lldp_interfaces: *id001
 
@@ -53,7 +53,7 @@
           - result.changed == false
           - result.commands | length == 0
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_feature:
         feature: lldp
         state: disabled

--- a/tests/integration/targets/nxos_lldp_interfaces/tests/common/overridden.yml
+++ b/tests/integration/targets/nxos_lldp_interfaces/tests/common/overridden.yml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: Start nxos_lldp_interfaces overridden tests connection={{ ansible_connection }}
 
-- name: Enable LLDP feature
+- name: Enable lldp feature
   cisco.nxos.nxos_feature:
     feature: lldp
     state: enabled
@@ -59,7 +59,7 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_feature:
         feature: lldp
         state: disabled

--- a/tests/integration/targets/nxos_lldp_interfaces/tests/common/parsed.yml
+++ b/tests/integration/targets/nxos_lldp_interfaces/tests/common/parsed.yml
@@ -17,8 +17,7 @@
     - name: Parsed
       register: result
       cisco.nxos.nxos_lldp_interfaces: &id001
-        running_config:
-          "interface Ethernet1/1\n  lldp receive\n  no lldp transmit\ninterface Ethernet1/2\n  no lldp receive\n  lldp tlv-set vlan 12\ninterface Ethernet1/3\n\
+        running_config: "interface Ethernet1/1\n  lldp receive\n  no lldp transmit\ninterface Ethernet1/2\n  no lldp receive\n  lldp tlv-set vlan 12\ninterface Ethernet1/3\n\
           \  lldp tlv-set management-address 192.0.2.12\n"
         state: parsed
 
@@ -27,14 +26,14 @@
           - result.changed == false
           - result.parsed == parsed
 
-    - name: Idempotence - Parsed
+    - name: Idempotence - parsed
       register: result
       cisco.nxos.nxos_lldp_interfaces: *id001
 
     - ansible.builtin.assert:
         that: result.changed == false
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_feature:
         feature: lldp
         state: disabled

--- a/tests/integration/targets/nxos_lldp_interfaces/tests/common/parsed.yml
+++ b/tests/integration/targets/nxos_lldp_interfaces/tests/common/parsed.yml
@@ -17,7 +17,8 @@
     - name: Parsed
       register: result
       cisco.nxos.nxos_lldp_interfaces: &id001
-        running_config: "interface Ethernet1/1\n  lldp receive\n  no lldp transmit\ninterface Ethernet1/2\n  no lldp receive\n  lldp tlv-set vlan 12\ninterface Ethernet1/3\n\
+        running_config:
+          "interface Ethernet1/1\n  lldp receive\n  no lldp transmit\ninterface Ethernet1/2\n  no lldp receive\n  lldp tlv-set vlan 12\ninterface Ethernet1/3\n\
           \  lldp tlv-set management-address 192.0.2.12\n"
         state: parsed
 

--- a/tests/integration/targets/nxos_lldp_interfaces/tests/common/rendered.yml
+++ b/tests/integration/targets/nxos_lldp_interfaces/tests/common/rendered.yml
@@ -33,7 +33,7 @@
       - "'lldp tlv-set management-address 192.0.2.12' in result.rendered"
       - result.rendered | length == 8
 
-- name: Idempotence - Rendered
+- name: Idempotence - rendered
   register: result
   cisco.nxos.nxos_lldp_interfaces: *id001
 

--- a/tests/integration/targets/nxos_lldp_interfaces/tests/common/replaced.yml
+++ b/tests/integration/targets/nxos_lldp_interfaces/tests/common/replaced.yml
@@ -46,7 +46,7 @@
         that:
           - ansible_facts.network_resources.lldp_interfaces == result.after
 
-    - name: Idempotence - Replaced
+    - name: Idempotence - replaced
       register: result
       cisco.nxos.nxos_lldp_interfaces: *id001
 
@@ -55,7 +55,7 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_feature:
         feature: lldp
         state: disabled

--- a/tests/integration/targets/nxos_lldp_interfaces/tests/common/rtt.yml
+++ b/tests/integration/targets/nxos_lldp_interfaces/tests/common/rtt.yml
@@ -9,7 +9,7 @@
 - ansible.builtin.include_tasks: remove_config.yaml
 
 - block:
-    - name: RTT - Apply the provided configuration (base config)
+    - name: Rtt - apply the provided configuration (base config)
       register: base_config
       cisco.nxos.nxos_lldp_interfaces:
         config:
@@ -63,7 +63,7 @@
       ansible.builtin.assert:
         that: "{{ base_config['after'] | symmetric_difference(revert['after']) |length == 0 }}"
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_feature:
         feature: lldp
         state: disabled

--- a/tests/integration/targets/nxos_logging/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_logging/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_logging/tasks/main.yaml
+++ b/tests/integration/targets/nxos_logging/tasks/main.yaml
@@ -1,16 +1,16 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
 
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi
   always:
-    - name: Set Baud Rate Back to 9600 so our tests don't break
+    - name: Set baud rate back to 9600 so our tests don't break
       connection: ansible.netcommon.network_cli
       cisco.nxos.nxos_config:
         lines:

--- a/tests/integration/targets/nxos_logging/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_logging/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_logging/tests/common/basic.yaml
+++ b/tests/integration/targets/nxos_logging/tests/common/basic.yaml
@@ -139,7 +139,7 @@
 
 - ansible.builtin.assert: *id003
 
-- name: Configure Remote Logging
+- name: Configure remote logging
   register: result
   cisco.nxos.nxos_logging: &id009
     dest: server
@@ -154,13 +154,13 @@
       - result.changed == true
       - '"logging server test-syslogserver.com 1 facility auth use-vrf management" in result.commands'
 
-- name: Configure Remote Logging (idempotent)
+- name: Configure remote logging (idempotent)
   register: result
   cisco.nxos.nxos_logging: *id009
 
 - ansible.builtin.assert: *id003
 
-- name: Configure Source Interface for Logging
+- name: Configure source interface for logging
   register: result
   cisco.nxos.nxos_logging: &id010
     interface: mgmt0
@@ -170,7 +170,7 @@
       - result.changed == true
       - '"logging source-interface mgmt 0" in result.commands'
 
-- name: Configure Source Interface for Logging (idempotent)
+- name: Configure source interface for logging (idempotent)
   register: result
   cisco.nxos.nxos_logging: *id010
 
@@ -178,7 +178,7 @@
     that:
       - result.changed == false
 
-- name: remove logging as collection tearDown
+- name: Remove logging as collection teardown
   register: result
   cisco.nxos.nxos_logging: &id011
     aggregate:
@@ -228,14 +228,14 @@
       - '"no logging source-interface" in result.commands'
   when: platform is search('N5K|N7K') or imagetag is search("A8")
 
-- name: remove aggregate logging (idempotent)
+- name: Remove aggregate logging (idempotent)
   register: result
   cisco.nxos.nxos_logging: *id011
 
 - ansible.builtin.assert: *id003
 
 - block:
-    - name: Configure Logging message
+    - name: Configure logging message
       register: result
       cisco.nxos.nxos_logging: &id012
         interface_message: add-interface-description
@@ -245,13 +245,13 @@
         that:
           - result.changed == true
 
-    - name: Configure Logging message (idempotent)
+    - name: Configure logging message (idempotent)
       register: result
       cisco.nxos.nxos_logging: *id012
 
     - ansible.builtin.assert: *id003
 
-    - name: Remove Logging message
+    - name: Remove logging message
       register: result
       cisco.nxos.nxos_logging:
         interface_message: add-interface-description
@@ -411,7 +411,7 @@
 
 - ansible.builtin.assert: *id003
 
-- name: Set up Logging Timestamp
+- name: Set up logging timestamp
   register: result
   cisco.nxos.nxos_logging: &id023
     timestamp: microseconds
@@ -419,13 +419,13 @@
 
 - ansible.builtin.assert: *id013
 
-- name: Set up Logging Timestamp (idempotent)
+- name: Set up logging timestamp (idempotent)
   register: result
   cisco.nxos.nxos_logging: *id023
 
 - ansible.builtin.assert: *id003
 
-- name: Remove Logging Timestamp
+- name: Remove logging timestamp
   register: result
   cisco.nxos.nxos_logging:
     timestamp: microseconds
@@ -433,7 +433,7 @@
 
 - ansible.builtin.assert: *id013
 
-- name: Set up Facility ethpm Link UP Error
+- name: Set up facility ethpm link up error
   register: result
   cisco.nxos.nxos_logging: &id024
     facility: ethpm
@@ -442,13 +442,13 @@
 
 - ansible.builtin.assert: *id013
 
-- name: Set up Facility ethpm Link UP Error (idempotent)
+- name: Set up facility ethpm link up error (idempotent)
   register: result
   cisco.nxos.nxos_logging: *id024
 
 - ansible.builtin.assert: *id003
 
-- name: Remove Facility ethpm Link UP Error
+- name: Remove facility ethpm link up error
   register: result
   cisco.nxos.nxos_logging:
     facility: ethpm
@@ -457,7 +457,7 @@
 
 - ansible.builtin.assert: *id013
 
-- name: Set up Facility ethpm Link DOWN Error
+- name: Set up facility ethpm link down error
   register: result
   cisco.nxos.nxos_logging: &id025
     facility: ethpm
@@ -466,13 +466,13 @@
 
 - ansible.builtin.assert: *id013
 
-- name: Set up Facility ethpm Link DOWN Error (idempotent)
+- name: Set up facility ethpm link down error (idempotent)
   register: result
   cisco.nxos.nxos_logging: *id025
 
 - ansible.builtin.assert: *id003
 
-- name: Remove Facility ethpm Link DOWN Error
+- name: Remove facility ethpm link down error
   register: result
   cisco.nxos.nxos_logging:
     facility: ethpm

--- a/tests/integration/targets/nxos_logging/tests/common/purge.yaml
+++ b/tests/integration/targets/nxos_logging/tests/common/purge.yaml
@@ -19,7 +19,7 @@
           - result.changed == true
           - '"logging console 0" in result.commands'
 
-    - name: Set up Logging Timestamp
+    - name: Set up logging timestamp
       register: result
       cisco.nxos.nxos_logging:
         timestamp: microseconds
@@ -82,7 +82,7 @@
               - result.changed == false
       when: imagetag is not search("A8")
 
-    - name: remove logging as collection tearDown
+    - name: Remove logging as collection teardown
       register: result
       cisco.nxos.nxos_logging:
         aggregate:

--- a/tests/integration/targets/nxos_logging_global/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_logging_global/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_logging_global/tasks/main.yaml
+++ b/tests/integration/targets/nxos_logging_global/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli.yaml
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_logging_global/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_logging_global/tasks/nxapi.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_logging_global/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_logging_global/tests/common/deleted.yaml
@@ -26,7 +26,7 @@
         that:
           - result['after'] == {}
 
-    - name: Delete all logging configuration (IDEMPOTENT)
+    - name: Delete all logging configuration (idempotent)
       cisco.nxos.nxos_logging_global: *del
       register: result
 

--- a/tests/integration/targets/nxos_logging_global/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_logging_global/tests/common/merged.yaml
@@ -51,7 +51,7 @@
         that:
           - "{{ merged['after'] == result['after'] }}"
 
-    - name: Merge the provided configuration with the existing running configuration (IDEMPOTENT)
+    - name: Merge the provided configuration with the existing running configuration (idempotent)
       cisco.nxos.nxos_logging_global: *id001
       register: result
 

--- a/tests/integration/targets/nxos_logging_global/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_logging_global/tests/common/overridden.yaml
@@ -52,7 +52,7 @@
         that:
           - replaced['after'] == result['after']
 
-    - name: Override all logging configuration with provided configuration (IDEMPOTENT)
+    - name: Override all logging configuration with provided configuration (idempotent)
       register: result
       cisco.nxos.nxos_logging_global: *id001
 

--- a/tests/integration/targets/nxos_logging_global/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_logging_global/tests/common/replaced.yaml
@@ -52,7 +52,7 @@
         that:
           - replaced['after'] == result['after']
 
-    - name: Replace logging global configurations with provided configurations (IDEMPOTENT)
+    - name: Replace logging global configurations with provided configurations (idempotent)
       register: result
       cisco.nxos.nxos_logging_global: *id001
 

--- a/tests/integration/targets/nxos_ntp/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_ntp/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_ntp/tasks/main.yaml
+++ b/tests/integration/targets/nxos_ntp/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
   always:
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_ntp/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_ntp/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_ntp/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_ntp/tests/common/sanity.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }} nxos_ntp sanity test
 
-- name: Setup - Remove ntp if configured
+- name: Setup - remove ntp if configured
   ignore_errors: true
   cisco.nxos.nxos_ntp: &id005
     server: 1.2.3.4
@@ -27,7 +27,7 @@
         that:
           - result.changed == true
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_ntp: *id001
 
@@ -47,7 +47,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_ntp: *id003
 
@@ -59,7 +59,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Remove Idempotence Check
+    - name: Remove idempotence check
       register: result
       cisco.nxos.nxos_ntp: *id005
 
@@ -75,7 +75,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_ntp: *id006
 
@@ -89,7 +89,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_ntp: *id007
 
@@ -101,7 +101,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Remove Idempotence Check
+    - name: Remove idempotence check
       register: result
       cisco.nxos.nxos_ntp: *id005
 

--- a/tests/integration/targets/nxos_ntp_auth/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_ntp_auth/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_ntp_auth/tasks/main.yaml
+++ b/tests/integration/targets/nxos_ntp_auth/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_ntp_auth/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_ntp_auth/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_ntp_auth/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_ntp_auth/tests/common/sanity.yaml
@@ -42,7 +42,7 @@
 
     - ansible.builtin.assert: *id001
 
-    - name: Check Idempotence - Configure encrypt ntp authentication
+    - name: Check idempotence - configure encrypt ntp authentication
       register: result
       cisco.nxos.nxos_ntp_auth: *id002
 
@@ -58,7 +58,7 @@
 
     - ansible.builtin.assert: *id001
 
-    - name: Check Idempotence - Turn on authentication
+    - name: Check idempotence - turn on authentication
       register: result
       cisco.nxos.nxos_ntp_auth: *id003
 
@@ -72,7 +72,7 @@
 
     - ansible.builtin.assert: *id001
 
-    - name: Check Idempotence - Turn off authentication
+    - name: Check idempotence - turn off authentication
       register: result
       cisco.nxos.nxos_ntp_auth: *id005
 
@@ -87,7 +87,7 @@
 
     - ansible.builtin.assert: *id001
 
-    - name: Check Idempotence - Add trusted key
+    - name: Check idempotence - add trusted key
       register: result
       cisco.nxos.nxos_ntp_auth: *id006
 
@@ -102,7 +102,7 @@
 
     - ansible.builtin.assert: *id001
 
-    - name: Check Idempotence - Remove trusted key
+    - name: Check idempotence - remove trusted key
       register: result
       cisco.nxos.nxos_ntp_auth: *id007
 
@@ -119,7 +119,7 @@
 
     - ansible.builtin.assert: *id001
 
-    - name: Check Idempotence - Remove encrypt ntp authentication
+    - name: Check idempotence - remove encrypt ntp authentication
       register: result
       cisco.nxos.nxos_ntp_auth: *id008
 

--- a/tests/integration/targets/nxos_ntp_global/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_ntp_global/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_ntp_global/tasks/main.yaml
+++ b/tests/integration/targets/nxos_ntp_global/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli.yaml
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_ntp_global/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_ntp_global/tasks/nxapi.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_ntp_global/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_ntp_global/tests/common/deleted.yaml
@@ -26,7 +26,7 @@
         that:
           - result['after'] == {}
 
-    - name: Delete all logging configuration (IDEMPOTENT)
+    - name: Delete all logging configuration (idempotent)
       cisco.nxos.nxos_ntp_global: *del
       register: result
 

--- a/tests/integration/targets/nxos_ntp_global/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_ntp_global/tests/common/merged.yaml
@@ -50,7 +50,7 @@
         that:
           - "{{ merged['after'] == result['after'] }}"
 
-    - name: Merge the provided configuration with the existing running configuration (IDEMPOTENT)
+    - name: Merge the provided configuration with the existing running configuration (idempotent)
       cisco.nxos.nxos_ntp_global: *id001
       register: result
 

--- a/tests/integration/targets/nxos_ntp_global/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_ntp_global/tests/common/overridden.yaml
@@ -50,7 +50,7 @@
         that:
           - replaced['after'] == result['after']
 
-    - name: Override all logging configuration with provided configuration (IDEMPOTENT)
+    - name: Override all logging configuration with provided configuration (idempotent)
       register: result
       cisco.nxos.nxos_ntp_global: *id001
 

--- a/tests/integration/targets/nxos_ntp_global/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_ntp_global/tests/common/replaced.yaml
@@ -50,7 +50,7 @@
         that:
           - replaced['after'] == result['after']
 
-    - name: Replace logging global configurations with provided configurations (IDEMPOTENT)
+    - name: Replace logging global configurations with provided configurations (idempotent)
       register: result
       cisco.nxos.nxos_ntp_global: *id001
 

--- a/tests/integration/targets/nxos_ntp_options/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_ntp_options/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_ntp_options/tasks/main.yaml
+++ b/tests/integration/targets/nxos_ntp_options/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_ntp_options/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_ntp_options/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_ntp_options/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_ntp_options/tests/common/sanity.yaml
@@ -19,7 +19,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence - Configure ntp with master and default stratum
+    - name: Check idempotence - configure ntp with master and default stratum
       register: result
       cisco.nxos.nxos_ntp_options: *id001
 
@@ -36,7 +36,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence - Configure ntp with master and non-default stratum
+    - name: Check idempotence - configure ntp with master and non-default stratum
       register: result
       cisco.nxos.nxos_ntp_options: *id003
 
@@ -52,7 +52,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence - Configure ntp with master and no logging
+    - name: Check idempotence - configure ntp with master and no logging
       register: result
       cisco.nxos.nxos_ntp_options: *id005
 
@@ -67,7 +67,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence - Configure ntp with logging and no master
+    - name: Check idempotence - configure ntp with logging and no master
       register: result
       cisco.nxos.nxos_ntp_options: *id006
 
@@ -85,7 +85,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence - Remove
+    - name: Check idempotence - remove
       register: result
       cisco.nxos.nxos_ntp_options: *id007
 

--- a/tests/integration/targets/nxos_nxapi/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_nxapi/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_nxapi/tasks/main.yaml
+++ b/tests/integration/targets/nxos_nxapi/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_nxapi/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_nxapi/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:
@@ -31,7 +31,7 @@
   vars:
     ansible_connection: ansible.netcommon.httpapi
     connection: "{{ nxapi }}"
-- name: run test cases (connection=local)
+- name: Run test cases (connection=local)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_http.yaml
+++ b/tests/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_http.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Assert HTTP configuration changes
+- name: Assert http configuration changes
   ansible.builtin.assert:
     that:
       - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port
@@ -7,7 +7,7 @@
       - result.stdout[0]['operation_status'].o_status == 'nxapi enabled'
   when: result.stdout[0].TABLE_listen_on_port is defined
 
-- name: Assert HTTP configuration changes 9.2 or greater
+- name: Assert http configuration changes 9.2 or greater
   ansible.builtin.assert:
     that:
       - result.stdout[0]['http_port']

--- a/tests/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https.yaml
+++ b/tests/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Assert HTTPS configuration changes
+- name: Assert https configuration changes
   ansible.builtin.assert:
     that:
       - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port
@@ -7,7 +7,7 @@
       - result.stdout[0]['operation_status'].o_status == 'nxapi enabled'
   when: result.stdout[0].TABLE_listen_on_port is defined
 
-- name: Assert HTTPS configuration changes 9.2 or greater
+- name: Assert https configuration changes 9.2 or greater
   ansible.builtin.assert:
     that:
       - result.stdout[0]['https_port']

--- a/tests/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https_http.yaml
+++ b/tests/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https_http.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Assert HTTPS & HTTP configuration changes
+- name: Assert https & http configuration changes
   ansible.builtin.assert:
     that:
       - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][1].l_port
@@ -9,7 +9,7 @@
       - result.stdout[0]['operation_status'].o_status == 'nxapi enabled'
   when: result.stdout[0].TABLE_listen_on_port is defined
 
-- name: Assert HTTPS & HTTP configuration changes 9.2 or greater
+- name: Assert https & http configuration changes 9.2 or greater
   ansible.builtin.assert:
     that:
       - result.stdout[0]['https_port']

--- a/tests/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https_http_ports.yaml
+++ b/tests/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https_http_ports.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Assert HTTPS & HTTP configuration changes
+- name: Assert https & http configuration changes
   ansible.builtin.assert:
     that:
       - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][1].l_port
@@ -9,7 +9,7 @@
       - result.stdout[0]['operation_status'].o_status == 'nxapi enabled'
   when: result.stdout[0].TABLE_listen_on_port is defined
 
-- name: Assert HTTPS & HTTP configuration changes 9.2 or greater
+- name: Assert https & http configuration changes 9.2 or greater
   ansible.builtin.assert:
     that:
       - result.stdout[0]['https_port']

--- a/tests/integration/targets/nxos_nxapi/tasks/platform/n5k/assert_changes_http.yaml
+++ b/tests/integration/targets/nxos_nxapi/tasks/platform/n5k/assert_changes_http.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Assert HTTP configuration changes
+- name: Assert http configuration changes
   ansible.builtin.assert:
     that:
       - result.stdout[0].https_port is not defined

--- a/tests/integration/targets/nxos_nxapi/tasks/platform/n5k/assert_changes_https.yaml
+++ b/tests/integration/targets/nxos_nxapi/tasks/platform/n5k/assert_changes_https.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Assert HTTPS configuration changes
+- name: Assert https configuration changes
   ansible.builtin.assert:
     that:
       - result.stdout[0].http_port is not defined

--- a/tests/integration/targets/nxos_nxapi/tasks/platform/n5k/assert_changes_https_http.yaml
+++ b/tests/integration/targets/nxos_nxapi/tasks/platform/n5k/assert_changes_https_http.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Assert HTTPS && HTTP configuration changes
+- name: Assert https && http configuration changes
   ansible.builtin.assert:
     that:
       - result.stdout[0].https_port is defined

--- a/tests/integration/targets/nxos_nxapi/tasks/platform/n5k/assert_changes_https_http_ports.yaml
+++ b/tests/integration/targets/nxos_nxapi/tasks/platform/n5k/assert_changes_https_http_ports.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Assert HTTPS && HTTP configuration changes
+- name: Assert https && http configuration changes
   ansible.builtin.assert:
     that:
       - result.stdout[0].https_port is defined

--- a/tests/integration/targets/nxos_nxapi/tasks/platform/n7k/assert_changes_http.yaml
+++ b/tests/integration/targets/nxos_nxapi/tasks/platform/n7k/assert_changes_http.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Assert HTTP configuration changes
+- name: Assert http configuration changes
   ansible.builtin.assert:
     that:
       - result.stdout[0].https_port is not defined

--- a/tests/integration/targets/nxos_nxapi/tasks/platform/n7k/assert_changes_https.yaml
+++ b/tests/integration/targets/nxos_nxapi/tasks/platform/n7k/assert_changes_https.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Assert HTTPS configuration changes
+- name: Assert https configuration changes
   ansible.builtin.assert:
     that:
       - result.stdout[0].http_port is not defined

--- a/tests/integration/targets/nxos_nxapi/tasks/platform/n7k/assert_changes_https_http.yaml
+++ b/tests/integration/targets/nxos_nxapi/tasks/platform/n7k/assert_changes_https_http.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Assert HTTPS & HTTP configuration changes
+- name: Assert https & http configuration changes
   ansible.builtin.assert:
     that:
       - result.stdout[0].https_port is defined

--- a/tests/integration/targets/nxos_nxapi/tasks/platform/n7k/assert_changes_https_http_ports.yaml
+++ b/tests/integration/targets/nxos_nxapi/tasks/platform/n7k/assert_changes_https_http_ports.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Assert HTTPS & HTTP configuration changes
+- name: Assert https & http configuration changes
   ansible.builtin.assert:
     that:
       - result.stdout[0].https_port is defined

--- a/tests/integration/targets/nxos_nxapi/tests/cli/configure.yaml
+++ b/tests/integration/targets/nxos_nxapi/tests/cli/configure.yaml
@@ -7,12 +7,12 @@
     nxapi_sandbox_option: true
   when: platform is search('N7K')
 
-- name: Setup - put NXAPI in stopped state
+- name: Setup - put nxapi in stopped state
   cisco.nxos.nxos_nxapi:
     state: absent
 
 - block:
-    - name: Configure NXAPI HTTPS
+    - name: Configure nxapi https
       register: result
       cisco.nxos.nxos_nxapi: &id001
         enable_http: false
@@ -34,7 +34,7 @@
     - ansible.builtin.include: tasks/platform/default/assert_changes_https.yaml
       when: platform is not search('N35|N5K|N6K|N7K')
 
-    - name: Configure NXAPI HTTPS again
+    - name: Configure nxapi https again
       register: result
       cisco.nxos.nxos_nxapi: *id001
 
@@ -43,7 +43,7 @@
         that:
           - result.changed == false
 
-    - name: Configure NXAPI HTTPS & HTTP
+    - name: Configure nxapi https & http
       register: result
       cisco.nxos.nxos_nxapi: &id002
         enable_http: true
@@ -65,14 +65,14 @@
     - ansible.builtin.include: tasks/platform/default/assert_changes_https_http.yaml
       when: platform is not search('N35|N5K|N6K|N7K')
 
-    - name: Configure NXAPI HTTPS & HTTP again
+    - name: Configure nxapi https & http again
       register: result
       cisco.nxos.nxos_nxapi: *id002
 
     - name: Assert configuration is idempotent
       ansible.builtin.assert: *id003
 
-    - name: Configure different NXAPI HTTPS & HTTP ports
+    - name: Configure different nxapi https & http ports
       register: result
       cisco.nxos.nxos_nxapi: &id004
         enable_http: true
@@ -95,14 +95,14 @@
     - ansible.builtin.include: tasks/platform/default/assert_changes_https_http_ports.yaml
       when: platform is not search('N35|N5K|N6K|N7K')
 
-    - name: Configure different NXAPI HTTPS & HTTP ports again
+    - name: Configure different nxapi https & http ports again
       register: result
       cisco.nxos.nxos_nxapi: *id004
 
     - name: Assert configuration is idempotent
       ansible.builtin.assert: *id003
 
-    - name: Configure NXAPI HTTP
+    - name: Configure nxapi http
       register: result
       cisco.nxos.nxos_nxapi: &id005
         enable_http: true
@@ -123,19 +123,19 @@
     - ansible.builtin.include: tasks/platform/default/assert_changes_http.yaml
       when: platform is not search('N35|N5K|N6K|N7K')
 
-    - name: Configure NXAPI HTTP again
+    - name: Configure nxapi http again
       register: result
       cisco.nxos.nxos_nxapi: *id005
 
     - name: Assert configuration is idempotent
       ansible.builtin.assert: *id003
   always:
-    - name: Cleanup - Disable NXAPI
+    - name: Cleanup - disable nxapi
       register: result
       cisco.nxos.nxos_nxapi:
         state: absent
 
-    - name: Cleanup - Re-enable NXAPI
+    - name: Cleanup - re-enable nxapi
       register: result
       cisco.nxos.nxos_nxapi:
         state: present

--- a/tests/integration/targets/nxos_nxapi/tests/cli/disable.yaml
+++ b/tests/integration/targets/nxos_nxapi/tests/cli/disable.yaml
@@ -2,22 +2,22 @@
 - ansible.builtin.debug:
     msg: START cli/disable.yaml
 
-- name: Disable NXAPI
+- name: Disable nxapi
   register: result
   cisco.nxos.nxos_nxapi:
     state: absent
 
-- name: Check NXAPI state
+- name: Check nxapi state
   register: result
   cisco.nxos.nxos_command:
     commands:
       - show feature | grep nxapi
 
-- name: Assert NXAPI is disabled
+- name: Assert nxapi is disabled
   ansible.builtin.assert:
     that: result.stdout[0]  is search('disabled')
 
-- name: Disable NXAPI again
+- name: Disable nxapi again
   register: result
   cisco.nxos.nxos_nxapi:
     state: absent

--- a/tests/integration/targets/nxos_nxapi/tests/cli/enable.yaml
+++ b/tests/integration/targets/nxos_nxapi/tests/cli/enable.yaml
@@ -2,27 +2,27 @@
 - ansible.builtin.debug:
     msg: START cli/enable.yaml
 
-- name: Setup - put NXAPI in stopped state
+- name: Setup - put nxapi in stopped state
   register: result
   cisco.nxos.nxos_nxapi:
     state: absent
 
-- name: Enable NXAPI
+- name: Enable nxapi
   register: result
   cisco.nxos.nxos_nxapi:
     state: present
 
-- name: Check NXAPI state
+- name: Check nxapi state
   register: result
   cisco.nxos.nxos_command:
     commands:
       - show feature | grep nxapi
 
-- name: Assert NXAPI is enabled
+- name: Assert nxapi is enabled
   ansible.builtin.assert:
     that: result.stdout[0]  is search('enabled')
 
-- name: Enable NXAPI again
+- name: Enable nxapi again
   register: result
   cisco.nxos.nxos_nxapi:
 

--- a/tests/integration/targets/nxos_nxapi/tests/cli/nxapi_ssl.yaml
+++ b/tests/integration/targets/nxos_nxapi/tests/cli/nxapi_ssl.yaml
@@ -243,5 +243,6 @@
 
     - ansible.builtin.debug:
         msg: END cli/nxapi_ssl.yaml
-  when: (platform is match("N9K") or platform is match("N3K") or platform is match("N9K-F") or platform is match("N35") or platform is match("N3L")) and major_version
+  when:
+    (platform is match("N9K") or platform is match("N3K") or platform is match("N9K-F") or platform is match("N35") or platform is match("N3L")) and major_version
     is version('9.2', '>=')

--- a/tests/integration/targets/nxos_nxapi/tests/cli/nxapi_ssl.yaml
+++ b/tests/integration/targets/nxos_nxapi/tests/cli/nxapi_ssl.yaml
@@ -3,7 +3,7 @@
     - ansible.builtin.debug:
         msg: START cli/nxapi_ssl.yaml
 
-    - name: Configure NXAPI HTTPs w/weak ciphers
+    - name: Configure nxapi https w/weak ciphers
       register: result
       cisco.nxos.nxos_nxapi: &id001
         enable_https: true
@@ -20,7 +20,7 @@
         that:
           - result.stdout_lines[0][0] == 'nxapi ssl ciphers weak'
 
-    - name: Configure NXAPI HTTP w/weak ciphers again
+    - name: Configure nxapi http w/weak ciphers again
       register: result
       cisco.nxos.nxos_nxapi: *id001
 
@@ -29,7 +29,7 @@
         that:
           - result.changed == false
 
-    - name: Configure NXAPI HTTPs w/strong ciphers
+    - name: Configure nxapi https w/strong ciphers
       register: result
       cisco.nxos.nxos_nxapi: &id002
         enable_https: true
@@ -46,14 +46,14 @@
         that:
           - result.stdout_lines[0][0] == 'no nxapi ssl ciphers weak'
 
-    - name: Configure NXAPI HTTPs w/strong ciphers again
+    - name: Configure nxapi https w/strong ciphers again
       register: result
       cisco.nxos.nxos_nxapi: *id002
 
     - name: Assert configuration is idempotent
       ansible.builtin.assert: *id003
 
-    - name: Configure NXAPI HTTPs w/default TLSv1
+    - name: Configure nxapi https w/default tlsv1
       register: result
       cisco.nxos.nxos_nxapi: &id004
         enable_https: true
@@ -64,19 +64,19 @@
         commands:
           - show run all | inc nxapi | inc protocols
 
-    - name: Assert NXAPI HTTPs w/default TLSv1 configuration
+    - name: Assert nxapi https w/default tlsv1 configuration
       ansible.builtin.assert:
         that:
           - result.stdout_lines[0][0] == 'nxapi ssl protocols TLSv1'
 
-    - name: Configure NXAPI HTTPs w/default again
+    - name: Configure nxapi https w/default again
       register: result
       cisco.nxos.nxos_nxapi: *id004
 
     - name: Assert configuration is idempotent
       ansible.builtin.assert: *id003
 
-    - name: Configure NXAPI HTTPs TLSv1.1 -default TLSv1
+    - name: Configure nxapi https tlsv1.1 -default tlsv1
       register: result
       cisco.nxos.nxos_nxapi: &id005
         enable_https: true
@@ -89,19 +89,19 @@
         commands:
           - show run all | inc nxapi | inc protocols
 
-    - name: Assert NXAPI HTTPs w/TLSv1.1 configuration
+    - name: Assert nxapi https w/tlsv1.1 configuration
       ansible.builtin.assert:
         that:
           - result.stdout_lines[0][0] == 'nxapi ssl protocols TLSv1.1'
 
-    - name: Configure NXAPI HTTPs w/TLSv1.1 -default TLSv1 again
+    - name: Configure nxapi https w/tlsv1.1 -default tlsv1 again
       register: result
       cisco.nxos.nxos_nxapi: *id005
 
     - name: Assert configuration is idempotent
       ansible.builtin.assert: *id003
 
-    - name: Configure NXAPI HTTPs TLSv1.2 -default TLSv1
+    - name: Configure nxapi https tlsv1.2 -default tlsv1
       register: result
       cisco.nxos.nxos_nxapi: &id006
         enable_https: true
@@ -114,19 +114,19 @@
         commands:
           - show run all | inc nxapi | inc protocols
 
-    - name: Assert NXAPI HTTPs w/TLSv1.2 configuration
+    - name: Assert nxapi https w/tlsv1.2 configuration
       ansible.builtin.assert:
         that:
           - result.stdout_lines[0][0] == 'nxapi ssl protocols TLSv1.2'
 
-    - name: Configure NXAPI HTTPs w/TLSv1.2 -default TLSv1 again
+    - name: Configure nxapi https w/tlsv1.2 -default tlsv1 again
       register: result
       cisco.nxos.nxos_nxapi: *id006
 
     - name: Assert configuration is idempotent
       ansible.builtin.assert: *id003
 
-    - name: Configure NXAPI HTTPs w/TLS1.2 +default TLSv1
+    - name: Configure nxapi https w/tls1.2 +default tlsv1
       register: result
       cisco.nxos.nxos_nxapi: &id007
         enable_https: true
@@ -139,19 +139,19 @@
         commands:
           - show run all | inc nxapi | inc protocols
 
-    - name: Assert NXAPI HTTPs w/TLS1.2 +default TLSv1 configuration
+    - name: Assert nxapi https w/tls1.2 +default tlsv1 configuration
       ansible.builtin.assert:
         that:
           - result.stdout_lines[0][0] == 'nxapi ssl protocols TLSv1 TLSv1.2'
 
-    - name: Configure NXAPI HTTPs w/TLS1.2 again
+    - name: Configure nxapi https w/tls1.2 again
       register: result
       cisco.nxos.nxos_nxapi: *id007
 
     - name: Assert configuration is idempotent
       ansible.builtin.assert: *id003
 
-    - name: Configure NXAPI HTTPs w/TLS1.2 TLS1.1 -default TLSv1
+    - name: Configure nxapi https w/tls1.2 tls1.1 -default tlsv1
       register: result
       cisco.nxos.nxos_nxapi: &id008
         enable_https: true
@@ -166,19 +166,19 @@
         commands:
           - show run all | inc nxapi | inc protocols
 
-    - name: Assert NXAPI HTTPs w/TLS1.2 TLS1.2 -default TLSv1 configuration
+    - name: Assert nxapi https w/tls1.2 tls1.2 -default tlsv1 configuration
       ansible.builtin.assert:
         that:
           - result.stdout_lines[0][0] == 'nxapi ssl protocols TLSv1.1 TLSv1.2'
 
-    - name: Configure NXAPI HTTPs w/TLS1.2 TLS1.1 -default TLSv1 again
+    - name: Configure nxapi https w/tls1.2 tls1.1 -default tlsv1 again
       register: result
       cisco.nxos.nxos_nxapi: *id008
 
     - name: Assert configuration is idempotent
       ansible.builtin.assert: *id003
 
-    - name: Configure NXAPI HTTPs w/TLS1.2 TLS1.1 +default TLSv1
+    - name: Configure nxapi https w/tls1.2 tls1.1 +default tlsv1
       register: result
       cisco.nxos.nxos_nxapi: &id009
         enable_https: true
@@ -192,19 +192,19 @@
         commands:
           - show run all | inc nxapi | inc protocols
 
-    - name: Assert NXAPI HTTPs w/TLS1.2 TLS1.1 +default TLSv1 configuration
+    - name: Assert nxapi https w/tls1.2 tls1.1 +default tlsv1 configuration
       ansible.builtin.assert:
         that:
           - result.stdout_lines[0][0] == 'nxapi ssl protocols TLSv1 TLSv1.1 TLSv1.2'
 
-    - name: Configure NXAPI HTTPs w/TLS1.2 TLS1.1 +default TLSv1 again
+    - name: Configure nxapi https w/tls1.2 tls1.1 +default tlsv1 again
       register: result
       cisco.nxos.nxos_nxapi: *id009
 
     - name: Assert configuration is idempotent
       ansible.builtin.assert: *id003
 
-    - name: Configure NXAPI HTTPs with explicit TLS1.2 TLS1.1 TLSv1
+    - name: Configure nxapi https with explicit tls1.2 tls1.1 tlsv1
       register: result
       cisco.nxos.nxos_nxapi: &id010
         enable_https: true
@@ -219,30 +219,29 @@
         commands:
           - show run all | inc nxapi | inc protocols
 
-    - name: Assert NXAPI HTTPs w/TLS1.2 TLS1.2 TLSv1 configuration
+    - name: Assert nxapi https w/tls1.2 tls1.2 tlsv1 configuration
       ansible.builtin.assert:
         that:
           - result.stdout_lines[0][0] == 'nxapi ssl protocols TLSv1 TLSv1.1 TLSv1.2'
 
-    - name: Configure NXAPI HTTPs w/TLS1.2 TLS1.1 TLSv1 again
+    - name: Configure nxapi https w/tls1.2 tls1.1 tlsv1 again
       register: result
       cisco.nxos.nxos_nxapi: *id010
 
     - name: Assert configuration is idempotent
       ansible.builtin.assert: *id003
   always:
-    - name: Cleanup - Disable NXAPI
+    - name: Cleanup - disable nxapi
       register: result
       cisco.nxos.nxos_nxapi:
         state: absent
 
-    - name: Cleanup - Re-enable NXAPI
+    - name: Cleanup - re-enable nxapi
       register: result
       cisco.nxos.nxos_nxapi:
         state: present
 
     - ansible.builtin.debug:
         msg: END cli/nxapi_ssl.yaml
-  when:
-    (platform is match("N9K") or platform is match("N3K") or platform is match("N9K-F") or platform is match("N35") or platform is match("N3L")) and major_version
+  when: (platform is match("N9K") or platform is match("N3K") or platform is match("N9K-F") or platform is match("N35") or platform is match("N3L")) and major_version
     is version('9.2', '>=')

--- a/tests/integration/targets/nxos_ospf/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_ospf/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_ospf/tasks/main.yaml
+++ b/tests/integration/targets/nxos_ospf/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
   always:
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_ospf/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_ospf/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_ospf/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_ospf/tests/common/sanity.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }} nxos_ospf sanity test
 
-- name: Enable feature OSPF
+- name: Enable feature ospf
   ignore_errors: true
   cisco.nxos.nxos_feature:
     feature: ospf
@@ -19,7 +19,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_ospf: *id001
 
@@ -27,7 +27,7 @@
         that:
           - result.changed == false
   rescue:
-    - name: Disable feature OSPF
+    - name: Disable feature ospf
       ignore_errors: true
       cisco.nxos.nxos_feature:
         feature: ospf
@@ -41,7 +41,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_ospf: *id003
 

--- a/tests/integration/targets/nxos_ospf_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_ospf_interfaces/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_ospf_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/nxos_ospf_interfaces/tasks/main.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Enable OSPF v2 and v3 features
+- name: Enable ospf v2 and v3 features
   cisco.nxos.nxos_config:
     lines:
       - feature ospf
@@ -8,18 +8,18 @@
     ansible_connection: ansible.netcommon.network_cli
 
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli.yaml
 
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi
 
   always:
-    - name: Disable OSPF v2 and v3 features
+    - name: Disable ospf v2 and v3 features
       cisco.nxos.nxos_config:
         lines:
           - feature ospf

--- a/tests/integration/targets/nxos_ospf_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_ospf_interfaces/tasks/nxapi.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_ospf_interfaces/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_ospf_interfaces/tests/common/deleted.yaml
@@ -18,7 +18,7 @@
       name: "{{ nxos_int3 }}"
 
 - block:
-    - name: Delete OSPF config from a single interface
+    - name: Delete ospf config from a single interface
       cisco.nxos.nxos_ospf_interfaces: &id001
         config:
           - name: "{{ nxos_int1 }}"
@@ -51,7 +51,7 @@
           - result["after"][1] == merged["after"][1]
           - result["after"][2] == merged["after"][2]
 
-    - name: Delete OSPF config from a single interface (IDEMPOTENT)
+    - name: Delete ospf config from a single interface (idempotent)
       register: result
       cisco.nxos.nxos_ospf_interfaces: *id001
 
@@ -63,7 +63,7 @@
 
     - ansible.builtin.include_tasks: _populate_config.yaml
 
-    - name: Delete OSPF config from all interfaces
+    - name: Delete ospf config from all interfaces
       cisco.nxos.nxos_ospf_interfaces: &id002
         state: deleted
       register: result
@@ -87,7 +87,7 @@
           - result["after"][1] == int2
           - result["after"][2] == int3
 
-    - name: Delete OSPF config from all interfaces (IDEMPOTENT)
+    - name: Delete ospf config from all interfaces (idempotent)
       register: result
       cisco.nxos.nxos_ospf_interfaces: *id002
 

--- a/tests/integration/targets/nxos_ospf_interfaces/tests/common/gathered.yaml
+++ b/tests/integration/targets/nxos_ospf_interfaces/tests/common/gathered.yaml
@@ -9,7 +9,7 @@
 - ansible.builtin.include_tasks: _populate_config.yaml
 
 - block:
-    - name: Gather OSPF interfaces facts using gathered
+    - name: Gather ospf interfaces facts using gathered
       register: result
       cisco.nxos.nxos_ospf_interfaces:
         state: gathered

--- a/tests/integration/targets/nxos_ospf_interfaces/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_ospf_interfaces/tests/common/merged.yaml
@@ -65,7 +65,7 @@
           - "{{ result['after'][1]  == merged['after'][1] }}"
           - "{{ result['after'][2]  == merged['after'][2] }}"
 
-    - name: Merge the provided configuration with the existing running configuration (IDEMPOTENT)
+    - name: Merge the provided configuration with the existing running configuration (idempotent)
       cisco.nxos.nxos_ospf_interfaces: *id001
       register: result
 

--- a/tests/integration/targets/nxos_ospf_interfaces/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_ospf_interfaces/tests/common/overridden.yaml
@@ -9,7 +9,7 @@
 - ansible.builtin.include_tasks: _populate_config.yaml
 
 - block:
-    - name: Override all OSPF interfaces configuration with provided configuration
+    - name: Override all ospf interfaces configuration with provided configuration
       cisco.nxos.nxos_ospf_interfaces: &id001
         config:
           - name: Ethernet1/1
@@ -44,7 +44,7 @@
           - result['after'][1]  == overridden['after'][1]
           - result['after'][2]  == overridden['after'][2]
 
-    - name: Override all OSPF interfaces configuration with provided configuration (IDEMPOTENT)
+    - name: Override all ospf interfaces configuration with provided configuration (idempotent)
       register: result
       cisco.nxos.nxos_ospf_interfaces: *id001
 

--- a/tests/integration/targets/nxos_ospf_interfaces/tests/common/parsed.yaml
+++ b/tests/integration/targets/nxos_ospf_interfaces/tests/common/parsed.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START nxos_ospf_interfaces parsed integration tests on connection={{ ansible_connection }}
 
-- name: Parse externally provided OSPF interfaces config
+- name: Parse externally provided ospf interfaces config
   register: result
   cisco.nxos.nxos_ospf_interfaces:
     running_config: "{{ lookup('file', './fixtures/parsed.cfg') }}"

--- a/tests/integration/targets/nxos_ospf_interfaces/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_ospf_interfaces/tests/common/replaced.yaml
@@ -9,7 +9,7 @@
 - ansible.builtin.include_tasks: _populate_config.yaml
 
 - block:
-    - name: Replace OSPF configurations of listed interfaces with provided configurations
+    - name: Replace ospf configurations of listed interfaces with provided configurations
       cisco.nxos.nxos_ospf_interfaces: &id001
         config:
           - name: "{{ nxos_int1 }}"
@@ -45,7 +45,7 @@
           - result['after'][1]  == replaced['after'][1]
           - result['after'][2]  == replaced['after'][2]
 
-    - name: Replace OSPF configurations of listed interfaces with provided configurations (IDEMPOTENT)
+    - name: Replace ospf configurations of listed interfaces with provided configurations (idempotent)
       register: result
       cisco.nxos.nxos_ospf_interfaces: *id001
 

--- a/tests/integration/targets/nxos_ospf_vrf/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_ospf_vrf/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_ospf_vrf/tasks/main.yaml
+++ b/tests/integration/targets/nxos_ospf_vrf/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
   always:
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_ospf_vrf/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_ospf_vrf/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_ospf_vrf/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_ospf_vrf/tests/common/sanity.yaml
@@ -45,7 +45,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_ospf_vrf: *id001
 
@@ -70,7 +70,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_ospf_vrf: *id003
 
@@ -90,7 +90,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_ospf_vrf: *id005
 
@@ -105,7 +105,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_ospf_vrf: *id006
 
@@ -121,7 +121,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_ospf_vrf: *id007
 

--- a/tests/integration/targets/nxos_ospfv2/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_ospfv2/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_ospfv2/tasks/main.yaml
+++ b/tests/integration/targets/nxos_ospfv2/tasks/main.yaml
@@ -1,23 +1,23 @@
 ---
-- name: Enable OSPF feature
+- name: Enable ospf feature
   cisco.nxos.nxos_feature:
     feature: ospf
   vars:
     ansible_connection: ansible.netcommon.network_cli
 
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli.yaml
 
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi
 
   always:
-    - name: Disable OSPF feature
+    - name: Disable ospf feature
       cisco.nxos.nxos_feature:
         feature: ospf
         state: disabled

--- a/tests/integration/targets/nxos_ospfv2/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_ospfv2/tasks/nxapi.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_ospfv2/tests/common/_remove_config.yaml
+++ b/tests/integration/targets/nxos_ospfv2/tests/common/_remove_config.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Remove pre-existing OSPF processes
+- name: Remove pre-existing ospf processes
   cisco.nxos.nxos_config:
     lines:
       - no router ospf 100

--- a/tests/integration/targets/nxos_ospfv2/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_ospfv2/tests/common/deleted.yaml
@@ -7,7 +7,7 @@
 - ansible.builtin.include_tasks: _populate_config.yaml
 
 - block:
-    - name: Delete a single OSPF process
+    - name: Delete a single ospf process
       cisco.nxos.nxos_ospfv2: &id001
         config:
           processes:
@@ -31,7 +31,7 @@
         that:
           - "{{ deleted['after']['processes'] | symmetric_difference(result['after']['processes']) |length == 0 }}"
 
-    - name: Delete a single OSPF process (IDEMPOTENT)
+    - name: Delete a single ospf process (idempotent)
       register: result
       cisco.nxos.nxos_ospfv2: *id001
 
@@ -48,7 +48,7 @@
 
     - ansible.builtin.include_tasks: _populate_config.yaml
 
-    - name: Delete all OSPF processes from the device
+    - name: Delete all ospf processes from the device
       cisco.nxos.nxos_ospfv2: &id002
         state: deleted
       register: result
@@ -70,7 +70,7 @@
         that:
           - "{{ result['after'] == {} }}"
 
-    - name: Delete all OSPF processes from the device (IDEMPOTENT)
+    - name: Delete all ospf processes from the device (idempotent)
       register: result
       cisco.nxos.nxos_ospfv2: *id002
 

--- a/tests/integration/targets/nxos_ospfv2/tests/common/gathered.yaml
+++ b/tests/integration/targets/nxos_ospfv2/tests/common/gathered.yaml
@@ -7,7 +7,7 @@
 - ansible.builtin.include_tasks: _populate_config.yaml
 
 - block:
-    - name: Gather OSPFv2 facts using gathered
+    - name: Gather ospfv2 facts using gathered
       register: result
       cisco.nxos.nxos_ospfv2:
         state: gathered

--- a/tests/integration/targets/nxos_ospfv2/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_ospfv2/tests/common/merged.yaml
@@ -76,7 +76,7 @@
         that:
           - "{{ merged['after']['processes'] | symmetric_difference(result['after']['processes']) |length == 0 }}"
 
-    - name: Merge the provided configuration with the existing running configuration (IDEMPOTENT)
+    - name: Merge the provided configuration with the existing running configuration (idempotent)
       cisco.nxos.nxos_ospfv2: *id001
       register: result
 

--- a/tests/integration/targets/nxos_ospfv2/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_ospfv2/tests/common/overridden.yaml
@@ -7,7 +7,7 @@
 - ansible.builtin.include_tasks: _populate_config.yaml
 
 - block:
-    - name: Override all OSPF configuration with provided configuration
+    - name: Override all ospf configuration with provided configuration
       cisco.nxos.nxos_ospfv2: &id001
         config:
           processes:
@@ -34,7 +34,7 @@
         that:
           - "{{ overridden['after']['processes'] | symmetric_difference(result['after']['processes']) |length == 0 }}"
 
-    - name: Override all OSPF configuration with provided configuration (IDEMPOTENT)
+    - name: Override all ospf configuration with provided configuration (idempotent)
       register: result
       cisco.nxos.nxos_ospfv2: *id001
 

--- a/tests/integration/targets/nxos_ospfv2/tests/common/parsed.yaml
+++ b/tests/integration/targets/nxos_ospfv2/tests/common/parsed.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START nxos_ospfv2 parsed integration tests on connection={{ ansible_connection }}
 
-- name: Parse externally provided OSPFv2 config
+- name: Parse externally provided ospfv2 config
   register: result
   cisco.nxos.nxos_ospfv2:
     running_config: "{{ lookup('file', './fixtures/parsed.cfg') }}"

--- a/tests/integration/targets/nxos_ospfv2/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_ospfv2/tests/common/replaced.yaml
@@ -7,7 +7,7 @@
 - ansible.builtin.include_tasks: _populate_config.yaml
 
 - block:
-    - name: Replace device configurations of listed OSPF processes with provided configurations
+    - name: Replace device configurations of listed ospf processes with provided configurations
       cisco.nxos.nxos_ospfv2: &id001
         config:
           processes:
@@ -60,7 +60,7 @@
         that:
           - "{{ replaced['after']['processes'] | symmetric_difference(result['after']['processes']) |length == 0 }}"
 
-    - name: Replace device configurations of listed OSPF processes with provided configurarions (IDEMPOTENT)
+    - name: Replace device configurations of listed ospf processes with provided configurarions (idempotent)
       register: result
       cisco.nxos.nxos_ospfv2: *id001
 

--- a/tests/integration/targets/nxos_ospfv3/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_ospfv3/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_ospfv3/tasks/main.yaml
+++ b/tests/integration/targets/nxos_ospfv3/tasks/main.yaml
@@ -1,23 +1,23 @@
 ---
-- name: Enable OSPFv3 feature
+- name: Enable ospfv3 feature
   cisco.nxos.nxos_feature:
     feature: ospfv3
   vars:
     ansible_connection: ansible.netcommon.network_cli
 
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli.yaml
 
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi
 
   always:
-    - name: Disable OSPFv3 feature
+    - name: Disable ospfv3 feature
       cisco.nxos.nxos_feature:
         feature: ospfv3
         state: disabled

--- a/tests/integration/targets/nxos_ospfv3/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_ospfv3/tasks/nxapi.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_ospfv3/tests/common/_remove_config.yaml
+++ b/tests/integration/targets/nxos_ospfv3/tests/common/_remove_config.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Remove pre-existing OSPF processes
+- name: Remove pre-existing ospf processes
   cisco.nxos.nxos_config:
     lines:
       - no router ospfv3 100

--- a/tests/integration/targets/nxos_ospfv3/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_ospfv3/tests/common/deleted.yaml
@@ -7,7 +7,7 @@
 - ansible.builtin.include_tasks: _populate_config.yaml
 
 - block:
-    - name: Delete a single OSPF process
+    - name: Delete a single ospf process
       cisco.nxos.nxos_ospfv3: &id001
         config:
           processes:
@@ -31,7 +31,7 @@
         that:
           - "{{ deleted['after']['processes'] | symmetric_difference(result['after']['processes']) |length == 0 }}"
 
-    - name: Delete a single OSPF process (IDEMPOTENT)
+    - name: Delete a single ospf process (idempotent)
       register: result
       cisco.nxos.nxos_ospfv3: *id001
 
@@ -48,7 +48,7 @@
 
     - ansible.builtin.include_tasks: _populate_config.yaml
 
-    - name: Delete all OSPFv3 processes from the device
+    - name: Delete all ospfv3 processes from the device
       cisco.nxos.nxos_ospfv3: &id002
         state: deleted
       register: result
@@ -70,7 +70,7 @@
         that:
           - "{{ result['after'] == {} }}"
 
-    - name: Delete all OSPF processes from the device (IDEMPOTENT)
+    - name: Delete all ospf processes from the device (idempotent)
       register: result
       cisco.nxos.nxos_ospfv3: *id002
 

--- a/tests/integration/targets/nxos_ospfv3/tests/common/gathered.yaml
+++ b/tests/integration/targets/nxos_ospfv3/tests/common/gathered.yaml
@@ -7,7 +7,7 @@
 - ansible.builtin.include_tasks: _populate_config.yaml
 
 - block:
-    - name: Gather OSPFv3 facts using gathered
+    - name: Gather ospfv3 facts using gathered
       register: result
       cisco.nxos.nxos_ospfv3:
         state: gathered

--- a/tests/integration/targets/nxos_ospfv3/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_ospfv3/tests/common/merged.yaml
@@ -69,7 +69,7 @@
         that:
           - "{{ merged['after']['processes'] | symmetric_difference(result['after']['processes']) |length == 0 }}"
 
-    - name: Merge the provided configuration with the existing running configuration (IDEMPOTENT)
+    - name: Merge the provided configuration with the existing running configuration (idempotent)
       cisco.nxos.nxos_ospfv3: *id001
       register: result
 

--- a/tests/integration/targets/nxos_ospfv3/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_ospfv3/tests/common/overridden.yaml
@@ -7,7 +7,7 @@
 - ansible.builtin.include_tasks: _populate_config.yaml
 
 - block:
-    - name: Override all OSPFv3 configuration with provided configuration
+    - name: Override all ospfv3 configuration with provided configuration
       cisco.nxos.nxos_ospfv3: &id001
         config:
           processes:
@@ -34,7 +34,7 @@
         that:
           - "{{ overridden['after']['processes'] | symmetric_difference(result['after']['processes']) |length == 0 }}"
 
-    - name: Override all OSPF configuration with provided configuration (IDEMPOTENT)
+    - name: Override all ospf configuration with provided configuration (idempotent)
       register: result
       cisco.nxos.nxos_ospfv3: *id001
 

--- a/tests/integration/targets/nxos_ospfv3/tests/common/parsed.yaml
+++ b/tests/integration/targets/nxos_ospfv3/tests/common/parsed.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START nxos_ospfv3 parsed integration tests on connection={{ ansible_connection }}
 
-- name: Parse externally provided OSPFv3 config
+- name: Parse externally provided ospfv3 config
   register: result
   cisco.nxos.nxos_ospfv3:
     running_config: "{{ lookup('file', './fixtures/parsed.cfg') }}"

--- a/tests/integration/targets/nxos_ospfv3/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_ospfv3/tests/common/replaced.yaml
@@ -7,7 +7,7 @@
 - ansible.builtin.include_tasks: _populate_config.yaml
 
 - block:
-    - name: Replace device configurations of listed OSPFv3 processes with provided configurations
+    - name: Replace device configurations of listed ospfv3 processes with provided configurations
       cisco.nxos.nxos_ospfv3: &id001
         config:
           processes:
@@ -56,7 +56,7 @@
         that:
           - "{{ replaced['after']['processes'] | symmetric_difference(result['after']['processes']) |length == 0 }}"
 
-    - name: Replace device configurations of listed OSPF processes with provided configurarions (IDEMPOTENT)
+    - name: Replace device configurations of listed ospf processes with provided configurarions (idempotent)
       register: result
       cisco.nxos.nxos_ospfv3: *id001
 

--- a/tests/integration/targets/nxos_overlay_global/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_overlay_global/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_overlay_global/tasks/main.yaml
+++ b/tests/integration/targets/nxos_overlay_global/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
   always:
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_overlay_global/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_overlay_global/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_overlay_global/tasks/platform/n7k/cleanup.yaml
+++ b/tests/integration/targets/nxos_overlay_global/tasks/platform/n7k/cleanup.yaml
@@ -1,22 +1,22 @@
 ---
-- name: Unconfigure VDC setting limit-resource module-type f3
+- name: Unconfigure vdc setting limit-resource module-type f3
   ignore_errors: true
   cisco.nxos.nxos_config:
     commands:
       - terminal dont-ask ; vdc {{ vdcid }} ;  no limit-resource module-type f3
     match: none
 
-- name: Previous command is asynchronous and can take a while.  Allow time for it to complete
+- name: Previous command is asynchronous and can take a while.  allow time for it to complete
   ansible.builtin.pause:
     seconds: 45
 
-- name: Configure VDC setting allocate interface unallocated-interfaces
+- name: Configure vdc setting allocate interface unallocated-interfaces
   ignore_errors: true
   cisco.nxos.nxos_config:
     commands:
       - terminal dont-ask ; vdc {{ vdcid }} ; allocate interface unallocated-interfaces
     match: none
 
-- name: Previous command is asynchronous can take a while.  Allow time for it to complete
+- name: Previous command is asynchronous can take a while.  allow time for it to complete
   ansible.builtin.pause:
     seconds: 45

--- a/tests/integration/targets/nxos_overlay_global/tasks/platform/n7k/setup.yaml
+++ b/tests/integration/targets/nxos_overlay_global/tasks/platform/n7k/setup.yaml
@@ -9,29 +9,29 @@
   ansible.builtin.set_fact:
     vdcid: "{{ vdcout.stdout_lines[0].name }}"
 
-- name: Configure VDC setting limit-resource module-type f3
+- name: Configure vdc setting limit-resource module-type f3
   ignore_errors: true
   cisco.nxos.nxos_config:
     commands:
       - terminal dont-ask ; vdc {{ vdcid }} ;  limit-resource module-type f3
     match: none
 
-- name: Previous command is asynchronous and can take a while.  Allow time for it to complete
+- name: Previous command is asynchronous and can take a while.  allow time for it to complete
   ansible.builtin.pause:
     seconds: 45
 
-- name: Configure VDC setting allocate interface unallocated-interfaces
+- name: Configure vdc setting allocate interface unallocated-interfaces
   ignore_errors: true
   cisco.nxos.nxos_config:
     commands:
       - terminal dont-ask ; vdc {{ vdcid }} ; allocate interface unallocated-interfaces
     match: none
 
-- name: Previous command is asynchronous and can take a while.  Allow time for it to complete
+- name: Previous command is asynchronous and can take a while.  allow time for it to complete
   ansible.builtin.pause:
     seconds: 45
 
-- name: Configure Additional N7K requiste features
+- name: Configure additional n7k requiste features
   cisco.nxos.nxos_config:
     commands:
       - feature-set fabric

--- a/tests/integration/targets/nxos_overlay_global/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_overlay_global/tests/common/sanity.yaml
@@ -20,11 +20,11 @@
       cisco.nxos.nxos_evpn_global:
         nv_overlay_evpn: true
 
-    - name: Apply N7K specific setup config
+    - name: Apply n7k specific setup config
       ansible.builtin.include: tasks/platform/n7k/setup.yaml
       when: platform is match('N7K')
 
-    - name: Configure Additional N7K requiste features
+    - name: Configure additional n7k requiste features
       when: platform is match('N7K')
       cisco.nxos.nxos_config:
         commands:
@@ -48,7 +48,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_overlay_global: *id001
 
@@ -63,7 +63,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_overlay_global: *id003
 
@@ -76,14 +76,14 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_overlay_global: *id005
 
     - ansible.builtin.assert: *id004
   when: overlay_global_supported
   always:
-    - name: Apply N7K specific cleanup config
+    - name: Apply n7k specific cleanup config
       ansible.builtin.include: tasks/platform/n7k/cleanup.yaml
       when: platform is match('N7K')
 

--- a/tests/integration/targets/nxos_pim/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_pim/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_pim/tasks/main.yaml
+++ b/tests/integration/targets/nxos_pim/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
   always:
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_pim/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_pim/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_pim/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_pim/tests/common/sanity.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }} nxos_pim sanity test
 
-- name: "Setup: Disable features"
+- name: "Setup: disable features"
   ignore_errors: true
   loop:
     - pim
@@ -11,7 +11,7 @@
     feature: "{{ item }}"
     state: disabled
 
-- name: "Setup: Enable features"
+- name: "Setup: enable features"
   loop:
     - pim
     - bfd
@@ -19,7 +19,7 @@
     feature: "{{ item }}"
     state: enabled
 
-- name: "Setup: Configure ssm_range none"
+- name: "Setup: configure ssm_range none"
   cisco.nxos.nxos_pim: &id005
     ssm_range: none
 
@@ -52,7 +52,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: ssm_range default idempotence
+    - name: Ssm_range default idempotence
       register: result
       cisco.nxos.nxos_pim: *id003
 
@@ -64,13 +64,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: ssm_range none idempotence
+    - name: Ssm_range none idempotence
       register: result
       cisco.nxos.nxos_pim: *id005
 
     - ansible.builtin.assert: *id004
   always:
-    - name: "Teardown: Disable features"
+    - name: "Teardown: disable features"
       ignore_errors: true
       loop:
         - pim

--- a/tests/integration/targets/nxos_pim_interface/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_pim_interface/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_pim_interface/tasks/main.yaml
+++ b/tests/integration/targets/nxos_pim_interface/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
   always:
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_pim_interface/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_pim_interface/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_pim_interface/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_pim_interface/tests/common/sanity.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }} nxos_pim_interface sanity test
 
-- name: "Setup: Disable features"
+- name: "Setup: disable features"
   loop:
     - pim
     - bfd
@@ -11,7 +11,7 @@
     feature: "{{ item }}"
     state: disabled
 
-- name: "Setup: Enable features"
+- name: "Setup: enable features"
   loop:
     - pim
     - bfd
@@ -23,7 +23,7 @@
   ansible.builtin.set_fact:
     testint: "{{ nxos_int1 }}"
 
-- name: "Setup: Put interface {{ testint }} into a default state"
+- name: "Setup: put interface {{ testint }} into a default state"
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines:
@@ -43,7 +43,7 @@
         interface: "{{ testint }}"
         state: absent
 
-    - name: configure jp policy and type
+    - name: Configure jp policy and type
       register: result
       cisco.nxos.nxos_pim_interface: &id001
         interface: "{{ testint }}"
@@ -66,7 +66,7 @@
         that:
           - result.changed == false
 
-    - name: configure neighbor policy and rm
+    - name: Configure neighbor policy and rm
       register: result
       cisco.nxos.nxos_pim_interface: &id003
         interface: "{{ testint }}"
@@ -84,7 +84,7 @@
     - ansible.builtin.pause:
         seconds: 5
 
-    - name: configure neighbor policy and prefix
+    - name: Configure neighbor policy and prefix
       register: result
       cisco.nxos.nxos_pim_interface: &id005
         interface: "{{ testint }}"
@@ -99,7 +99,7 @@
 
     - ansible.builtin.assert: *id004
 
-    - name: configure hello_auth_key
+    - name: Configure hello_auth_key
       register: result
       cisco.nxos.nxos_pim_interface:
         interface: "{{ testint }}"
@@ -107,7 +107,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: configure pim other params
+    - name: Configure pim other params
       register: result
       cisco.nxos.nxos_pim_interface: &id006
         interface: "{{ testint }}"
@@ -126,7 +126,7 @@
 
     - ansible.builtin.assert: *id004
 
-    - name: configure negative
+    - name: Configure negative
       register: result
       cisco.nxos.nxos_pim_interface: &id007
         interface: "{{ testint }}"
@@ -146,7 +146,7 @@
     - ansible.builtin.pause:
         seconds: 5
 
-    - name: configure state default
+    - name: Configure state default
       register: result
       cisco.nxos.nxos_pim_interface: &id008
         interface: "{{ testint }}"
@@ -160,7 +160,7 @@
 
     - ansible.builtin.assert: *id004
 
-    - name: configure border
+    - name: Configure border
       register: result
       cisco.nxos.nxos_pim_interface: &id009
         interface: "{{ testint }}"
@@ -175,7 +175,7 @@
 
     - ansible.builtin.assert: *id004
 
-    - name: configure state absent
+    - name: Configure state absent
       register: result
       cisco.nxos.nxos_pim_interface: *id010
 
@@ -187,7 +187,7 @@
 
     - ansible.builtin.assert: *id004
   always:
-    - name: Disable feature PIM
+    - name: Disable feature pim
       loop:
         - pim
         - bfd

--- a/tests/integration/targets/nxos_pim_rp_address/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_pim_rp_address/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_pim_rp_address/tasks/main.yaml
+++ b/tests/integration/targets/nxos_pim_rp_address/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_pim_rp_address/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_pim_rp_address/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_pim_rp_address/tests/common/configure.yaml
+++ b/tests/integration/targets/nxos_pim_rp_address/tests/common/configure.yaml
@@ -23,17 +23,17 @@
   when: platform is not search('N3L|N7K')
 
 - block:
-    - name: Disable feature PIM
+    - name: Disable feature pim
       cisco.nxos.nxos_feature: &id014
         feature: pim
         state: disabled
 
-    - name: Enable feature PIM
+    - name: Enable feature pim
       cisco.nxos.nxos_feature:
         feature: pim
         state: enabled
 
-    - name: 1.0 Configure rp_address + group_list
+    - name: 1.0 configure rp_address + group_list
       register: result
       cisco.nxos.nxos_pim_rp_address: &id001
         rp_address: 10.1.1.1
@@ -45,7 +45,7 @@
         that:
           - result.changed == true
 
-    - name: 1.0 Idempotence rp_address + group_list
+    - name: 1.0 idempotence rp_address + group_list
       register: result
       cisco.nxos.nxos_pim_rp_address: *id001
 
@@ -101,7 +101,7 @@
         - assert: *id004
       when: bidir_true is defined
 
-    - name: 1.4 Remove rp_address + group_list
+    - name: 1.4 remove rp_address + group_list
       register: result
       cisco.nxos.nxos_pim_rp_address: &id007
         rp_address: 10.1.1.1
@@ -110,13 +110,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: 1.4 Idempotence remove rp_address + group_list
+    - name: 1.4 idempotence remove rp_address + group_list
       register: result
       cisco.nxos.nxos_pim_rp_address: *id007
 
     - ansible.builtin.assert: *id004
 
-    - name: 2.0 Configure rp_address + prefix_list (bidir_true)
+    - name: 2.0 configure rp_address + prefix_list (bidir_true)
       register: result
       cisco.nxos.nxos_pim_rp_address: &id008
         rp_address: 10.1.1.2
@@ -126,7 +126,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: 2.0 Idempotence rp_address + prefix_list (bidir_true)
+    - name: 2.0 idempotence rp_address + prefix_list (bidir_true)
       register: result
       cisco.nxos.nxos_pim_rp_address: *id008
 
@@ -150,7 +150,7 @@
         - assert: *id004
       when: bidir_false is defined
 
-    - name: 2.2 Remove rp_address + prefix_list (bidir_false)
+    - name: 2.2 remove rp_address + prefix_list (bidir_false)
       register: result
       cisco.nxos.nxos_pim_rp_address: &id010
         rp_address: 10.1.1.2
@@ -160,13 +160,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: 2.2 Idempotence remove rp_address + prefix_list (bidir_false)
+    - name: 2.2 idempotence remove rp_address + prefix_list (bidir_false)
       register: result
       cisco.nxos.nxos_pim_rp_address: *id010
 
     - ansible.builtin.assert: *id004
 
-    - name: 3.0 Configure rp_address + route_map + (bidir_true)
+    - name: 3.0 configure rp_address + route_map + (bidir_true)
       register: result
       cisco.nxos.nxos_pim_rp_address: &id011
         rp_address: 10.1.1.3
@@ -176,7 +176,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: 3.0 Idempotence rp_address + route_map + (bidir_true)
+    - name: 3.0 idempotence rp_address + route_map + (bidir_true)
       register: result
       cisco.nxos.nxos_pim_rp_address: *id011
 
@@ -200,7 +200,7 @@
         - assert: *id004
       when: bidir_false is defined
 
-    - name: 3.2 Remove rp_address + route_map (bidir_false)
+    - name: 3.2 remove rp_address + route_map (bidir_false)
       register: result
       cisco.nxos.nxos_pim_rp_address: &id013
         rp_address: 10.1.1.3
@@ -210,13 +210,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: 3.2 Idempotence remove rp_address + route_map (bidir_false)
+    - name: 3.2 idempotence remove rp_address + route_map (bidir_false)
       register: result
       cisco.nxos.nxos_pim_rp_address: *id013
 
     - ansible.builtin.assert: *id004
   always:
-    - name: Disable feature PIM
+    - name: Disable feature pim
       cisco.nxos.nxos_feature: *id014
 
 - ansible.builtin.debug:

--- a/tests/integration/targets/nxos_prefix_lists/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_prefix_lists/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_prefix_lists/tasks/main.yaml
+++ b/tests/integration/targets/nxos_prefix_lists/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli.yaml
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_prefix_lists/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_prefix_lists/tasks/nxapi.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_prefix_lists/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_prefix_lists/tests/common/deleted.yaml
@@ -7,7 +7,7 @@
 - ansible.builtin.include_tasks: _populate_config.yaml
 
 - block:
-    - name: Delete all prefix-lists for an AFI
+    - name: Delete all prefix-lists for an afi
       cisco.nxos.nxos_prefix_lists:
         config:
           - afi: ipv4
@@ -77,7 +77,7 @@
         that:
           - result["after"] == []
 
-    - name: Delete all prefix-lists (IDEMPOTENT)
+    - name: Delete all prefix-lists (idempotent)
       register: result
       cisco.nxos.nxos_prefix_lists: *id001
 

--- a/tests/integration/targets/nxos_prefix_lists/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_prefix_lists/tests/common/merged.yaml
@@ -57,7 +57,7 @@
           - "{{ merged['after'][0] == result['after'][0] }}"
           - "{{ merged['after'][1] == result['after'][1] }}"
 
-    - name: Merge the provided configuration with the existing running configuration (IDEMPOTENT)
+    - name: Merge the provided configuration with the existing running configuration (idempotent)
       cisco.nxos.nxos_prefix_lists: *id001
       register: result
 
@@ -67,7 +67,7 @@
           - result['changed'] == false
           - result.commands|length == 0
 
-    - name: Attempt to update an existing prefix-list entry (SHOULD FAIL)
+    - name: Attempt to update an existing prefix-list entry (should fail)
       cisco.nxos.nxos_prefix_lists:
         config:
           - afi: ipv4

--- a/tests/integration/targets/nxos_prefix_lists/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_prefix_lists/tests/common/overridden.yaml
@@ -43,7 +43,7 @@
         that:
           - "{{ overridden['after'][0] == result['after'][0] }}"
 
-    - name: Override all prefix-lists configuration with provided configuration (IDEMPOTENT)
+    - name: Override all prefix-lists configuration with provided configuration (idempotent)
       register: result
       cisco.nxos.nxos_prefix_lists: *id001
 

--- a/tests/integration/targets/nxos_prefix_lists/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_prefix_lists/tests/common/replaced.yaml
@@ -44,7 +44,7 @@
           - "{{ replaced['after'][0] == result['after'][0] }}"
           - "{{ replaced['after'][1] == result['after'][1] }}"
 
-    - name: Replace prefix-lists configurations of listed prefix-lists with provided configurations (IDEMPOTENT)
+    - name: Replace prefix-lists configurations of listed prefix-lists with provided configurations (idempotent)
       register: result
       cisco.nxos.nxos_prefix_lists: *id001
 

--- a/tests/integration/targets/nxos_reboot/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_reboot/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_reboot/tasks/main.yaml
+++ b/tests/integration/targets/nxos_reboot/tasks/main.yaml
@@ -1,8 +1,8 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags: cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags: nxapi

--- a/tests/integration/targets/nxos_reboot/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_reboot/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_reboot/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_reboot/tests/common/sanity.yaml
@@ -6,7 +6,7 @@
     msg: "***WARNING*** Set run_nxos_reboot_test to True to verify this module ***WARNING***"
 
 - block:
-    - name: Reboot Switch
+    - name: Reboot switch
       ignore_errors: true
       cisco.nxos.nxos_reboot:
         confirm: true

--- a/tests/integration/targets/nxos_rollback/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_rollback/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_rollback/tasks/main.yaml
+++ b/tests/integration/targets/nxos_rollback/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_rollback/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_rollback/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_rollback/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_rollback/tests/common/sanity.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }} nxos_rollback sanity test
 
-- name: delete existing checkpoint file
+- name: Delete existing checkpoint file
   ignore_errors: true
   cisco.nxos.nxos_config: &id001
     commands:
@@ -14,11 +14,11 @@
   cisco.nxos.nxos_rollback:
     checkpoint_file: backup.cfg
 
-- name: rollback to the previously created checkpoint file
+- name: Rollback to the previously created checkpoint file
   cisco.nxos.nxos_rollback:
     rollback_to: backup.cfg
 
-- name: cleanup checkpoint file
+- name: Cleanup checkpoint file
   ignore_errors: true
   cisco.nxos.nxos_config: *id001
 

--- a/tests/integration/targets/nxos_route_maps/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_route_maps/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_route_maps/tasks/main.yaml
+++ b/tests/integration/targets/nxos_route_maps/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli.yaml
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_route_maps/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_route_maps/tasks/nxapi.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_route_maps/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_route_maps/tests/common/deleted.yaml
@@ -52,7 +52,7 @@
         that:
           - result["after"] == []
 
-    - name: Delete all route-maps (IDEMPOTENT)
+    - name: Delete all route-maps (idempotent)
       register: result
       cisco.nxos.nxos_route_maps: *id001
 

--- a/tests/integration/targets/nxos_route_maps/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_route_maps/tests/common/merged.yaml
@@ -94,7 +94,7 @@
           - "{{ merged['after'][0] == result['after'][0] }}"
           - "{{ merged['after'][1] == result['after'][1] }}"
 
-    - name: Merge the provided configuration with the existing running configuration (IDEMPOTENT)
+    - name: Merge the provided configuration with the existing running configuration (idempotent)
       cisco.nxos.nxos_route_maps: *id001
       register: result
 

--- a/tests/integration/targets/nxos_route_maps/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_route_maps/tests/common/overridden.yaml
@@ -46,7 +46,7 @@
         that:
           - "{{ overridden['after'][0] == result['after'][0] }}"
 
-    - name: Override all route-maps configuration with provided configuration (IDEMPOTENT)
+    - name: Override all route-maps configuration with provided configuration (idempotent)
       register: result
       cisco.nxos.nxos_route_maps: *id001
 

--- a/tests/integration/targets/nxos_route_maps/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_route_maps/tests/common/replaced.yaml
@@ -47,7 +47,7 @@
           - "{{ replaced['after'][0] == result['after'][0] }}"
           - "{{ replaced['after'][1] == result['after'][1] }}"
 
-    - name: Replace route-maps configurations of listed route-maps with provided configurations (IDEMPOTENT)
+    - name: Replace route-maps configurations of listed route-maps with provided configurations (idempotent)
       register: result
       cisco.nxos.nxos_route_maps: *id001
 

--- a/tests/integration/targets/nxos_rpm/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_rpm/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_rpm/tasks/main.yaml
+++ b/tests/integration/targets/nxos_rpm/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_rpm/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_rpm/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_smoke/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_smoke/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,7 +18,7 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
@@ -28,7 +28,7 @@
       transport: cli
       authorize: true
 
-- name: run test cases (connection=network_cli)
+- name: Run test cases (connection=network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:
@@ -44,7 +44,6 @@
 #  loop_control:
 #    loop_var: test_case_to_run
 
-- name: run test cases (connection=network_cli)
-  ansible.builtin.include:
-    "{{ role_path }}/tests/common/caching.yaml ansible_connection=ansible.netcommon.network_cli ansible_network_single_user_mode=True connection={{\
+- name: Run test cases (connection=network_cli)
+  ansible.builtin.include: "{{ role_path }}/tests/common/caching.yaml ansible_connection=ansible.netcommon.network_cli ansible_network_single_user_mode=True connection={{\
     \ cli }}"

--- a/tests/integration/targets/nxos_smoke/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_smoke/tasks/cli.yaml
@@ -45,5 +45,6 @@
 #    loop_var: test_case_to_run
 
 - name: Run test cases (connection=network_cli)
-  ansible.builtin.include: "{{ role_path }}/tests/common/caching.yaml ansible_connection=ansible.netcommon.network_cli ansible_network_single_user_mode=True connection={{\
+  ansible.builtin.include:
+    "{{ role_path }}/tests/common/caching.yaml ansible_connection=ansible.netcommon.network_cli ansible_network_single_user_mode=True connection={{\
     \ cli }}"

--- a/tests/integration/targets/nxos_smoke/tasks/main.yaml
+++ b/tests/integration/targets/nxos_smoke/tasks/main.yaml
@@ -3,11 +3,11 @@
 # This block/always ensures the hostname gets changed back to
 # the correct name.
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - "cli"
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - "nxapi"

--- a/tests/integration/targets/nxos_smoke/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_smoke/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=httpapi)
+- name: Run test cases (connection=httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_smoke/tests/common/caching.yaml
+++ b/tests/integration/targets/nxos_smoke/tests/common/caching.yaml
@@ -7,7 +7,7 @@
       cisco.nxos.nxos_config:
         lines: "no system default switchport\nsystem default switchport shutdown\n"
 
-    - name: setup
+    - name: Setup
       cisco.nxos.nxos_config: &rem
         lines:
           - "default interface {{ nxos_int1 }}"
@@ -34,7 +34,7 @@
           - '"description Configured by Ansible (L3)" in result.commands'
           - result.commands|length == 5
 
-    - name: Merge base interfaces configuration (IDEMPOTENT)
+    - name: Merge base interfaces configuration (idempotent)
       register: result
       cisco.nxos.nxos_interfaces: *merged
 
@@ -42,7 +42,7 @@
         that:
           - result.changed == False
 
-    - name: Merge L2 interfaces configuration
+    - name: Merge l2 interfaces configuration
       register: result
       cisco.nxos.nxos_l2_interfaces: &mergedl2
         config:
@@ -59,7 +59,7 @@
           - '"switchport trunk allowed vlan 2,4,15" in result.commands'
           - result.commands|length == 3
 
-    - name: Merge L2 interfaces configuration (IDEMPOTENT)
+    - name: Merge l2 interfaces configuration (idempotent)
       register: result
       cisco.nxos.nxos_l2_interfaces: *mergedl2
 
@@ -67,7 +67,7 @@
         that:
           - result.changed == False
 
-    - name: Merge L3 interfaces configuration
+    - name: Merge l3 interfaces configuration
       register: result
       cisco.nxos.nxos_l3_interfaces: &mergedl3
         config:
@@ -82,7 +82,7 @@
           - '"ip address 203.0.113.1/24" in result.commands'
           - result.commands|length == 2
 
-    - name: Merge L3 interfaces configuration (IDEMPOTENT)
+    - name: Merge l3 interfaces configuration (idempotent)
       register: result
       cisco.nxos.nxos_l3_interfaces: *mergedl3
 
@@ -91,6 +91,6 @@
           - result.changed == False
 
   always:
-    - name: cleanup
+    - name: Cleanup
       cisco.nxos.nxos_config: *rem
   when: ansible_connection == "ansible.netcommon.network_cli" and ansible_network_single_user_mode|d(False)

--- a/tests/integration/targets/nxos_smoke/tests/common/common_config.yaml
+++ b/tests/integration/targets/nxos_smoke/tests/common/common_config.yaml
@@ -14,7 +14,7 @@
   ansible.builtin.set_fact:
     intname: "{{ nxos_int1 }}"
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     commands:
       - no description
@@ -24,20 +24,20 @@
     match: none
     provider: "{{ connection }}"
 
-- name: collect any backup files
+- name: Collect any backup files
   ansible.builtin.find: &backups
     paths: "{{ role_path }}/backup"
     pattern: "{{ inventory_hostname_short }}_config*"
   connection: local
   register: backup_files
 
-- name: delete backup files
+- name: Delete backup files
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: absent
   with_items: "{{backup_files.files|default([])}}"
 
-- name: configure device with config
+- name: Configure device with config
   cisco.nxos.nxos_config:
     commands:
       - description this is a test
@@ -53,7 +53,7 @@
       - "result.changed == true"
       - "result.updates is defined"
 
-- name: collect any backup files
+- name: Collect any backup files
   ansible.builtin.find: *backups
   connection: local
   register: backup_files
@@ -63,7 +63,7 @@
       - "backup_files.files is defined"
 
 # hit block/sublevel sections
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config: &clear
     lines: no ip access-list test
     provider: "{{ connection }}"
@@ -71,7 +71,7 @@
   ignore_errors: true
 
 # hit NetworkConfig._diff_exact
-- name: configure sub level command using block replace - exact
+- name: Configure sub level command using block replace - exact
   cisco.nxos.nxos_config:
     lines:
       - 10 permit ip 192.0.2.1/32 any log
@@ -94,7 +94,7 @@
       - "'40 permit ip 192.0.2.4/32 any log' in result.updates"
 
 # hit NetworkConfig._diff_strict
-- name: configure sub level command using block replace strict
+- name: Configure sub level command using block replace strict
   cisco.nxos.nxos_config:
     lines:
       - 10 permit ip 192.0.2.1/32 any log
@@ -107,12 +107,12 @@
     match: strict
   register: result
 
-- name: teardown
+- name: Teardown
   nxos_config: *clear
 
 # hit CustomNetworkConfig
 - block:
-    - name: create static route
+    - name: Create static route
       cisco.nxos.nxos_static_route:
         prefix: "192.168.20.64/24"
         next_hop: "192.0.2.3"
@@ -127,7 +127,7 @@
         that:
           - "result.changed == true"
 
-    - name: remove static route
+    - name: Remove static route
       cisco.nxos.nxos_static_route:
         prefix: "192.168.20.64/24"
         next_hop: "192.0.2.3"
@@ -142,7 +142,7 @@
     - ansible.builtin.assert: *true
 
   always:
-    - name: remove static route
+    - name: Remove static route
       cisco.nxos.nxos_static_route:
         prefix: "192.168.20.64/24"
         next_hop: "192.0.2.3"
@@ -154,7 +154,7 @@
         provider: "{{ connection }}"
       ignore_errors: true
 
-    - name: remove static route aggregate
+    - name: Remove static route aggregate
       cisco.nxos.nxos_static_route:
         aggregate:
           - prefix: "192.168.22.64/24"

--- a/tests/integration/targets/nxos_smoke/tests/common/common_utils.yaml
+++ b/tests/integration/targets/nxos_smoke/tests/common/common_utils.yaml
@@ -10,20 +10,20 @@
   when: ansible_connection == "local"
 
 # hit ComplexList
-- name: test contains operator
+- name: Test contains operator
   cisco.nxos.nxos_command:
     commands:
       - show version
     provider: "{{ connection }}"
 
 # hit to_list()
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     lines: hostname switch
     provider: "{{ connection }}"
     match: none
 
-- name: configure top level command
+- name: Configure top level command
   cisco.nxos.nxos_config:
     lines: hostname foo
     provider: "{{ connection }}"
@@ -34,7 +34,7 @@
       - "result.changed == true"
       - "'hostname foo' in result.updates"
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     lines: hostname switch
     provider: "{{ connection }}"
@@ -48,7 +48,7 @@
   ansible.builtin.set_fact:
     testint2: "{{ nxos_int2 }}"
 
-- name: "Setup: Put interfaces into a default state"
+- name: "Setup: put interfaces into a default state"
   cisco.nxos.nxos_config:
     lines:
       - "default interface {{ testint1 }}"
@@ -87,7 +87,7 @@
       - "'tx_rate lt(0)' in result.failed_conditions"
       - "'rx_rate lt(0)' in result.failed_conditions"
 
-- name: aggregate definition of interface
+- name: Aggregate definition of interface
   cisco.nxos.nxos_interface:
     aggregate:
       - name: "{{ testint1 }}"
@@ -101,7 +101,7 @@
     that:
       - "result.changed == true"
 
-- name: "TearDown: Put interfaces into a default state"
+- name: "Teardown: put interfaces into a default state"
   cisco.nxos.nxos_config:
     lines:
       - "default interface {{ testint1 }}"

--- a/tests/integration/targets/nxos_smoke/tests/common/misc_tests.yaml
+++ b/tests/integration/targets/nxos_smoke/tests/common/misc_tests.yaml
@@ -5,7 +5,7 @@
     msg: Using provider={{ connection.transport }}
   when: ansible_connection == "local"
 
-- name: hit conditional for lists of 10 or more commands
+- name: Hit conditional for lists of 10 or more commands
   cisco.nxos.nxos_command:
     commands:
       - show hostname
@@ -25,7 +25,7 @@
     that:
       - result.stdout|length == 10
 
-- name: combine with provider
+- name: Combine with provider
   cisco.nxos.nxos_command:
     commands:
       - show hostname

--- a/tests/integration/targets/nxos_snapshot/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_snapshot/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_snapshot/tasks/main.yaml
+++ b/tests/integration/targets/nxos_snapshot/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_snapshot/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_snapshot/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_snapshot/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_snapshot/tests/common/sanity.yaml
@@ -26,7 +26,7 @@
   when: imagetag is search("D1")
 
 - block:
-    - name: create snapshot
+    - name: Create snapshot
       register: result
       cisco.nxos.nxos_snapshot: &id001
         action: create
@@ -38,7 +38,7 @@
         that:
           - result.changed == true
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_snapshot: *id001
 
@@ -66,7 +66,7 @@
         - assert: *id004
       when: add_sec
 
-    - name: create another snapshot
+    - name: Create another snapshot
       register: result
       cisco.nxos.nxos_snapshot: &id005
         action: create
@@ -79,13 +79,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_snapshot: *id005
 
     - ansible.builtin.assert: *id004
 
-    - name: compare snapshots
+    - name: Compare snapshots
       cisco.nxos.nxos_snapshot:
         action: compare
         snapshot1: test_snapshot1
@@ -94,7 +94,7 @@
         compare_option: summary
         path: .
 
-    - name: delete snapshot
+    - name: Delete snapshot
       register: result
       cisco.nxos.nxos_snapshot: &id006
         snapshot_name: test_snapshot2
@@ -102,34 +102,34 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_snapshot: *id006
 
     - ansible.builtin.assert: *id004
 
-    - name: delete all snapshots
+    - name: Delete all snapshots
       register: result
       cisco.nxos.nxos_snapshot: &id007
         action: delete_all
 
     - ansible.builtin.assert: *id002
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_snapshot: *id007
 
     - ansible.builtin.assert: *id004
   when: snapshot_run
   always:
-    - name: delete all sections
+    - name: Delete all sections
       ignore_errors: true
       cisco.nxos.nxos_config:
         commands:
           - snapshot section delete myshow
         match: none
 
-    - name: delete all snapshots
+    - name: Delete all snapshots
       ignore_errors: true
       cisco.nxos.nxos_snapshot:
         action: delete_all

--- a/tests/integration/targets/nxos_snmp_community/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_snmp_community/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_snmp_community/tasks/main.yaml
+++ b/tests/integration/targets/nxos_snmp_community/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
   always:
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_snmp_community/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_snmp_community/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_snmp_community/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_snmp_community/tests/common/sanity.yaml
@@ -2,14 +2,14 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }} nxos_snmp_community sanity test
 
-- name: Setup - Remove snmp_community if configured - 1
+- name: Setup - remove snmp_community if configured - 1
   ignore_errors: true
   cisco.nxos.nxos_snmp_community: &id005
     community: TESTING7
     group: network-operator
     state: absent
 
-- name: Setup - Remove snmp_community if configured - 2
+- name: Setup - remove snmp_community if configured - 2
   ignore_errors: true
   cisco.nxos.nxos_snmp_community: &id010
     community: TEST
@@ -28,7 +28,7 @@
         that:
           - result.changed == true
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_snmp_community: *id001
 
@@ -45,7 +45,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_snmp_community: *id003
 
@@ -57,7 +57,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_snmp_community: *id005
 
@@ -72,7 +72,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_snmp_community: *id006
 
@@ -84,7 +84,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_snmp_community: *id005
 
@@ -100,7 +100,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_snmp_community: *id007
 
@@ -116,7 +116,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_snmp_community: *id008
 
@@ -132,7 +132,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_snmp_community: *id009
 

--- a/tests/integration/targets/nxos_snmp_contact/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_snmp_contact/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_snmp_contact/tasks/main.yaml
+++ b/tests/integration/targets/nxos_snmp_contact/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_snmp_contact/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_snmp_contact/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_snmp_contact/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_snmp_contact/tests/common/sanity.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }} nxos_snmp_community sanity test
 
-- name: Setup - Remove snmp_contact if configured
+- name: Setup - remove snmp_contact if configured
   cisco.nxos.nxos_snmp_contact: &id005
     contact: Test
     state: absent
@@ -18,7 +18,7 @@
         that:
           - result.changed == true
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_snmp_contact: *id001
 
@@ -34,7 +34,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_snmp_contact: *id003
 
@@ -46,7 +46,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_snmp_contact: *id005
 

--- a/tests/integration/targets/nxos_snmp_host/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_snmp_host/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_snmp_host/tasks/main.yaml
+++ b/tests/integration/targets/nxos_snmp_host/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
   always:
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_snmp_host/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_snmp_host/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v1_trap.yaml
+++ b/tests/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v1_trap.yaml
@@ -15,7 +15,7 @@
     intname: "{{ nxos_int1 }}"
   when: platform is not search('N5K|N6K')
 
-- name: Setup - Remove snmp_host if configured
+- name: Setup - remove snmp_host if configured
   ignore_errors: true
   cisco.nxos.nxos_snmp_host: &id007
     snmp_host: 192.0.2.3
@@ -46,7 +46,7 @@
         that:
           - result.changed == true
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_snmp_host: *id001
 
@@ -72,7 +72,7 @@
         - assert: *id004
       when: platform is not search('N35|N5K|N6K')
 
-    - name: remove some configuration
+    - name: Remove some configuration
       register: result
       cisco.nxos.nxos_snmp_host: &id005
         snmp_host: 192.0.2.3
@@ -84,7 +84,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_snmp_host: *id005
 
@@ -114,7 +114,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Cleanup Idempotence
+    - name: Cleanup idempotence
       register: result
       cisco.nxos.nxos_snmp_host: *id007
 

--- a/tests/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v2_inform.yaml
+++ b/tests/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v2_inform.yaml
@@ -15,7 +15,7 @@
     intname: "{{ nxos_int1 }}"
   when: platform is not search('N5K|N6K')
 
-- name: Setup - Remove snmp_host if configured
+- name: Setup - remove snmp_host if configured
   ignore_errors: true
   cisco.nxos.nxos_snmp_host: &id007
     snmp_host: 192.0.2.3
@@ -46,7 +46,7 @@
         that:
           - result.changed == true
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_snmp_host: *id001
 
@@ -72,7 +72,7 @@
         - assert: *id004
       when: platform is not search('N35|N5K|N6K')
 
-    - name: remove some configuration
+    - name: Remove some configuration
       register: result
       cisco.nxos.nxos_snmp_host: &id005
         snmp_host: 192.0.2.3
@@ -84,7 +84,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_snmp_host: *id005
 
@@ -114,7 +114,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Cleanup Idempotence
+    - name: Cleanup idempotence
       register: result
       cisco.nxos.nxos_snmp_host: *id007
 

--- a/tests/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_inform.yaml
+++ b/tests/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_inform.yaml
@@ -28,7 +28,7 @@
     run: false
   when: platform is match('N35')
 
-- name: Setup - Remove snmp_host if configured
+- name: Setup - remove snmp_host if configured
   ignore_errors: true
   cisco.nxos.nxos_snmp_host: &id007
     snmp_host: 192.0.2.3
@@ -59,7 +59,7 @@
         that:
           - result.changed == true
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_snmp_host: *id001
 
@@ -84,7 +84,7 @@
         - assert: *id004
       when: platform is not search('N35|N5K|N6K')
 
-    - name: remove some configuration
+    - name: Remove some configuration
       register: result
       cisco.nxos.nxos_snmp_host: &id005
         snmp_host: 192.0.2.3
@@ -95,7 +95,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_snmp_host: *id005
 
@@ -124,7 +124,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Cleanup Idempotence
+    - name: Cleanup idempotence
       register: result
       cisco.nxos.nxos_snmp_host: *id007
 

--- a/tests/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_trap.yaml
+++ b/tests/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_trap.yaml
@@ -19,7 +19,7 @@
     intname: "{{ nxos_int1 }}"
   when: platform is not search('N5K|N6K')
 
-- name: Setup - Remove snmp_host if configured
+- name: Setup - remove snmp_host if configured
   ignore_errors: true
   cisco.nxos.nxos_snmp_host: &id007
     snmp_host: 192.0.2.3
@@ -52,7 +52,7 @@
         that:
           - result.changed == true
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_snmp_host: *id001
 
@@ -78,7 +78,7 @@
         - assert: *id004
       when: platform is not search('N35|N5K|N6K')
 
-    - name: remove some configuration
+    - name: Remove some configuration
       register: result
       cisco.nxos.nxos_snmp_host: &id005
         snmp_host: 192.0.2.3
@@ -90,7 +90,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_snmp_host: *id005
 
@@ -120,7 +120,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Cleanup Idempotence
+    - name: Cleanup idempotence
       register: result
       cisco.nxos.nxos_snmp_host: *id007
 

--- a/tests/integration/targets/nxos_snmp_location/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_snmp_location/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_snmp_location/tasks/main.yaml
+++ b/tests/integration/targets/nxos_snmp_location/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
   always:
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_snmp_location/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_snmp_location/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_snmp_location/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_snmp_location/tests/common/sanity.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }} nxos_snmp_location sanity test
 
-- name: Setup - Remove snmp_location if configured
+- name: Setup - remove snmp_location if configured
   cisco.nxos.nxos_snmp_location: &id005
     location: Test
     state: absent
@@ -18,7 +18,7 @@
         that:
           - result.changed == true
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_snmp_location: *id001
 
@@ -34,19 +34,19 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_snmp_location: *id003
 
     - ansible.builtin.assert: *id004
 
-    - name: remove snmp location
+    - name: Remove snmp location
       register: result
       cisco.nxos.nxos_snmp_location: *id005
 
     - ansible.builtin.assert: *id002
 
-    - name: Remove Idempotence
+    - name: Remove idempotence
       register: result
       cisco.nxos.nxos_snmp_location: *id005
 

--- a/tests/integration/targets/nxos_snmp_server/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_snmp_server/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_snmp_server/tasks/main.yaml
+++ b/tests/integration/targets/nxos_snmp_server/tasks/main.yaml
@@ -1,39 +1,39 @@
 ---
-- name: Get admin user SNMP data
+- name: Get admin user snmp data
   cisco.nxos.nxos_command:
     commands: show running | section '^snmp-server user'
   register: result
 
-- name: Grep admin user SNMP localized key
+- name: Grep admin user snmp localized key
   ansible.builtin.set_fact:
     admin_snmp_passwd: "{{ result['stdout'][0] | regex_search('snmp-server user admin network-admin auth (md5|sha) (\\S+)', '\\2') }}"
 
-- name: Find admin user SNMP localized key
+- name: Find admin user snmp localized key
   ansible.builtin.set_fact:
     admin_snmp_passwd: "{{ admin_snmp_passwd[0] }}"
 
-- name: Grep admin user SNMP localized key (second)
+- name: Grep admin user snmp localized key (second)
   ansible.builtin.set_fact:
     admin_snmp_passwd_2: "{{ result['stdout'][0] | regex_search('snmp-server user admin auth (md5|sha) (\\S+)', '\\2') }}"
 
-- name: Find admin user SNMP localized key (second)
+- name: Find admin user snmp localized key (second)
   ansible.builtin.set_fact:
     admin_snmp_passwd_2: "{{ admin_snmp_passwd_2[0] }}"
 
-- name: Grep admin user SNMP engineID (second)
+- name: Grep admin user snmp engineid (second)
   ansible.builtin.set_fact:
     admin_snmp_engineid_2: "{{ result['stdout'][0] | regex_search('admin auth (md5|sha) (\\S+) priv (\\S+) localizedkey engineID (\\S+)', '\\4') }}"
 
-- name: Find admin user SNMP engineID (second)
+- name: Find admin user snmp engineid (second)
   ansible.builtin.set_fact:
     admin_snmp_engineid_2: "{{ admin_snmp_engineid_2[0] }}"
 
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli.yaml
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_snmp_server/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_snmp_server/tasks/nxapi.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_snmp_server/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_snmp_server/tests/common/merged.yaml
@@ -81,7 +81,7 @@
         that:
           - "{{ merged['after'] == result['after'] }}"
 
-    - name: Merge the provided configuration with the existing running configuration (IDEMPOTENT)
+    - name: Merge the provided configuration with the existing running configuration (idempotent)
       cisco.nxos.nxos_snmp_server: *id001
       register: result
 

--- a/tests/integration/targets/nxos_snmp_server/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_snmp_server/tests/common/overridden.yaml
@@ -91,7 +91,7 @@
         that:
           - "{{ replaced['after'] == result['after'] }}"
 
-    - name: Override snmp-server configurations of listed snmp-server with provided configurations (IDEMPOTENT)
+    - name: Override snmp-server configurations of listed snmp-server with provided configurations (idempotent)
       register: result
       cisco.nxos.nxos_snmp_server: *id001
 

--- a/tests/integration/targets/nxos_snmp_server/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_snmp_server/tests/common/replaced.yaml
@@ -91,7 +91,7 @@
         that:
           - "{{ replaced['after'] == result['after'] }}"
 
-    - name: Replace snmp-server configurations of listed snmp-server with provided configurations (IDEMPOTENT)
+    - name: Replace snmp-server configurations of listed snmp-server with provided configurations (idempotent)
       register: result
       cisco.nxos.nxos_snmp_server: *id001
 

--- a/tests/integration/targets/nxos_snmp_traps/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_snmp_traps/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_snmp_traps/tasks/main.yaml
+++ b/tests/integration/targets/nxos_snmp_traps/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
   always:
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_snmp_traps/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_snmp_traps/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_snmp_traps/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_snmp_traps/tests/common/sanity.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }} nxos_snmp_traps sanity test
 
-- name: Setup - Remove snmp_traps if configured
+- name: Setup - remove snmp_traps if configured
   cisco.nxos.nxos_snmp_traps: &id006
     group: all
     state: disabled
@@ -18,7 +18,7 @@
         that:
           - result.changed == true
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_snmp_traps: *id001
 
@@ -34,7 +34,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_snmp_traps: *id003
 
@@ -62,7 +62,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Cleanup Idempotence
+    - name: Cleanup idempotence
       register: result
       cisco.nxos.nxos_snmp_traps: *id006
 

--- a/tests/integration/targets/nxos_snmp_user/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_snmp_user/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_snmp_user/tasks/main.yaml
+++ b/tests/integration/targets/nxos_snmp_user/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
   always:
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_snmp_user/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_snmp_user/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_snmp_user/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_snmp_user/tests/common/sanity.yaml
@@ -56,7 +56,7 @@
 
     - ansible.builtin.assert: *id001
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_snmp_user: *id002
 
@@ -76,7 +76,7 @@
     - ansible.builtin.pause:
         seconds: 5
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_snmp_user: *id003
 
@@ -102,11 +102,11 @@
         - assert: *id004
       when: delete_last_user_allowed
   always:
-    - name: delete snmp user
+    - name: Delete snmp user
       when: platform is not search('N5K|N6K|N9K-F')
       cisco.nxos.nxos_snmp_user: *id006
 
-    - name: remove user workaround
+    - name: Remove user workaround
       when: platform is search('N5K|N6K|N9K-F')
       cisco.nxos.nxos_user: *id007
 

--- a/tests/integration/targets/nxos_static_route/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_static_route/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_static_route/tasks/main.yaml
+++ b/tests/integration/targets/nxos_static_route/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
   always:
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_static_route/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_static_route/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_static_route/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_static_route/tests/common/sanity.yaml
@@ -6,7 +6,7 @@
   ansible.builtin.set_fact:
     test_track_feature: true
 
-- name: configure track
+- name: Configure track
   register: cmd_result
   ignore_errors: true
   cisco.nxos.nxos_config:
@@ -52,7 +52,7 @@
     state: present
 
 - block:
-    - name: create static route
+    - name: Create static route
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_static_route: &id001
@@ -67,7 +67,7 @@
         that:
           - result.changed == true
 
-    - name: Conf static Idempotence
+    - name: Conf static idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_static_route: *id001
@@ -76,7 +76,7 @@
         that:
           - result.changed == false
 
-    - name: change static route
+    - name: Change static route
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_static_route: &id003
@@ -89,14 +89,14 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Change Idempotence
+    - name: Change idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_static_route: *id003
 
     - ansible.builtin.assert: *id004
 
-    - name: configure static route with track
+    - name: Configure static route with track
       with_items: "{{ vrfs }}"
       register: result
       when: test_track_feature
@@ -112,7 +112,7 @@
     - ansible.builtin.assert: *id002
       when: test_track_feature
 
-    - name: Config track Idempotence
+    - name: Config track idempotence
       with_items: "{{ vrfs }}"
       register: result
       when: test_track_feature
@@ -121,7 +121,7 @@
     - ansible.builtin.assert: *id004
       when: test_track_feature
 
-    - name: configure static route with not configured track
+    - name: Configure static route with not configured track
       with_items: "{{ vrfs }}"
       register: result
       ignore_errors: true
@@ -140,7 +140,7 @@
           - result.failed == True
       when: test_track_feature
 
-    - name: remove static route
+    - name: Remove static route
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_static_route: &id006
@@ -153,14 +153,14 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Remove Idempotence
+    - name: Remove idempotence
       with_items: "{{ vrfs }}"
       register: result
       cisco.nxos.nxos_static_route: *id006
 
     - ansible.builtin.assert: *id004
 
-    - name: configure static route(aggregate)
+    - name: Configure static route(aggregate)
       register: result
       cisco.nxos.nxos_static_route: &id007
         aggregate:
@@ -172,13 +172,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: configure static route aggregate(Idempotence)
+    - name: Configure static route aggregate(idempotence)
       register: result
       cisco.nxos.nxos_static_route: *id007
 
     - ansible.builtin.assert: *id004
 
-    - name: remove static route aggregate
+    - name: Remove static route aggregate
       register: result
       cisco.nxos.nxos_static_route: &id008
         aggregate:
@@ -191,20 +191,20 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: remove static route aggregate(Idempotence)
+    - name: Remove static route aggregate(idempotence)
       register: result
       cisco.nxos.nxos_static_route: *id008
 
     - ansible.builtin.assert: *id004
   always:
-    - name: remove track
+    - name: Remove track
       ignore_errors: true
       when: test_track_feature
       cisco.nxos.nxos_config:
         lines:
           - no track 1
 
-    - name: teardown test routes
+    - name: Teardown test routes
       with_items: "{{ vrfs }}"
       ignore_errors: true
       cisco.nxos.nxos_static_route: *id009

--- a/tests/integration/targets/nxos_static_routes/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_static_routes/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_static_routes/tasks/main.yaml
+++ b/tests/integration/targets/nxos_static_routes/tasks/main.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - "cli"

--- a/tests/integration/targets/nxos_static_routes/tests/common/deleted.yml
+++ b/tests/integration/targets/nxos_static_routes/tests/common/deleted.yml
@@ -12,7 +12,7 @@
           - "!min"
         gather_network_resources: static_routes
 
-    - name: Delete all routes based on VRF
+    - name: Delete all routes based on vrf
       cisco.nxos.nxos_static_routes:
         config:
           - vrf: trial_vrf
@@ -29,7 +29,7 @@
 
     - ansible.builtin.include_tasks: _populate_config.yaml
 
-    - name: Delete routes based on AFI in a VRF
+    - name: Delete routes based on afi in a vrf
       cisco.nxos.nxos_static_routes:
         config:
           - vrf: trial_vrf
@@ -50,7 +50,7 @@
 
     - ansible.builtin.include_tasks: _populate_config.yaml
 
-    - name: Deleted (All routes)
+    - name: Deleted (all routes)
       cisco.nxos.nxos_static_routes: &deleted
         state: deleted
       register: result

--- a/tests/integration/targets/nxos_static_routes/tests/common/gathered.yml
+++ b/tests/integration/targets/nxos_static_routes/tests/common/gathered.yml
@@ -22,7 +22,7 @@
           - "result.changed == false"
           - "ansible_facts.network_resources.static_routes == result.gathered"
 
-    - name: Idempotence - Gathered
+    - name: Idempotence - gathered
       cisco.nxos.nxos_static_routes: *gathered
       register: result
 

--- a/tests/integration/targets/nxos_static_routes/tests/common/merged.yml
+++ b/tests/integration/targets/nxos_static_routes/tests/common/merged.yml
@@ -49,7 +49,7 @@
           - "'ip route 192.0.2.64/28 192.0.2.23 name merged_route 1' in result.commands"
           - "result.commands | length == 6"
 
-    - name: Idempotence - Merged
+    - name: Idempotence - merged
       cisco.nxos.nxos_static_routes: *merged
       register: result
 

--- a/tests/integration/targets/nxos_static_routes/tests/common/parsed.yml
+++ b/tests/integration/targets/nxos_static_routes/tests/common/parsed.yml
@@ -18,7 +18,7 @@
       - "result.changed == false"
       - "result.parsed == parsed"
 
-- name: Idempotence - Parsed
+- name: Idempotence - parsed
   cisco.nxos.nxos_static_routes: *parsed
   register: result
 

--- a/tests/integration/targets/nxos_static_routes/tests/common/rendered.yml
+++ b/tests/integration/targets/nxos_static_routes/tests/common/rendered.yml
@@ -40,7 +40,7 @@
       - "'ipv6 route 2001:db8:12::/32 2001:db8::1001 name rendered_route 3' in result.rendered"
       - "result.rendered | length == 5"
 
-- name: Idempotence - Rendered
+- name: Idempotence - rendered
   nxos_static_routes: *rendered
   register: result
 

--- a/tests/integration/targets/nxos_static_routes/tests/common/replaced.yml
+++ b/tests/integration/targets/nxos_static_routes/tests/common/replaced.yml
@@ -40,7 +40,7 @@
           - "'ip route 192.0.2.16/28 {{ nxos_int2 }} 192.0.2.45 vrf destinationVRF name replaced_route2' in result.commands"
           - "result.commands | length == 4"
 
-    - name: Idempotence - Replaced
+    - name: Idempotence - replaced
       cisco.nxos.nxos_static_routes: *replaced
       register: result
 

--- a/tests/integration/targets/nxos_system/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_system/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_system/tasks/main.yaml
+++ b/tests/integration/targets/nxos_system/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_system/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_system/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_system/tests/cli/net_system.yaml
+++ b/tests/integration/targets/nxos_system/tests/cli/net_system.yaml
@@ -2,14 +2,14 @@
 - ansible.builtin.debug:
     msg: START nxos cli/net_system.yaml on connection={{ ansible_connection }}
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     lines:
       - no ip domain-list ansible.com
       - no ip domain-list redhat.com
     match: none
 
-- name: configure domain_list using platform agnostic module
+- name: Configure domain_list using platform agnostic module
   register: result
   ansible.netcommon.net_system:
     domain_search:
@@ -22,7 +22,7 @@
       - "'ip domain-list ansible.com' in result.commands"
       - "'ip domain-list redhat.com' in result.commands"
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     lines:
       - no ip domain-list ansible.com

--- a/tests/integration/targets/nxos_system/tests/cli/set_domain_list.yaml
+++ b/tests/integration/targets/nxos_system/tests/cli/set_domain_list.yaml
@@ -2,14 +2,14 @@
 - ansible.builtin.debug:
     msg: START cli/set_domain_list.yaml
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     lines:
       - no ip domain-list ansible.com
       - no ip domain-list redhat.com
     match: none
 
-- name: configure domain_list
+- name: Configure domain_list
   register: result
   cisco.nxos.nxos_system:
     domain_search:
@@ -22,7 +22,7 @@
       - "'ip domain-list ansible.com' in result.commands"
       - "'ip domain-list redhat.com' in result.commands"
 
-- name: verify domain_list
+- name: Verify domain_list
   register: result
   cisco.nxos.nxos_system:
     domain_search:
@@ -33,7 +33,7 @@
     that:
       - result.changed == false
 
-- name: remove one entry
+- name: Remove one entry
   register: result
   cisco.nxos.nxos_system:
     domain_search:
@@ -44,7 +44,7 @@
       - result.changed == true
       - "'no ip domain-list redhat.com' in result.commands"
 
-- name: verify remove one entry
+- name: Verify remove one entry
   register: result
   cisco.nxos.nxos_system:
     domain_search:
@@ -54,7 +54,7 @@
     that:
       - result.changed == false
 
-- name: add one entry
+- name: Add one entry
   register: result
   cisco.nxos.nxos_system:
     domain_search:
@@ -66,7 +66,7 @@
       - result.changed == true
       - "'ip domain-list redhat.com' in result.commands"
 
-- name: verify add one entry
+- name: Verify add one entry
   register: result
   cisco.nxos.nxos_system:
     domain_search:
@@ -77,7 +77,7 @@
     that:
       - result.changed == false
 
-- name: add and remove one entry
+- name: Add and remove one entry
   register: result
   cisco.nxos.nxos_system:
     domain_search:
@@ -91,7 +91,7 @@
       - "'ip domain-list eng.ansible.com' in result.commands"
       - result.commands|length == 2
 
-- name: verify add and remove one entry
+- name: Verify add and remove one entry
   register: result
   cisco.nxos.nxos_system:
     domain_search:
@@ -102,7 +102,7 @@
     that:
       - result.changed == false
 
-- name: teardown
+- name: Teardown
   cisco.nxos.nxos_config:
     lines:
       - no ip domain-list ansible.com

--- a/tests/integration/targets/nxos_system/tests/cli/set_domain_name.yaml
+++ b/tests/integration/targets/nxos_system/tests/cli/set_domain_name.yaml
@@ -2,12 +2,12 @@
 - ansible.builtin.debug:
     msg: START cli/set_domain_name.yaml
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     lines: no ip domain-name eng.ansible.com
     match: none
 
-- name: configure domain_name
+- name: Configure domain_name
   register: result
   cisco.nxos.nxos_system:
     domain_name: eng.ansible.com
@@ -16,7 +16,7 @@
     that:
       - result.changed == true
 
-- name: verify domain_name
+- name: Verify domain_name
   register: result
   cisco.nxos.nxos_system:
     domain_name: eng.ansible.com
@@ -25,7 +25,7 @@
     that:
       - result.changed == false
 
-- name: teardown
+- name: Teardown
   cisco.nxos.nxos_config:
     lines: no ip domain-name eng.ansible.com
     match: none

--- a/tests/integration/targets/nxos_system/tests/cli/set_name_servers.yaml
+++ b/tests/integration/targets/nxos_system/tests/cli/set_name_servers.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START cli/set_name_servers.yaml
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config: &id002
     lines:
       - no ip name-server 192.0.2.1
@@ -10,7 +10,7 @@
       - no ip name-server 192.0.2.3
     match: none
 
-- name: configure name_servers
+- name: Configure name_servers
   register: result
   cisco.nxos.nxos_system:
     name_servers:
@@ -25,7 +25,7 @@
       - "'ip name-server 192.0.2.2' in result.commands"
       - "'ip name-server 192.0.2.3' in result.commands"
 
-- name: verify name_servers
+- name: Verify name_servers
   register: result
   cisco.nxos.nxos_system:
     name_servers:
@@ -37,7 +37,7 @@
     that:
       - result.changed == false
 
-- name: remove one
+- name: Remove one
   register: result
   cisco.nxos.nxos_system:
     name_servers:
@@ -50,7 +50,7 @@
       - result.commands|length == 1
       - "'no ip name-server 192.0.2.3' in result.commands"
 
-- name: default name server
+- name: Default name server
   register: result
   cisco.nxos.nxos_system: &id001
     name_servers: default
@@ -67,7 +67,7 @@
     that:
       - result.changed == false
 
-- name: teardown
+- name: Teardown
   ignore_errors: true
   cisco.nxos.nxos_config: *id002
 

--- a/tests/integration/targets/nxos_system/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_system/tests/common/sanity.yaml
@@ -3,19 +3,19 @@
     msg: START connection={{ ansible_connection }}/sanity.yaml
 
 - block:
-    - name: remove configuration
+    - name: Remove configuration
       register: result
       ignore_errors: true
       cisco.nxos.nxos_system: &id010
         state: absent
 
-    - name: configure domain lookup
+    - name: Configure domain lookup
       register: result
       cisco.nxos.nxos_system: &id007
         domain_lookup: true
         state: present
 
-    - name: configure hostname and domain-name
+    - name: Configure hostname and domain-name
       register: result
       cisco.nxos.nxos_system: &id001
         hostname: switch
@@ -33,7 +33,7 @@
         that:
           - result.changed == false
 
-    - name: configure name servers
+    - name: Configure name servers
       register: result
       cisco.nxos.nxos_system: &id003
         name_servers:
@@ -48,7 +48,7 @@
 
     - ansible.builtin.assert: *id004
 
-    - name: configure name servers with VRF support
+    - name: Configure name servers with vrf support
       register: result
       cisco.nxos.nxos_system: &id005
         name_servers:
@@ -66,7 +66,7 @@
 
     - ansible.builtin.assert: *id004
 
-    - name: configure domain lookup1
+    - name: Configure domain lookup1
       register: result
       cisco.nxos.nxos_system: &id006
         domain_lookup: false
@@ -79,7 +79,7 @@
 
     - ansible.builtin.assert: *id004
 
-    - name: configure domain lookup2
+    - name: Configure domain lookup2
       register: result
       cisco.nxos.nxos_system: *id007
 
@@ -91,7 +91,7 @@
 
     - ansible.builtin.assert: *id004
 
-    - name: configure system mtu
+    - name: Configure system mtu
       register: result
       cisco.nxos.nxos_system: &id008
         system_mtu: 3000
@@ -104,7 +104,7 @@
 
     - ansible.builtin.assert: *id004
 
-    - name: default configuration
+    - name: Default configuration
       register: result
       cisco.nxos.nxos_system: &id009
         hostname: default
@@ -120,7 +120,7 @@
 
     - ansible.builtin.assert: *id004
   always:
-    - name: remove configuration
+    - name: Remove configuration
       cisco.nxos.nxos_system: *id010
 
     - name: Re-configure hostname

--- a/tests/integration/targets/nxos_system/tests/common/set_hostname.yaml
+++ b/tests/integration/targets/nxos_system/tests/common/set_hostname.yaml
@@ -3,12 +3,12 @@
     msg: START connection={{ ansible_connection }}/set_hostname.yaml
 
 - block:
-    - name: setup
+    - name: Setup
       cisco.nxos.nxos_config:
         lines: hostname switch
         match: none
 
-    - name: configure hostname
+    - name: Configure hostname
       register: result
       cisco.nxos.nxos_system:
         hostname: foo
@@ -17,7 +17,7 @@
         that:
           - result.changed == true
 
-    - name: verify hostname
+    - name: Verify hostname
       register: result
       cisco.nxos.nxos_system:
         hostname: foo
@@ -26,7 +26,7 @@
         that:
           - result.changed == false
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_config:
         lines: hostname switch
         match: none

--- a/tests/integration/targets/nxos_system/tests/nxapi/net_system.yaml
+++ b/tests/integration/targets/nxos_system/tests/nxapi/net_system.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START nxos nxapi/net_system.yaml on connection={{ ansible_connection }}
 
-- name: setup
+- name: Setup
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines:
@@ -10,7 +10,7 @@
       - no ip domain-list redhat.com
     match: none
 
-- name: configure domain_list using platform agnostic module
+- name: Configure domain_list using platform agnostic module
   register: result
   ansible.netcommon.net_system:
     domain_search:
@@ -23,7 +23,7 @@
       - "'ip domain-list ansible.com' in result.commands"
       - "'ip domain-list redhat.com' in result.commands"
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     lines:
       - no ip domain-list ansible.com

--- a/tests/integration/targets/nxos_system/tests/nxapi/set_domain_list.yaml
+++ b/tests/integration/targets/nxos_system/tests/nxapi/set_domain_list.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START nxapi/set_domain_list.yaml
 
-- name: setup
+- name: Setup
   ignore_errors: true
   with_items:
     - ansible.com
@@ -12,7 +12,7 @@
       - no ip domain-list {{ item }}
     match: none
 
-- name: configure domain_list
+- name: Configure domain_list
   register: result
   cisco.nxos.nxos_system:
     domain_search:
@@ -25,7 +25,7 @@
       - "'ip domain-list ansible.com' in result.commands"
       - "'ip domain-list redhat.com' in result.commands"
 
-- name: verify domain_list
+- name: Verify domain_list
   register: result
   cisco.nxos.nxos_system:
     domain_search:
@@ -36,7 +36,7 @@
     that:
       - result.changed == false
 
-- name: remove one entry
+- name: Remove one entry
   register: result
   cisco.nxos.nxos_system:
     domain_search:
@@ -47,7 +47,7 @@
       - result.changed == true
       - "'no ip domain-list redhat.com' in result.commands"
 
-- name: verify remove one entry
+- name: Verify remove one entry
   register: result
   cisco.nxos.nxos_system:
     domain_search:
@@ -57,7 +57,7 @@
     that:
       - result.changed == false
 
-- name: add one entry
+- name: Add one entry
   register: result
   cisco.nxos.nxos_system:
     domain_search:
@@ -69,7 +69,7 @@
       - result.changed == true
       - "'ip domain-list redhat.com' in result.commands"
 
-- name: verify add one entry
+- name: Verify add one entry
   register: result
   cisco.nxos.nxos_system:
     domain_search:
@@ -80,7 +80,7 @@
     that:
       - result.changed == false
 
-- name: add and remove one entry
+- name: Add and remove one entry
   register: result
   cisco.nxos.nxos_system:
     domain_search:
@@ -94,7 +94,7 @@
       - "'ip domain-list eng.ansible.com' in result.commands"
       - result.commands|length == 2
 
-- name: verify add and remove one entry
+- name: Verify add and remove one entry
   register: result
   cisco.nxos.nxos_system:
     domain_search:
@@ -105,7 +105,7 @@
     that:
       - result.changed == false
 
-- name: teardown
+- name: Teardown
   ignore_errors: true
   with_items:
     - ansible.com

--- a/tests/integration/targets/nxos_system/tests/nxapi/set_domain_name.yaml
+++ b/tests/integration/targets/nxos_system/tests/nxapi/set_domain_name.yaml
@@ -2,13 +2,13 @@
 - ansible.builtin.debug:
     msg: START nxapi/set_domain_name.yaml
 
-- name: setup
+- name: Setup
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines: no ip domain-name eng.ansible.com
     match: none
 
-- name: configure domain_name
+- name: Configure domain_name
   register: result
   cisco.nxos.nxos_system:
     domain_name: eng.ansible.com
@@ -17,7 +17,7 @@
     that:
       - result.changed == true
 
-- name: verify domain_name
+- name: Verify domain_name
   register: result
   cisco.nxos.nxos_system:
     domain_name: eng.ansible.com
@@ -26,7 +26,7 @@
     that:
       - result.changed == false
 
-- name: teardown
+- name: Teardown
   cisco.nxos.nxos_config:
     lines: no ip domain-name eng.ansible.com
     match: none

--- a/tests/integration/targets/nxos_system/tests/nxapi/set_name_servers.yaml
+++ b/tests/integration/targets/nxos_system/tests/nxapi/set_name_servers.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START nxapi/set_name_servers.yaml
 
-- name: setup
+- name: Setup
   ignore_errors: true
   with_items:
     - 192.0.2.1
@@ -13,7 +13,7 @@
       - no ip name-server {{ item }}
     match: none
 
-- name: configure name_servers
+- name: Configure name_servers
   register: result
   cisco.nxos.nxos_system:
     name_servers:
@@ -28,7 +28,7 @@
       - "'ip name-server 192.0.2.2' in result.commands"
       - "'ip name-server 192.0.2.3' in result.commands"
 
-- name: verify name_servers
+- name: Verify name_servers
   register: result
   cisco.nxos.nxos_system:
     name_servers:
@@ -40,7 +40,7 @@
     that:
       - result.changed == false
 
-- name: remove one
+- name: Remove one
   register: result
   cisco.nxos.nxos_system:
     name_servers:
@@ -53,7 +53,7 @@
       - result.commands|length == 1
       - "'no ip name-server 192.0.2.3' in result.commands"
 
-- name: default name server
+- name: Default name server
   register: result
   cisco.nxos.nxos_system: &id001
     name_servers: default
@@ -70,7 +70,7 @@
     that:
       - result.changed == false
 
-- name: teardown
+- name: Teardown
   with_items:
     - 192.0.2.1
     - 192.0.2.2

--- a/tests/integration/targets/nxos_telemetry/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_telemetry/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_telemetry/tasks/main.yaml
+++ b/tests/integration/targets/nxos_telemetry/tasks/main.yaml
@@ -18,7 +18,7 @@
     commands: show interface mgmt 0 | json
   register: result
 
-- name: Store mgmt interface IP address
+- name: Store mgmt interface ip address
   ansible.builtin.set_fact:
     mgmt0_ip: "{{ result['stdout'][0]['TABLE_interface']['ROW_interface']['eth_ip_addr'] }}"
 
@@ -34,12 +34,12 @@
     configured_password: "{{ temp_passwd }}"
   no_log: true
 
-- name: Setup - Turn on feature scp-server
+- name: Setup - turn on feature scp-server
   cisco.nxos.nxos_feature:
     feature: scp-server
     state: enabled
 
-- name: Setup - Backup admin password if ansible_user is not admin
+- name: Setup - backup admin password if ansible_user is not admin
   cisco.nxos.nxos_command:
     commands:
       - command: show running-config | include "username admin password"
@@ -47,13 +47,13 @@
   no_log: true
   when: ansible_user != "admin"
 
-- name: Setup - Change admin password if ansible_user is not admin
+- name: Setup - change admin password if ansible_user is not admin
   cisco.nxos.nxos_user:
     name: admin
     configured_password: "{{ temp_passwd }}"
   when: ansible_user != "admin"
 
-- name: Copy crt file from Ansible controller to bootflash
+- name: Copy crt file from ansible controller to bootflash
   register: result
   cisco.nxos.nxos_file_copy:
     local_file: "{{ role_path }}/tests/common/fixtures/{{ item }}"
@@ -67,12 +67,12 @@
     ansible_connection: ansible.netcommon.network_cli
 
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags: cli
       when: run_test
 
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags: nxapi
       when: run_test
@@ -87,7 +87,7 @@
         feature: scp-server
         state: disabled
 
-    - name: Setup - Remove existing file
+    - name: Setup - remove existing file
       ignore_errors: true
       cisco.nxos.nxos_command:
         commands:

--- a/tests/integration/targets/nxos_telemetry/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_telemetry/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_telemetry/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_telemetry/tests/common/deleted.yaml
@@ -22,7 +22,7 @@
     feature: telemetry
     state: disabled
 
-- name: Setup - Configure Telemetry
+- name: Setup - configure telemetry
   cisco.nxos.nxos_telemetry:
     state: merged
     config:
@@ -112,7 +112,7 @@
             sample_interval: 2000
 
 - block:
-    - name: Gather Telemetry Facts Before Changes
+    - name: Gather telemetry facts before changes
       cisco.nxos.nxos_facts: &id001
         gather_subset:
           - "!all"
@@ -135,7 +135,7 @@
         that:
           - (ansible_facts.network_resources.telemetry|dict2items)|symmetric_difference(result.before|dict2items)|length == 0
 
-    - name: Gather Telemetry Facts After Changes
+    - name: Gather telemetry facts after changes
       cisco.nxos.nxos_facts: *id001
 
     - ansible.builtin.assert:

--- a/tests/integration/targets/nxos_telemetry/tests/common/gathered.yaml
+++ b/tests/integration/targets/nxos_telemetry/tests/common/gathered.yaml
@@ -29,7 +29,7 @@
           - "subscription 100"
           - "snsr-grp 8 sample-interval 15000"
 
-    - name: Gather Telemetry Facts using gathered
+    - name: Gather telemetry facts using gathered
       cisco.nxos.nxos_telemetry:
         state: gathered
       register: result

--- a/tests/integration/targets/nxos_telemetry/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_telemetry/tests/common/merged.yaml
@@ -23,7 +23,7 @@
     state: disabled
 
 - block:
-    - name: Gather Telemetry Facts Before Changes
+    - name: Gather telemetry facts before changes
       cisco.nxos.nxos_facts: &id001
         gather_subset:
           - "!all"
@@ -166,7 +166,7 @@
         that:
           - (ansible_facts.network_resources.telemetry|dict2items)|symmetric_difference(result.before|dict2items)|length == 0
 
-    - name: Gather Telemetry Facts After Changes
+    - name: Gather telemetry facts after changes
       cisco.nxos.nxos_facts: *id001
 
     - ansible.builtin.assert:

--- a/tests/integration/targets/nxos_telemetry/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_telemetry/tests/common/replaced.yaml
@@ -49,7 +49,7 @@
       - "    source-interface loopback55"
 
 - block:
-    - name: Gather Telemetry Facts Before Changes
+    - name: Gather telemetry facts before changes
       cisco.nxos.nxos_facts: &id001
         gather_subset:
           - "!all"
@@ -142,7 +142,7 @@
         that:
           - (ansible_facts.network_resources.telemetry|dict2items)|symmetric_difference(result.before|dict2items)|length == 0
 
-    - name: Gather Telemetry Facts After Changes
+    - name: Gather telemetry facts after changes
       cisco.nxos.nxos_facts: *id001
 
     - ansible.builtin.assert:

--- a/tests/integration/targets/nxos_udld/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_udld/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_udld/tasks/main.yaml
+++ b/tests/integration/targets/nxos_udld/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
   always:
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_udld/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_udld/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_udld/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_udld/tests/common/sanity.yaml
@@ -32,7 +32,7 @@
         that:
           - result.changed == true
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_udld: *id001
 
@@ -51,7 +51,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_udld: *id003
 
@@ -64,7 +64,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_udld: *id005
 
@@ -83,7 +83,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Check Idempotence
+    - name: Check idempotence
       register: result
       cisco.nxos.nxos_udld: *id006
 

--- a/tests/integration/targets/nxos_udld_interface/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_udld_interface/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_udld_interface/tasks/main.yaml
+++ b/tests/integration/targets/nxos_udld_interface/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
   always:
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_udld_interface/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_udld_interface/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_udld_interface/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_udld_interface/tests/common/sanity.yaml
@@ -35,13 +35,13 @@
         feature: udld
         state: enabled
 
-    - name: put the interface into default state
+    - name: Put the interface into default state
       cisco.nxos.nxos_config:
         commands:
           - default interface {{intname}}
         match: none
 
-    - name: ensure interface is configured to be in aggressive mode
+    - name: Ensure interface is configured to be in aggressive mode
       register: result
       cisco.nxos.nxos_udld_interface: &id001
         interface: "{{ intname }}"
@@ -52,7 +52,7 @@
         that:
           - result.changed == true
 
-    - name: Conf1 Idempotence
+    - name: Conf1 idempotence
       register: result
       cisco.nxos.nxos_udld_interface: *id001
 

--- a/tests/integration/targets/nxos_user/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_user/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_user/tasks/main.yaml
+++ b/tests/integration/targets/nxos_user/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_user/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_user/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_user/tests/common/auth.yaml
+++ b/tests/integration/targets/nxos_user/tests/common/auth.yaml
@@ -7,30 +7,28 @@
         state: present
         configured_password: pasS!123
 
-    - name: test login
+    - name: Test login
       ansible.builtin.expect:
-        command:
-          ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no
+        command: ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no
           show version
         responses:
           (?i)password: pasS!123
 
-    - name: test login with invalid password (should fail)
+    - name: Test login with invalid password (should fail)
       ansible.builtin.expect:
-        command:
-          ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no
+        command: ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no
           show version
         responses:
           (?i)password: badpass
       ignore_errors: true
       register: results
 
-    - name: check that attempt failed
+    - name: Check that attempt failed
       ansible.builtin.assert:
         that:
           - results.failed
   always:
-    - name: delete user
+    - name: Delete user
       register: result
       cisco.nxos.nxos_user:
         name: auth_user

--- a/tests/integration/targets/nxos_user/tests/common/auth.yaml
+++ b/tests/integration/targets/nxos_user/tests/common/auth.yaml
@@ -9,14 +9,16 @@
 
     - name: Test login
       ansible.builtin.expect:
-        command: ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no
+        command:
+          ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no
           show version
         responses:
           (?i)password: pasS!123
 
     - name: Test login with invalid password (should fail)
       ansible.builtin.expect:
-        command: ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no
+        command:
+          ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no
           show version
         responses:
           (?i)password: badpass

--- a/tests/integration/targets/nxos_user/tests/common/basic.yaml
+++ b/tests/integration/targets/nxos_user/tests/common/basic.yaml
@@ -61,7 +61,7 @@
     lines: password strength-check
   when: not pwdchck
 
-- name: Attempt to create user with weak password with pwd check enabled (SHOULD FAIL)
+- name: Attempt to create user with weak password with pwd check enabled (should fail)
   cisco.nxos.nxos_user:
     name: ansibletest_failed
     configured_password: abc
@@ -77,7 +77,7 @@
   cisco.nxos.nxos_config:
     lines: no password strength-check
 
-- name: Attempt to create user with weak password without pwd check enabled (SHOULD WARN)
+- name: Attempt to create user with weak password without pwd check enabled (should warn)
   cisco.nxos.nxos_user:
     name: ansibletest_warn
     configured_password: abc
@@ -127,7 +127,7 @@
       - result.failed == True
       - '"invalid role specified" in result.msg'
 
-- name: tearDown
+- name: Teardown
   register: result
   cisco.nxos.nxos_user: *rem
 

--- a/tests/integration/targets/nxos_user/tests/common/net_user.yaml
+++ b/tests/integration/targets/nxos_user/tests/common/net_user.yaml
@@ -20,7 +20,7 @@
       - '"username" in result.commands[0]'
       - '"role network-operator" in result.commands[0]'
 
-- name: teardown
+- name: Teardown
   ansible.netcommon.net_user:
     name: ansibletest1
     state: absent

--- a/tests/integration/targets/nxos_user/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_user/tests/common/sanity.yaml
@@ -43,7 +43,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: remove idempotency
+    - name: Remove idempotency
       register: result
       cisco.nxos.nxos_user: *id003
 
@@ -76,7 +76,7 @@
         - assert: *id004
       when: idem
 
-    - name: tearDown
+    - name: Teardown
       register: result
       cisco.nxos.nxos_user: &id006
         name: "{{ ansible_user }}"
@@ -84,13 +84,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: teardown idempotency
+    - name: Teardown idempotency
       register: result
       cisco.nxos.nxos_user: *id006
 
     - ansible.builtin.assert: *id004
   always:
-    - name: tearDown
+    - name: Teardown
       register: result
       ignore_errors: true
       cisco.nxos.nxos_user: *id006

--- a/tests/integration/targets/nxos_vlan/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vlan/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vlan/tasks/main.yaml
+++ b/tests/integration/targets/nxos_vlan/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_vlan/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vlan/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vlan/tests/common/agg.yaml
+++ b/tests/integration/targets/nxos_vlan/tests/common/agg.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: START connection={{ ansible_connection }}/agg.yaml
 
-- name: setup - remove vlan used in test
+- name: Setup - remove vlan used in test
   ignore_errors: true
   cisco.nxos.nxos_config: &id005
     lines:
@@ -10,7 +10,7 @@
       - no vlan 103
       - no vlan 104
 
-- name: configure vlan with aggregate
+- name: Configure vlan with aggregate
   register: result
   cisco.nxos.nxos_vlan: &id001
     aggregate:
@@ -30,7 +30,7 @@
       - '"no shutdown" in result.commands'
       - '"state active" in result.commands'
 
-- name: conf1 - Idempotence
+- name: Conf1 - idempotence
   register: result
   cisco.nxos.nxos_vlan: *id001
 
@@ -38,7 +38,7 @@
     that:
       - result.changed == false
 
-- name: change property of existing vlan - admin_state down
+- name: Change property of existing vlan - admin_state down
   register: result
   cisco.nxos.nxos_vlan: &id002
     aggregate:
@@ -57,7 +57,7 @@
       - '"vlan 103" in result.commands'
       - '"shutdown" in result.commands'
 
-- name: conf2 - Idempotence
+- name: Conf2 - idempotence
   register: result
   cisco.nxos.nxos_vlan: *id002
 
@@ -65,7 +65,7 @@
     that:
       - result.changed == false
 
-- name: purge
+- name: Purge
   register: result
   cisco.nxos.nxos_vlan: &id003
     vlan_id: 1
@@ -77,7 +77,7 @@
       - '"no vlan 102" in result.commands'
       - '"no vlan 103" in result.commands'
 
-- name: purge - Idempotence
+- name: Purge - idempotence
   register: result
   cisco.nxos.nxos_vlan: *id003
 
@@ -85,12 +85,12 @@
     that:
       - result.changed == false
 
-- name: setup for purge test with aggregate add
+- name: Setup for purge test with aggregate add
   cisco.nxos.nxos_vlan:
     vlan_id: 104
     purge: true
 
-- name: purge 104 with aggregate add 102-103
+- name: Purge 104 with aggregate add 102-103
   register: result
   cisco.nxos.nxos_vlan: &id004
     aggregate:
@@ -106,7 +106,7 @@
       - '"vlan 103" in result.commands'
       - '"no vlan 104" in result.commands'
 
-- name: purge_add - Idempotence
+- name: Purge_add - idempotence
   register: result
   cisco.nxos.nxos_vlan: *id004
 
@@ -114,7 +114,7 @@
     that:
       - result.changed == false
 
-- name: teardown
+- name: Teardown
   ignore_errors: true
   cisco.nxos.nxos_config: *id005
 

--- a/tests/integration/targets/nxos_vlan/tests/common/interface.yaml
+++ b/tests/integration/targets/nxos_vlan/tests/common/interface.yaml
@@ -7,27 +7,27 @@
   ansible.builtin.set_fact:
     testint2: "{{ nxos_int2 }}"
 
-- name: setup - remove vlan used in test
+- name: Setup - remove vlan used in test
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines:
       - no vlan 100
 
-- name: setup - remove vlan from interfaces used in test(part1)
+- name: Setup - remove vlan from interfaces used in test(part1)
   cisco.nxos.nxos_config:
     lines:
       - no switchport access vlan 100
     parents: switchport
     before: interface {{ testint1 }}
 
-- name: setup - remove vlan from interfaces used in test(part2)
+- name: Setup - remove vlan from interfaces used in test(part2)
   cisco.nxos.nxos_config:
     lines:
       - no switchport access vlan 100
     parents: switchport
     before: interface {{ testint2 }}
 
-- name: create vlan
+- name: Create vlan
   cisco.nxos.nxos_vlan:
     vlan_id: 100
 
@@ -109,19 +109,19 @@
     that:
       - result.changed == false
 
-- name: teardown(part1)
+- name: Teardown(part1)
   cisco.nxos.nxos_config:
     lines:
       - no vlan 100
 
-- name: teardown - remove vlan from interfaces used in test(part1)
+- name: Teardown - remove vlan from interfaces used in test(part1)
   cisco.nxos.nxos_config:
     lines:
       - no switchport access vlan 100
     parents: switchport
     before: interface {{ testint1 }}
 
-- name: teardown - remove vlan from interfaces used in test(part2)
+- name: Teardown - remove vlan from interfaces used in test(part2)
   cisco.nxos.nxos_config:
     lines:
       - no switchport access vlan 100

--- a/tests/integration/targets/nxos_vlan/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vlan/tests/common/sanity.yaml
@@ -11,7 +11,7 @@
     testint2: "{{ nxos_int2 }}"
 
 - block:
-    - name: Install and Enable FabricPath feature set
+    - name: Install and enable fabricpath feature set
       when: platform is search('N5K|N7K')
       cisco.nxos.nxos_config:
         lines:
@@ -25,13 +25,13 @@
           - feature vn-segment-vlan-based
         match: none
 
-    - name: vlan teardown
+    - name: Vlan teardown
       ignore_errors: true
       cisco.nxos.nxos_vlan: &id013
         vlan_range: 2-200
         state: absent
 
-    - name: Ensure a range of VLANs are present on the switch
+    - name: Ensure a range of vlans are present on the switch
       register: result
       cisco.nxos.nxos_vlan: &id001
         vlan_range: 2-10,20,50,55-60,100-150
@@ -40,7 +40,7 @@
         that:
           - result.changed == true
 
-    - name: Vlan Idempotence
+    - name: Vlan idempotence
       register: result
       cisco.nxos.nxos_vlan: *id001
 
@@ -48,7 +48,7 @@
         that:
           - result.changed == false
 
-    - name: Ensure VLAN 50 exists with the name WEB and is in the shutdown state
+    - name: Ensure vlan 50 exists with the name web and is in the shutdown state
       register: result
       when: platform is search('N9K')
       cisco.nxos.nxos_vlan: &id003
@@ -61,7 +61,7 @@
     - ansible.builtin.assert: *id002
       when: platform is search('N9K')
 
-    - name: web1 Idempotence
+    - name: Web1 idempotence
       register: result
       when: platform is search('N9K')
       cisco.nxos.nxos_vlan: *id003
@@ -69,7 +69,7 @@
     - ansible.builtin.assert: *id004
       when: platform is search('N9K')
 
-    - name: change name and vni to default
+    - name: Change name and vni to default
       register: result
       when: platform is search('N9K')
       cisco.nxos.nxos_vlan: &id005
@@ -82,7 +82,7 @@
     - ansible.builtin.assert: *id002
       when: platform is search('N9K')
 
-    - name: web2 Idempotence
+    - name: Web2 idempotence
       register: result
       when: platform is search('N9K')
       cisco.nxos.nxos_vlan: *id005
@@ -90,7 +90,7 @@
     - ansible.builtin.assert: *id004
       when: platform is search('N9K')
 
-    - name: Ensure VLAN 50 exists with the name WEB and is in the shutdown state
+    - name: Ensure vlan 50 exists with the name web and is in the shutdown state
       register: result
       when: platform is search('N3K|N7K')
       cisco.nxos.nxos_vlan: &id006
@@ -102,7 +102,7 @@
     - ansible.builtin.assert: *id002
       when: platform is search('N3K|N7K')
 
-    - name: web3 Idempotence
+    - name: Web3 idempotence
       register: result
       when: platform is search('N3K|N7K')
       cisco.nxos.nxos_vlan: *id006
@@ -122,7 +122,7 @@
     - ansible.builtin.assert: *id002
       when: platform is search('N3K|N7K')
 
-    - name: web4 Idempotence
+    - name: Web4 idempotence
       register: result
       when: platform is search('N3K|N7K')
       cisco.nxos.nxos_vlan: *id007
@@ -140,7 +140,7 @@
     - ansible.builtin.assert: *id002
       when: platform is search('N5K|N7K')
 
-    - name: mode1 Idempotence
+    - name: Mode1 idempotence
       register: result
       when: platform is search('N5K|N7K')
       cisco.nxos.nxos_vlan: *id008
@@ -158,7 +158,7 @@
     - ansible.builtin.assert: *id002
       when: platform is search('N5K|N7K')
 
-    - name: mode2 Idempotence
+    - name: Mode2 idempotence
       register: result
       when: platform is search('N5K|N7K')
       cisco.nxos.nxos_vlan: *id009
@@ -166,7 +166,7 @@
     - ansible.builtin.assert: *id004
       when: platform is search('N5K|N7K')
 
-    - name: Ensure VLAN is NOT on the device
+    - name: Ensure vlan is not on the device
       register: result
       cisco.nxos.nxos_vlan: &id010
         vlan_id: 50
@@ -174,7 +174,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: no vlan Idempotence
+    - name: No vlan idempotence
       register: result
       cisco.nxos.nxos_vlan: *id010
 
@@ -215,7 +215,7 @@
       ignore_errors: true
       cisco.nxos.nxos_vlan: *id012
 
-    - name: vlan teardown final
+    - name: Vlan teardown final
       ignore_errors: true
       cisco.nxos.nxos_vlan: *id013
 

--- a/tests/integration/targets/nxos_vlans/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vlans/tasks/cli.yaml
@@ -1,5 +1,5 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
@@ -7,7 +7,7 @@
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -19,11 +19,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vlans/tasks/main.yaml
+++ b/tests/integration/targets/nxos_vlans/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_vlans/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vlans/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vlans/tests/common/_remove_config.yaml
+++ b/tests/integration/targets/nxos_vlans/tests/common/_remove_config.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Remove Config
+- name: Remove config
   cisco.nxos.nxos_config:
     lines:
       - "no vlan 2-100"

--- a/tests/integration/targets/nxos_vlans/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_vlans/tests/common/deleted.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: Start nxos_vlans deleted integration tests connection={{ ansible_connection }}
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config:
     lines:
       - "no vlan 2-100"
@@ -17,7 +17,7 @@
           - "!min"
         gather_network_resources: vlans
 
-    - name: deleted
+    - name: Deleted
       register: result
       cisco.nxos.nxos_vlans: &id001
         config:
@@ -43,7 +43,7 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_config:
         lines:
           - "no vlan 5"

--- a/tests/integration/targets/nxos_vlans/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_vlans/tests/common/merged.yaml
@@ -2,7 +2,7 @@
 - ansible.builtin.debug:
     msg: Start nxos_vlans merged integration tests connection={{ ansible_connection }}
 
-- name: setup
+- name: Setup
   cisco.nxos.nxos_config: &id002
     lines:
       - "no vlan 2-100"
@@ -43,7 +43,7 @@
         that:
           - result.after|length == ansible_facts.network_resources.vlans|length
 
-    - name: Idempotence - Merged
+    - name: Idempotence - merged
       register: result
       cisco.nxos.nxos_vlans: *id001
 
@@ -52,5 +52,5 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_config: *id002

--- a/tests/integration/targets/nxos_vlans/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_vlans/tests/common/overridden.yaml
@@ -2,13 +2,13 @@
 - ansible.builtin.debug:
     msg: Start nxos_vlans overridden integration tests connection={{ ansible_connection }}
 
-- name: setup1
+- name: Setup1
   cisco.nxos.nxos_config: &id003
     lines:
       - "no vlan 2-100"
 
 - block:
-    - name: setup
+    - name: Setup
       cisco.nxos.nxos_config:
         lines:
           - "vlan 5"
@@ -55,7 +55,7 @@
         that:
           - result.after|length == ansible_facts.network_resources.vlans|length
 
-    - name: Idempotence - Overridden
+    - name: Idempotence - overridden
       register: result
       cisco.nxos.nxos_vlans: *id002
 
@@ -64,5 +64,5 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_config: *id003

--- a/tests/integration/targets/nxos_vlans/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_vlans/tests/common/replaced.yaml
@@ -2,13 +2,13 @@
 - ansible.builtin.debug:
     msg: Start nxos_vlans replaced integration tests connection={{ ansible_connection }}
 
-- name: setup1
+- name: Setup1
   cisco.nxos.nxos_config: &id003
     lines:
       - "no vlan 2-100"
 
 - block:
-    - name: setup2
+    - name: Setup2
       cisco.nxos.nxos_config:
         lines:
           - "vlan 5"
@@ -47,7 +47,7 @@
         that:
           - result.after|length == ansible_facts.network_resources.vlans|length
 
-    - name: Idempotence - Replaced
+    - name: Idempotence - replaced
       register: result
       cisco.nxos.nxos_vlans: *id002
 
@@ -56,5 +56,5 @@
           - result.changed == false
           - result.commands|length == 0
   always:
-    - name: teardown
+    - name: Teardown
       cisco.nxos.nxos_config: *id003

--- a/tests/integration/targets/nxos_vlans/tests/common/rtt.yaml
+++ b/tests/integration/targets/nxos_vlans/tests/common/rtt.yaml
@@ -5,7 +5,7 @@
 - ansible.builtin.include_tasks: _remove_config.yaml
 
 - block:
-    - name: Apply the provided configuration (Base config)
+    - name: Apply the provided configuration (base config)
       register: base_config
       cisco.nxos.nxos_vlans:
         config:
@@ -19,7 +19,7 @@
         state: merged
       tags: base_config
 
-    - name: Gather VLANs facts
+    - name: Gather vlans facts
       cisco.nxos.nxos_facts:
         gather_subset:
           - "!all"

--- a/tests/integration/targets/nxos_vpc/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vpc/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vpc/tasks/main.yaml
+++ b/tests/integration/targets/nxos_vpc/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
   always:
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_vpc/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vpc/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vpc/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vpc/tests/common/sanity.yaml
@@ -13,17 +13,17 @@
   when: platform is not search("N35|N5K|N6K")
 
 - block:
-    - name: disable vpc for initial vpc config cleanup
+    - name: Disable vpc for initial vpc config cleanup
       cisco.nxos.nxos_feature:
         feature: vpc
         state: disabled
 
-    - name: enable feature vpc
+    - name: Enable feature vpc
       cisco.nxos.nxos_feature:
         feature: vpc
         state: enabled
 
-    - name: Ensure ntc VRF exists on switch
+    - name: Ensure ntc vrf exists on switch
       cisco.nxos.nxos_vrf:
         vrf: ntc
 
@@ -40,7 +40,7 @@
         that:
           - result.changed == true
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_vpc: *id001
 
@@ -62,7 +62,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_vpc: *id003
 
@@ -111,7 +111,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Conf Idempotence auto-recovery reload-delay
+    - name: Conf idempotence auto-recovery reload-delay
       register: result
       cisco.nxos.nxos_vpc: *id007
 
@@ -131,7 +131,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_vpc: *id008
 
@@ -146,13 +146,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_vpc: *id009
 
     - ansible.builtin.assert: *id004
 
-    - name: remove vpc
+    - name: Remove vpc
       register: result
       cisco.nxos.nxos_vpc: &id010
         state: absent
@@ -160,19 +160,19 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Remove Idempotence
+    - name: Remove idempotence
       register: result
       cisco.nxos.nxos_vpc: *id010
 
     - ansible.builtin.assert: *id004
   always:
-    - name: remove vrf
+    - name: Remove vrf
       ignore_errors: true
       cisco.nxos.nxos_vrf:
         vrf: ntc
         state: absent
 
-    - name: disable feature vpc
+    - name: Disable feature vpc
       ignore_errors: true
       cisco.nxos.nxos_feature:
         feature: vpc

--- a/tests/integration/targets/nxos_vpc_interface/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vpc_interface/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vpc_interface/tasks/main.yaml
+++ b/tests/integration/targets/nxos_vpc_interface/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
   always:
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_vpc_interface/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vpc_interface/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vpc_interface/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vpc_interface/tests/common/sanity.yaml
@@ -3,26 +3,26 @@
     msg: START connection={{ ansible_connection }} nxos_vpc_interface sanity test
 
 - block:
-    - name: enable feature vpc
+    - name: Enable feature vpc
       cisco.nxos.nxos_feature:
         feature: vpc
         state: enabled
 
-    - name: create port-channel10
+    - name: Create port-channel10
       cisco.nxos.nxos_config:
         commands:
           - interface port-channel10
           - switchport
         match: none
 
-    - name: create port-channel11
+    - name: Create port-channel11
       cisco.nxos.nxos_config:
         commands:
           - interface port-channel11
           - switchport
         match: none
 
-    - name: configure vpc
+    - name: Configure vpc
       cisco.nxos.nxos_vpc:
         state: present
         domain: 100
@@ -43,7 +43,7 @@
         that:
           - result.changed == true
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_vpc_interface: *id001
 
@@ -61,7 +61,7 @@
     - ansible.builtin.assert: *id002
       when: image_version != "7.0(3)I5(1)"
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       when: image_version != "7.0(3)I5(1)"
       cisco.nxos.nxos_vpc_interface: *id003
@@ -79,7 +79,7 @@
     - ansible.builtin.assert: *id002
       when: image_version != "7.0(3)I5(1)"
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       when: image_version != "7.0(3)I5(1)"
       cisco.nxos.nxos_vpc_interface: *id005
@@ -87,7 +87,7 @@
     - ansible.builtin.assert: *id004
       when: image_version != "7.0(3)I5(1)"
 
-    - name: remove vpc port channel
+    - name: Remove vpc port channel
       register: result
       cisco.nxos.nxos_vpc_interface: &id006
         portchannel: 10
@@ -96,13 +96,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Remove Idempotence
+    - name: Remove idempotence
       register: result
       cisco.nxos.nxos_vpc_interface: *id006
 
     - ansible.builtin.assert: *id004
   always:
-    - name: remove vpc
+    - name: Remove vpc
       ignore_errors: true
       cisco.nxos.nxos_vpc:
         state: absent
@@ -114,14 +114,14 @@
         peer_gw: true
         auto_recovery: false
 
-    - name: remove vpc port channel
+    - name: Remove vpc port channel
       ignore_errors: true
       cisco.nxos.nxos_vpc_interface:
         portchannel: 10
         vpc: 10
         state: absent
 
-    - name: remove port channel
+    - name: Remove port channel
       ignore_errors: true
       cisco.nxos.nxos_config:
         commands:
@@ -129,7 +129,7 @@
           - no interface port-channel11
         match: none
 
-    - name: disable feature vpc
+    - name: Disable feature vpc
       cisco.nxos.nxos_feature:
         feature: vpc
         state: disabled

--- a/tests/integration/targets/nxos_vrf/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vrf/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vrf/tasks/main.yaml
+++ b/tests/integration/targets/nxos_vrf/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_vrf/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vrf/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vrf/tests/common/intent.yaml
+++ b/tests/integration/targets/nxos_vrf/tests/common/intent.yaml
@@ -10,7 +10,7 @@
   ansible.builtin.set_fact:
     testint2: "{{ nxos_int2 }}"
 
-- name: setup - remove vrf from interfaces used in test(part1)
+- name: Setup - remove vrf from interfaces used in test(part1)
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines:
@@ -18,7 +18,7 @@
     parents: no switchport
     before: interface {{ testint1 }}
 
-- name: setup - remove vrf from interfaces used in test(part2)
+- name: Setup - remove vrf from interfaces used in test(part2)
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines:
@@ -26,19 +26,19 @@
     parents: no switchport
     before: interface {{ testint2 }}
 
-- name: setup - delete VRF test1 used in test
+- name: Setup - delete vrf test1 used in test
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines:
       - no vrf context test1
 
-- name: setup - remove VRF test2 used in test
+- name: Setup - remove vrf test2 used in test
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines:
       - no vrf context test2
 
-- name: aggregate definitions of VRFs
+- name: Aggregate definitions of vrfs
   register: result
   cisco.nxos.nxos_vrf: &id001
     aggregate:
@@ -59,7 +59,7 @@
       - '"description Testing" in result.commands'
       - '"shutdown" in result.commands'
 
-- name: aggregate definitions of VRFs(Idempotence)
+- name: Aggregate definitions of vrfs(idempotence)
   register: result
   cisco.nxos.nxos_vrf: *id001
 
@@ -67,7 +67,7 @@
     that:
       - result.changed == false
 
-- name: Assign interfaces to VRF (Config + intent)
+- name: Assign interfaces to vrf (config + intent)
   register: result
   cisco.nxos.nxos_vrf: &id002
     name: test1
@@ -87,7 +87,7 @@
       - '"interface {{ testint2 }}" in result.commands'
       - '"vrf member test1" in result.commands'
 
-- name: Assign interfaces to vrf(Idempotence)
+- name: Assign interfaces to vrf(idempotence)
   register: result
   cisco.nxos.nxos_vrf: *id002
 
@@ -95,7 +95,7 @@
     that:
       - result.changed == false
 
-- name: Check interfaces assigned to VRF (intent)
+- name: Check interfaces assigned to vrf (intent)
   register: result
   cisco.nxos.nxos_vrf:
     name: test1
@@ -107,7 +107,7 @@
     that:
       - result.failed == false
 
-- name: Assign interfaces to VRF (intent fail)
+- name: Assign interfaces to vrf (intent fail)
   register: result
   ignore_errors: true
   cisco.nxos.nxos_vrf:
@@ -140,7 +140,7 @@
     that:
       - result.changed == false
 
-- name: Delete VRFs
+- name: Delete vrfs
   register: result
   cisco.nxos.nxos_vrf: &id004
     aggregate:
@@ -158,7 +158,7 @@
       - '"no vrf context test1" in result.commands'
       - '"no vrf context test2" in result.commands'
 
-- name: Delete VRFs(Idempotence)
+- name: Delete vrfs(idempotence)
   register: result
   cisco.nxos.nxos_vrf: *id004
 
@@ -166,7 +166,7 @@
     that:
       - result.changed == false
 
-- name: setup - remove vrf from interfaces used in test(part1)
+- name: Setup - remove vrf from interfaces used in test(part1)
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines:
@@ -174,7 +174,7 @@
     parents: no switchport
     before: interface {{ testint1 }}
 
-- name: setup - remove vrf from interfaces used in test(part2)
+- name: Setup - remove vrf from interfaces used in test(part2)
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines:
@@ -182,13 +182,13 @@
     parents: no switchport
     before: interface {{ testint2 }}
 
-- name: setup - delete VRF test1 used in test
+- name: Setup - delete vrf test1 used in test
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines:
       - no vrf context test1
 
-- name: setup - remove VRF test2 used in test
+- name: Setup - remove vrf test2 used in test
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines:

--- a/tests/integration/targets/nxos_vrf/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vrf/tests/common/sanity.yaml
@@ -30,13 +30,13 @@
     vnid: default
   when: platform is not match("N35|N7K|N3L")
 
-- name: Enable feature BGP
+- name: Enable feature bgp
   ignore_errors: true
   cisco.nxos.nxos_feature:
     feature: bgp
     state: enabled
 
-- name: "Setup: Enable nv overlay evpn"
+- name: "Setup: enable nv overlay evpn"
   ignore_errors: true
   when: platform is match("N5K|N6K")
   cisco.nxos.nxos_config:
@@ -45,7 +45,7 @@
     provider: "{{ connection }}"
 
 - block:
-    - name: Ensure ntc VRF exists on switch
+    - name: Ensure ntc vrf exists on switch
       register: result
       cisco.nxos.nxos_vrf: &id001
         vrf: ntc
@@ -61,7 +61,7 @@
         that:
           - result.changed == true
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_vrf: *id001
 
@@ -83,13 +83,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_vrf: *id003
 
     - ansible.builtin.assert: *id004
 
-    - name: Ensure ntc VRF does not exist on switch
+    - name: Ensure ntc vrf does not exist on switch
       register: result
       cisco.nxos.nxos_vrf: &id005
         vrf: ntc
@@ -100,13 +100,13 @@
     - ansible.builtin.pause:
         seconds: 30
 
-    - name: Remove Idempotence
+    - name: Remove idempotence
       register: result
       cisco.nxos.nxos_vrf: *id005
 
     - ansible.builtin.assert: *id004
   always:
-    - name: "Setup: Disable nv overlay evpn"
+    - name: "Setup: disable nv overlay evpn"
       ignore_errors: true
       when: platform is match("N5K|N6K")
       cisco.nxos.nxos_config:
@@ -114,7 +114,7 @@
           - no nv overlay evpn
         provider: "{{ connection }}"
 
-    - name: Disable feature BGP
+    - name: Disable feature bgp
       ignore_errors: true
       cisco.nxos.nxos_feature:
         feature: bgp

--- a/tests/integration/targets/nxos_vrf_af/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vrf_af/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vrf_af/tasks/main.yaml
+++ b/tests/integration/targets/nxos_vrf_af/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
   always:
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_vrf_af/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vrf_af/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vrf_af/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vrf_af/tests/common/sanity.yaml
@@ -29,7 +29,7 @@
         that:
           - result.changed == true
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_vrf_af: *id001
 
@@ -46,7 +46,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_vrf_af: *id003
 
@@ -61,7 +61,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_vrf_af: *id005
 
@@ -76,7 +76,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_vrf_af: *id006
 
@@ -95,7 +95,7 @@
     - ansible.builtin.pause:
         seconds: 30
 
-    - name: Remove Idempotence
+    - name: Remove idempotence
       register: result
       cisco.nxos.nxos_vrf_af: *id007
 
@@ -114,7 +114,7 @@
     - ansible.builtin.pause:
         seconds: 30
 
-    - name: Remove Idempotence
+    - name: Remove idempotence
       register: result
       cisco.nxos.nxos_vrf_af: *id008
 

--- a/tests/integration/targets/nxos_vrf_interface/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vrf_interface/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vrf_interface/tasks/main.yaml
+++ b/tests/integration/targets/nxos_vrf_interface/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
   always:
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_vrf_interface/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vrf_interface/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vrf_interface/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vrf_interface/tests/common/sanity.yaml
@@ -7,7 +7,7 @@
     intname: "{{ nxos_int1 }}"
 
 - block:
-    - name: put interface in L3
+    - name: Put interface in l3
       cisco.nxos.nxos_config:
         commands:
           - no switchport
@@ -26,7 +26,7 @@
         that:
           - result.changed == true
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_vrf_interface: *id001
 
@@ -34,7 +34,7 @@
         that:
           - result.changed == false
 
-    - name: Ensure ntc VRF does not exist on interface
+    - name: Ensure ntc vrf does not exist on interface
       register: result
       cisco.nxos.nxos_vrf_interface: &id003
         vrf: ntc
@@ -43,13 +43,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Remove Idempotence
+    - name: Remove idempotence
       register: result
       cisco.nxos.nxos_vrf_interface: *id003
 
     - ansible.builtin.assert: *id004
   always:
-    - name: put interface in default mode
+    - name: Put interface in default mode
       ignore_errors: true
       cisco.nxos.nxos_config:
         lines: default interface {{ intname }}

--- a/tests/integration/targets/nxos_vrrp/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vrrp/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vrrp/tasks/main.yaml
+++ b/tests/integration/targets/nxos_vrrp/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_vrrp/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vrrp/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vrrp/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vrrp/tests/common/sanity.yaml
@@ -13,7 +13,7 @@
         feature: vrrp
         state: enabled
 
-    - name: create int vlan 10
+    - name: Create int vlan 10
       cisco.nxos.nxos_config:
         commands: int vlan 10
 
@@ -29,7 +29,7 @@
         that:
           - result.changed == true
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_vrrp: *id001
 
@@ -47,7 +47,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_vrrp: *id003
 
@@ -65,7 +65,7 @@
     - ansible.builtin.pause:
         seconds: 30
 
-    - name: Remove Idempotence
+    - name: Remove idempotence
       register: result
       cisco.nxos.nxos_vrrp: *id005
 
@@ -87,7 +87,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Reconfig Idempotence
+    - name: Reconfig idempotence
       register: result
       cisco.nxos.nxos_vrrp: *id006
 
@@ -106,13 +106,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Reconfig Idempotence
+    - name: Reconfig idempotence
       register: result
       cisco.nxos.nxos_vrrp: *id007
 
     - ansible.builtin.assert: *id004
   always:
-    - name: remove vrrp
+    - name: Remove vrrp
       ignore_errors: true
       cisco.nxos.nxos_vrrp: *id005
 

--- a/tests/integration/targets/nxos_vsan/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vsan/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vsan/tasks/main.yaml
+++ b/tests/integration/targets/nxos_vsan/tasks/main.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Check platform type and skip if not MDS
+- name: Check platform type and skip if not mds
   register: result
   cisco.nxos.nxos_command:
     commands: show version | grep MDS
@@ -8,12 +8,12 @@
   ansible.builtin.set_fact:
     skip_test: false
 
-- name: Set skip_test flag to true if not MDS
+- name: Set skip_test flag to true if not mds
   ansible.builtin.set_fact:
     skip_test: true
   when: result.stdout[0] is not search('MDS')
 
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags: cli
   when: not skip_test

--- a/tests/integration/targets/nxos_vsan/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vsan/tests/common/sanity.yaml
@@ -6,7 +6,7 @@
     msg: Using vsans {{ vsan1 }}, {{ vsan2 }} for running this sanity test, please make sure these are not used in the setup, these will be deleted after the tests
 
 - block:
-    - name: Setup - Remove vsan if configured
+    - name: Setup - remove vsan if configured
       ignore_errors: true
       cisco.nxos.nxos_vsan: &id002
         vsan:
@@ -42,7 +42,7 @@
           - result.commands == ["terminal dont-ask", "vsan database", "vsan 922", "vsan 922 name vsan-SAN-A", "vsan 922 suspend", "vsan 922 interface fc1/1", "vsan
             923", "vsan 923 name vsan-SAN-B", "no vsan 923 suspend", "vsan 923 interface fc1/2", "no terminal dont-ask"]
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_vsan: *id001
 

--- a/tests/integration/targets/nxos_vtp_domain/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vtp_domain/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vtp_domain/tasks/main.yaml
+++ b/tests/integration/targets/nxos_vtp_domain/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_vtp_domain/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vtp_domain/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vtp_domain/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vtp_domain/tests/common/sanity.yaml
@@ -12,18 +12,18 @@
   when: platform is search('N3K-F|N9K-F')
 
 - block:
-    - name: disable feature vtp
+    - name: Disable feature vtp
       ignore_errors: true
       cisco.nxos.nxos_feature:
         feature: vtp
         state: disabled
 
-    - name: enable feature vtp
+    - name: Enable feature vtp
       cisco.nxos.nxos_feature:
         feature: vtp
         state: enabled
 
-    - name: configure vtp domain
+    - name: Configure vtp domain
       register: result
       cisco.nxos.nxos_vtp_domain: &id001
         domain: ntc
@@ -32,7 +32,7 @@
         that:
           - result.changed == true
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_vtp_domain: *id001
 
@@ -41,7 +41,7 @@
           - result.changed == false
   when: vtp_run
   always:
-    - name: disable feature vtp
+    - name: Disable feature vtp
       cisco.nxos.nxos_feature:
         feature: vtp
         state: disabled

--- a/tests/integration/targets/nxos_vtp_password/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vtp_password/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vtp_password/tasks/main.yaml
+++ b/tests/integration/targets/nxos_vtp_password/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
   always:
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_vtp_password/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vtp_password/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vtp_password/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vtp_password/tests/common/sanity.yaml
@@ -12,22 +12,22 @@
   when: platform is search('N3K-F|N9K-F')
 
 - block:
-    - name: disable feature vtp
+    - name: Disable feature vtp
       ignore_errors: true
       cisco.nxos.nxos_feature:
         feature: vtp
         state: disabled
 
-    - name: enable feature vtp
+    - name: Enable feature vtp
       cisco.nxos.nxos_feature:
         feature: vtp
         state: enabled
 
-    - name: configure vtp domain
+    - name: Configure vtp domain
       cisco.nxos.nxos_vtp_domain:
         domain: testing
 
-    - name: configure vtp password
+    - name: Configure vtp password
       register: result
       cisco.nxos.nxos_vtp_password: &id001
         vtp_password: ntc
@@ -37,7 +37,7 @@
         that:
           - result.changed == true
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_vtp_password: *id001
 
@@ -45,7 +45,7 @@
         that:
           - result.changed == false
 
-    - name: remove vtp password
+    - name: Remove vtp password
       register: result
       cisco.nxos.nxos_vtp_password: &id003
         vtp_password: ntc
@@ -53,14 +53,14 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Remove Idempotence
+    - name: Remove idempotence
       register: result
       cisco.nxos.nxos_vtp_password: *id003
 
     - ansible.builtin.assert: *id004
   when: vtp_run
   always:
-    - name: disable feature vtp
+    - name: Disable feature vtp
       cisco.nxos.nxos_feature:
         feature: vtp
         state: disabled

--- a/tests/integration/targets/nxos_vtp_version/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vtp_version/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vtp_version/tasks/main.yaml
+++ b/tests/integration/targets/nxos_vtp_version/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_vtp_version/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vtp_version/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vtp_version/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vtp_version/tests/common/sanity.yaml
@@ -12,22 +12,22 @@
   when: platform is search('N3K-F|N9K-F')
 
 - block:
-    - name: disable feature vtp
+    - name: Disable feature vtp
       ignore_errors: true
       cisco.nxos.nxos_feature:
         feature: vtp
         state: disabled
 
-    - name: enable feature vtp
+    - name: Enable feature vtp
       cisco.nxos.nxos_feature:
         feature: vtp
         state: enabled
 
-    - name: configure supporting vtp domain
+    - name: Configure supporting vtp domain
       cisco.nxos.nxos_vtp_domain:
         domain: foo
 
-    - name: configure vtp version
+    - name: Configure vtp version
       register: result
       cisco.nxos.nxos_vtp_version: &id001
         version: 2
@@ -36,7 +36,7 @@
         that:
           - result.changed == true
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_vtp_version: *id001
 
@@ -45,7 +45,7 @@
           - result.changed == false
   when: vtp_run | bool
   always:
-    - name: disable feature vtp
+    - name: Disable feature vtp
       cisco.nxos.nxos_feature:
         feature: vtp
         state: disabled

--- a/tests/integration/targets/nxos_vxlan_vtep/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vxlan_vtep/tasks/main.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep/tasks/main.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- name: Include the NX-API tasks
+- name: Include the nx-api tasks
   ansible.builtin.include_tasks: nxapi.yaml
   tags:
     - nxapi

--- a/tests/integration/targets/nxos_vxlan_vtep/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vxlan_vtep/tasks/platform/n7k/cleanup.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep/tasks/platform/n7k/cleanup.yaml
@@ -1,22 +1,22 @@
 ---
-- name: Unconfigure VDC setting limit-resource module-type f3
+- name: Unconfigure vdc setting limit-resource module-type f3
   ignore_errors: true
   cisco.nxos.nxos_config:
     commands:
       - terminal dont-ask ; vdc {{ vdcid }} ;  no limit-resource module-type f3
     match: none
 
-- name: Previous command is asynchronous and can take a while.  Allow time for it to complete
+- name: Previous command is asynchronous and can take a while.  allow time for it to complete
   ansible.builtin.pause:
     seconds: 45
 
-- name: Configure VDC setting allocate interface unallocated-interfaces
+- name: Configure vdc setting allocate interface unallocated-interfaces
   ignore_errors: true
   cisco.nxos.nxos_config:
     commands:
       - terminal dont-ask ; vdc {{ vdcid }} ; allocate interface unallocated-interfaces
     match: none
 
-- name: Previous command is asynchronous can take a while.  Allow time for it to complete
+- name: Previous command is asynchronous can take a while.  allow time for it to complete
   ansible.builtin.pause:
     seconds: 45

--- a/tests/integration/targets/nxos_vxlan_vtep/tasks/platform/n7k/setup.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep/tasks/platform/n7k/setup.yaml
@@ -9,24 +9,24 @@
   ansible.builtin.set_fact:
     vdcid: "{{ vdcout.stdout_lines[0].name }}"
 
-- name: Configure VDC setting limit-resource module-type f3
+- name: Configure vdc setting limit-resource module-type f3
   ignore_errors: true
   cisco.nxos.nxos_config:
     commands:
       - terminal dont-ask ; vdc {{ vdcid }} ;  limit-resource module-type f3
     match: none
 
-- name: Previous command is asynchronous and can take a while.  Allow time for it to complete
+- name: Previous command is asynchronous and can take a while.  allow time for it to complete
   ansible.builtin.pause:
     seconds: 45
 
-- name: Configure VDC setting allocate interface unallocated-interfaces
+- name: Configure vdc setting allocate interface unallocated-interfaces
   ignore_errors: true
   cisco.nxos.nxos_config:
     commands:
       - terminal dont-ask ; vdc {{ vdcid }} ; allocate interface unallocated-interfaces
     match: none
 
-- name: Previous command is asynchronous and can take a while.  Allow time for it to complete
+- name: Previous command is asynchronous and can take a while.  allow time for it to complete
   ansible.builtin.pause:
     seconds: 45

--- a/tests/integration/targets/nxos_vxlan_vtep/tests/common/multisite.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep/tests/common/multisite.yaml
@@ -22,7 +22,7 @@
       - evpn multisite border-gateway 10
 
 - block:
-    - name: configure vxlan_vtep
+    - name: Configure vxlan_vtep
       register: result
       cisco.nxos.nxos_vxlan_vtep: &id001
         interface: nve1
@@ -38,7 +38,7 @@
         that:
           - result.changed == true
 
-    - name: Conf Idempotence
+    - name: Conf idempotence
       register: result
       cisco.nxos.nxos_vxlan_vtep: *id001
 
@@ -46,7 +46,7 @@
         that:
           - result.changed == false
 
-    - name: reset vxlan_vtep
+    - name: Reset vxlan_vtep
       register: result
       cisco.nxos.nxos_vxlan_vtep: &id003
         interface: nve1
@@ -60,13 +60,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: reset Idempotence
+    - name: Reset idempotence
       register: result
       cisco.nxos.nxos_vxlan_vtep: *id003
 
     - ansible.builtin.assert: *id004
 
-    - name: remove vxlan_vtep
+    - name: Remove vxlan_vtep
       register: result
       cisco.nxos.nxos_vxlan_vtep: &id005
         interface: nve1
@@ -81,7 +81,7 @@
         that:
           - result.changed == true
 
-    - name: Remove Idempotence
+    - name: Remove idempotence
       register: result
       cisco.nxos.nxos_vxlan_vtep: *id005
 

--- a/tests/integration/targets/nxos_vxlan_vtep/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep/tests/common/sanity.yaml
@@ -3,11 +3,11 @@
     msg: START connection={{ ansible_connection }} nxos_vxlan_vtep sanity test
 
 - block:
-    - name: Set a fact for 'global_mcast_group_L2'
+    - name: Set a fact for 'global_mcast_group_l2'
       ansible.builtin.set_fact:
         global_mcast_group_L2: 225.1.1.2
 
-    - name: Set a fact for 'def_global_mcast_group_L2'
+    - name: Set a fact for 'def_global_mcast_group_l2'
       ansible.builtin.set_fact:
         def_global_mcast_group_L2: default
 
@@ -21,7 +21,7 @@
         - set_fact: def_global_ingress_replication_bgp="false"
       when: false
 
-    - name: TCAM resource check for global_suppress_arp
+    - name: Tcam resource check for global_suppress_arp
       connection: ansible.netcommon.network_cli
       register: tcam_state
       cisco.nxos.nxos_command:
@@ -37,7 +37,7 @@
   when: platform is search('N9K') and (major_version is version('9.2', 'ge'))
 
 - block:
-    - name: Apply N7K specific setup config
+    - name: Apply n7k specific setup config
       ansible.builtin.include: targets/nxos_vxlan_vtep/tasks/platform/n7k/setup.yaml
       when: platform is match('N7K')
 
@@ -174,7 +174,7 @@
         - assert: *id004
       when: (platform is search('N7K'))
 
-    - name: remove vxlan_vtep
+    - name: Remove vxlan_vtep
       register: result
       cisco.nxos.nxos_vxlan_vtep: &id009
         interface: nve1
@@ -189,7 +189,7 @@
         that:
           - result.changed == true
 
-    - name: Remove Idempotence
+    - name: Remove idempotence
       register: result
       cisco.nxos.nxos_vxlan_vtep: *id009
 
@@ -198,7 +198,7 @@
           - result.changed == false
   when: (platform is search("N7K|N9K"))
   always:
-    - name: Apply N7K specific cleanup config
+    - name: Apply n7k specific cleanup config
       ansible.builtin.include: targets/nxos_vxlan_vtep/tasks/platform/n7k/cleanup.yaml
       when: platform is match('N7K')
 

--- a/tests/integration/targets/nxos_vxlan_vtep_vni/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep_vni/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vxlan_vtep_vni/tasks/main.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep_vni/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - block:
-    - name: Include the CLI tasks
+    - name: Include the cli tasks
       ansible.builtin.include_tasks: cli.yaml
       tags:
         - cli
   always:
-    - name: Include the NX-API tasks
+    - name: Include the nx-api tasks
       ansible.builtin.include_tasks: nxapi.yaml
       tags:
         - nxapi

--- a/tests/integration/targets/nxos_vxlan_vtep_vni/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep_vni/tasks/nxapi.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect nxapi test cases
+- name: Collect nxapi test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/nxapi"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + nxapi_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.httpapi)
+- name: Run test cases (connection=ansible.netcommon.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_vxlan_vtep_vni/tests/common/multisite.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep_vni/tests/common/multisite.yaml
@@ -28,7 +28,7 @@
       - evpn multisite border-gateway 10
 
 - block:
-    - name: configure vxlan_vtep - multisite
+    - name: Configure vxlan_vtep - multisite
       cisco.nxos.nxos_vxlan_vtep:
         interface: nve1
         host_reachability: true

--- a/tests/integration/targets/nxos_vxlan_vtep_vni/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep_vni/tests/common/sanity.yaml
@@ -3,7 +3,7 @@
     msg: START connection={{ ansible_connection }} nxos_vxlan_vtep_vni sanity test
 
 - block:
-    - name: Apply N7K specific setup config
+    - name: Apply n7k specific setup config
       ansible.builtin.include: targets/nxos_vxlan_vtep/tasks/platform/n7k/setup.yaml
       when: platform is match('N7K')
 
@@ -13,12 +13,12 @@
           - feature nv overlay
         match: none
 
-    - name: configure vxlan_vtep
+    - name: Configure vxlan_vtep
       cisco.nxos.nxos_vxlan_vtep:
         interface: nve1
         host_reachability: true
 
-    - name: configure vxlan_vtep_vni assoc-vrf
+    - name: Configure vxlan_vtep_vni assoc-vrf
       register: result
       cisco.nxos.nxos_vxlan_vtep_vni: &id001
         interface: nve1
@@ -29,7 +29,7 @@
         that:
           - result.changed == true
 
-    - name: Conf 1 Idempotence
+    - name: Conf 1 idempotence
       register: result
       cisco.nxos.nxos_vxlan_vtep_vni: *id001
 
@@ -37,14 +37,14 @@
         that:
           - result.changed == false
 
-    - name: remove vxlan_vtep_vni
+    - name: Remove vxlan_vtep_vni
       cisco.nxos.nxos_vxlan_vtep_vni:
         interface: nve1
         vni: 6000
         assoc_vrf: true
         state: absent
 
-    - name: configure vxlan_vtep_vni
+    - name: Configure vxlan_vtep_vni
       register: result
       cisco.nxos.nxos_vxlan_vtep_vni:
         interface: nve1
@@ -52,7 +52,7 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: configure vxlan_vtep_vni mcast
+    - name: Configure vxlan_vtep_vni mcast
       register: result
       cisco.nxos.nxos_vxlan_vtep_vni: &id003
         interface: nve1
@@ -61,13 +61,13 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Conf 3 Idempotence
+    - name: Conf 3 idempotence
       register: result
       cisco.nxos.nxos_vxlan_vtep_vni: *id003
 
     - ansible.builtin.assert: *id004
 
-    - name: configure vxlan_vtep_vni default mcast
+    - name: Configure vxlan_vtep_vni default mcast
       register: result
       cisco.nxos.nxos_vxlan_vtep_vni: &id005
         interface: nve1
@@ -76,19 +76,19 @@
 
     - ansible.builtin.assert: *id002
 
-    - name: Conf 4 Idempotence
+    - name: Conf 4 idempotence
       register: result
       cisco.nxos.nxos_vxlan_vtep_vni: *id005
 
     - ansible.builtin.assert: *id004
 
-    - name: remove config
+    - name: Remove config
       cisco.nxos.nxos_vxlan_vtep_vni: &id013
         interface: nve1
         vni: 8000
         state: absent
 
-    - name: configure vxlan_vtep
+    - name: Configure vxlan_vtep
       cisco.nxos.nxos_vxlan_vtep:
         interface: nve1
         host_reachability: false
@@ -229,11 +229,11 @@
       when: (platform is search('N9K'))
   when: (platform is search("N7K|N9K"))
   always:
-    - name: Apply N7K specific cleanup config
+    - name: Apply n7k specific cleanup config
       ansible.builtin.include: targets/nxos_vxlan_vtep/tasks/platform/n7k/cleanup.yaml
       when: platform is match('N7K')
 
-    - name: remove vxlan_vtep
+    - name: Remove vxlan_vtep
       ignore_errors: true
       cisco.nxos.nxos_vxlan_vtep:
         interface: nve1

--- a/tests/integration/targets/nxos_zone_zoneset/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_zone_zoneset/tasks/cli.yaml
@@ -1,12 +1,12 @@
 ---
-- name: collect common test cases
+- name: Collect common test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/common"
     patterns: "{{ testcase }}.yaml"
   connection: local
   register: test_cases
 
-- name: collect cli test cases
+- name: Collect cli test cases
   ansible.builtin.find:
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
@@ -18,11 +18,11 @@
     test_cases:
       files: "{{ test_cases.files + cli_cases.files }}"
 
-- name: set test_items
+- name: Set test_items
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test cases (connection=ansible.netcommon.network_cli)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:

--- a/tests/integration/targets/nxos_zone_zoneset/tasks/main.yaml
+++ b/tests/integration/targets/nxos_zone_zoneset/tasks/main.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Check platform type and skip if not MDS
+- name: Check platform type and skip if not mds
   register: result
   cisco.nxos.nxos_command:
     commands: show version | grep MDS
@@ -8,12 +8,12 @@
   ansible.builtin.set_fact:
     skip_test: false
 
-- name: Set skip_test flag to true if not MDS
+- name: Set skip_test flag to true if not mds
   ansible.builtin.set_fact:
     skip_test: true
   when: result.stdout[0] is not search('MDS')
 
-- name: Include the CLI tasks
+- name: Include the cli tasks
   ansible.builtin.include_tasks: cli.yaml
   tags: cli
   when: not skip_test

--- a/tests/integration/targets/nxos_zone_zoneset/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_zone_zoneset/tests/common/sanity.yaml
@@ -15,8 +15,8 @@
           - id: "{{ vsan2 | int }}"
             remove: true
   block:
-    - ignore_errors: true
-      name: Setup - Remove vsan if configured
+    - name: Setup - remove vsan if configured
+      ignore_errors: true
       cisco.nxos.nxos_vsan:
         vsan:
           - id: "{{ vsan1 | int }}"
@@ -117,11 +117,11 @@
             "member pwwn 62:62:62:62:21:21:21:21", "member device-alias somedummyname", "zoneset name zsetname21 vsan 923", "member zone21A", "member zone21B", "zoneset
             activate name zsetname21 vsan 923", "no terminal dont-ask"]
 
-    - name: Idempotence Check
+    - name: Idempotence check
       register: result
       cisco.nxos.nxos_zone_zoneset: *id001
 
-    - name: Display Idempotence Check result
+    - name: Display idempotence check result
       ansible.builtin.debug:
         var: result
 
@@ -178,7 +178,7 @@
           - result.commands == ["terminal dont-ask", "no zone name zoneA vsan 922", "no zone name zoneB vsan 922", "no zoneset name zsetname1 vsan 922", "zone commit
             vsan 922", "no zone name zone21A vsan 923", "no zone name zone21B vsan 923", "no zoneset name zsetname21 vsan 923", "no terminal dont-ask"]
 
-    - name: Idempotence Check for zone/zoneset removal
+    - name: Idempotence check for zone/zoneset removal
       register: result
       cisco.nxos.nxos_zone_zoneset: *id002
 

--- a/tests/integration/targets/prepare_nxos_tests/tasks/prepare.yml
+++ b/tests/integration/targets/prepare_nxos_tests/tasks/prepare.yml
@@ -1,12 +1,12 @@
 ---
-- name: Enable Feature Privilege
+- name: Enable feature privilege
   connection: ansible.netcommon.network_cli
   ignore_errors: true
   cisco.nxos.nxos_config:
     lines:
       - feature privilege
 
-- name: Enable Feature NXAPI
+- name: Enable feature nxapi
   connection: ansible.netcommon.network_cli
   cisco.nxos.nxos_nxapi:
     state: present


### PR DESCRIPTION
All task names are capitalized
A follow on PR will normalize and capitalize common acronyms:

cli => CLI
nxapi, nx-api => NX-API
tacacs => TACACS
acl => ACL
ace =>  ACE
rtt => RTT
motd => MOTD
bfd => BFD
bgp => BGP
vrf => VRF
fib => FIB
bgp_af => BGP_AF
af => AF
ospf => OSPF
ebgp =>  EBGP
gt => 'gt'
ge => 'ge'
lt => 'lt'
le => 'le'
neq => 'neq'
config => configuration
mds => MDS
nv => NV
evpn => EVPN
ip => IP
eigrp => EIGRP
igmp => IGMP
pim => PIM
ssh => SSH
os => OS
n5k => N5K
n7k => N7K
n3k => N3K
n9k => N9K
svi => SVI
vlan => VLAN
vsan => VSAN
vdc => VDC
vtp => VTP
ntc => NTC
l3 => layer 3
feature x => 'feature x'
conf => configure
Conf => Configure
l2 => layer 2
afi => AFI
snmp => SNMP