### PR TITLE
Add .virl and collections to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# CML/virl lab cache
+.virl/
+
+# A collection directory, resulting from the use of the pytest-ansible-units plugin
+collections/
+
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/changelogs/fragments/513.yaml
+++ b/changelogs/fragments/513.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Add collections and .virl to .gitignore


### PR DESCRIPTION
These two entries are necessary as a result of the new testing strategy.

- The collection folder is created with linked contents by the pytest-ansible-units plugin
- The .virl directory is a result of using virl within the source root