### PR TITLE
Switch to include_tasks

### DIFF
--- a/changelogs/fragments/520.yaml
+++ b/changelogs/fragments/520.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Switch to include_task from bare include

--- a/tests/integration/targets/nxos_config/tasks/main.yaml
+++ b/tests/integration/targets/nxos_config/tasks/main.yaml
@@ -11,11 +11,11 @@
       tags:
         - nxapi
 
-    - ansible.builtin.include: cli_config.yaml
+    - ansible.builtin.include_tasks: cli_config.yaml
       tags:
         - cli_config
 
-    - ansible.builtin.include: redirection.yaml
+    - ansible.builtin.include_tasks: redirection.yaml
       when: ansible_version.full is version('2.10.0', '>=')
   always:
     - name: Change hostname back to {{ inventory_hostname_short }}

--- a/tests/integration/targets/nxos_install_os/tasks/main.yaml
+++ b/tests/integration/targets/nxos_install_os/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
-- ansible.builtin.include: network_cli.yaml
+- ansible.builtin.include_tasks: network_cli.yaml
   when: ansible_connection == 'ansible.netcommon.network_cli'
 
-- ansible.builtin.include: httpapi.yaml
+- ansible.builtin.include_tasks: httpapi.yaml
   when: ansible_connection == 'ansible.netcommon.httpapi'

--- a/tests/integration/targets/nxos_install_os/tasks/upgrade/copy_kick_system_images.yaml
+++ b/tests/integration/targets/nxos_install_os/tasks/upgrade/copy_kick_system_images.yaml
@@ -8,7 +8,7 @@
     ignore_errors_httpapi: true
   when: ansible_connection == 'ansible.netcommon.httpapi'
 
-- ansible.builtin.include: enable_scp_server.yaml
+- ansible.builtin.include_tasks: enable_scp_server.yaml
 
 - name: Remove SSH known_hosts file before scp of image file
   ignore_errors: true # noqa ignore-errors

--- a/tests/integration/targets/nxos_install_os/tasks/upgrade/install_os.yaml
+++ b/tests/integration/targets/nxos_install_os/tasks/upgrade/install_os.yaml
@@ -1,14 +1,16 @@
 ---
-- ansible.builtin.include: delete_files.yaml
+- ansible.builtin.include_tasks: delete_files.yaml
   when: delete_files
 
-- ansible.builtin.include: copy_kick_system_images.yaml ansible_connection=ansible.netcommon.network_cli connection={{ cli }}
+- ansible.builtin.include_tasks: copy_kick_system_images.yaml
+  vars:
+    ansible_connection: ansible.netcommon.network_cli connection={{ cli }}
   when: copy_images
 
-- ansible.builtin.include: install_with_kick.yaml
+- ansible.builtin.include_tasks: install_with_kick.yaml
   when: ki is defined
 
-- ansible.builtin.include: install_system.yaml
+- ansible.builtin.include_tasks: install_system.yaml
   when: ki is undefined
 
 - name: Reset the connection

--- a/tests/integration/targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
+++ b/tests/integration/targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
@@ -6,4 +6,4 @@
 - name: End the play
   ansible.builtin.meta: end_play
 
-- ansible.builtin.include: install_os.yaml
+- ansible.builtin.include_tasks: install_os.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade.yaml
@@ -42,7 +42,7 @@
     ki: n3000-uk9-kickstart.6.0.2.U6.1a.bin
 
 - name: Upgrade to u6.1a
-  ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
+  ansible.builtin.include_tasks: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
 
 - name: Set a fact for 'si'
   ansible.builtin.set_fact:
@@ -53,7 +53,7 @@
     ki: n3000-uk9-kickstart.6.0.2.U6.2a.bin
 
 - name: Upgrade to u6.2a
-  ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
+  ansible.builtin.include_tasks: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
 
 - name: Set a fact for 'si'
   ansible.builtin.set_fact:
@@ -64,14 +64,14 @@
     ki: n3000-s2-kickstart.8.0.1.bin
 
 - name: Upgrade to u6.3a
-  ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
+  ansible.builtin.include_tasks: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
 
 - name: Set a fact for 'si'
   ansible.builtin.set_fact:
     si: nxos.7.0.3.I7.2.bin
 
 - name: Upgrade to 7.0.3.i7.2
-  ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
+  ansible.builtin.include_tasks: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
 
 - ansible.builtin.debug:
     msg: END connection={{ ansible_connection }} nxos_os_install upgrade

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_greensboro.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_greensboro.yaml
@@ -38,4 +38,4 @@
     si: nxos.7.0.3.I7.4.bin
 
 - name: Upgrade n3172 device to greensboro release image
-  ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
+  ansible.builtin.include_tasks: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_u61a.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_u61a.yaml
@@ -42,4 +42,4 @@
     ki: n3000-uk9-kickstart.6.0.2.U6.1a.bin
 
 - name: Upgrade n3500 device to u61a release image
-  ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
+  ansible.builtin.include_tasks: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_u62a.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_u62a.yaml
@@ -42,4 +42,4 @@
     ki: n3000-uk9-kickstart.6.0.2.U6.2a.bin
 
 - name: Upgrade n3500 device to u62a release image
-  ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
+  ansible.builtin.include_tasks: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_u63a.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n3172_u63a.yaml
@@ -42,4 +42,4 @@
     ki: n3000-uk9-kickstart.6.0.2.U6.3a.bin
 
 - name: Upgrade n3500 device to u63a release image
-  ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
+  ansible.builtin.include_tasks: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n35_62a88.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n35_62a88.yaml
@@ -42,4 +42,4 @@
     ki: n3500-uk9-kickstart.6.0.2.A8.8.bin
 
 - name: Upgrade n3500 device to a8_8 release image
-  ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
+  ansible.builtin.include_tasks: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n35_greensboro.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n35_greensboro.yaml
@@ -38,4 +38,4 @@
     si: nxos.7.0.3.I7.4.bin
 
 - name: Upgrade n3500 device to greensboro release image
-  ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
+  ansible.builtin.include_tasks: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n5k_730_N11.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n5k_730_N11.yaml
@@ -41,4 +41,4 @@
     ki: n6000-uk9-kickstart.7.3.0.N1.1.bin
 
 - name: Upgrade N5K device to 7.3(0)n1(1) release image
-  ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
+  ansible.builtin.include_tasks: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n5k_733_N11.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n5k_733_N11.yaml
@@ -41,4 +41,4 @@
     ki: n6000-uk9-kickstart.7.3.3.N1.1.bin
 
 - name: Upgrade N5K device to 7.3(3)n1(1) release image
-  ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
+  ansible.builtin.include_tasks: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n7k_atherton.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n7k_atherton.yaml
@@ -41,4 +41,4 @@
     ki: n7000-s2-kickstart.8.0.1.bin
 
 - name: Upgrade N7K device to atherton release image
-  ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
+  ansible.builtin.include_tasks: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n7k_helsinki.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n7k_helsinki.yaml
@@ -41,4 +41,4 @@
     ki: n7000-s2-kickstart.7.3.0.D1.1.bin
 
 - name: Upgrade N7K device to helsinki release image
-  ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
+  ansible.builtin.include_tasks: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n9k_greensboro.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n9k_greensboro.yaml
@@ -47,4 +47,4 @@
     si: nxos.7.0.3.I7.4.bin
 
 - name: Upgrade N9K device to greensboro release image
-  ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
+  ansible.builtin.include_tasks: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n9k_greensboro_force.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n9k_greensboro_force.yaml
@@ -47,4 +47,4 @@
     si: nxos.7.0.3.I7.4.bin
 
 - name: Upgrade N9K device to greensboro release image
-  ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
+  ansible.builtin.include_tasks: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_install_os/tests/common/upgrade_n9k_hamilton.yaml
+++ b/tests/integration/targets/nxos_install_os/tests/common/upgrade_n9k_hamilton.yaml
@@ -45,4 +45,4 @@
     si: nxos.9.2.1.bin
 
 - name: Upgrade N9K device to hamilton release image
-  ansible.builtin.include: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml
+  ansible.builtin.include_tasks: targets/nxos_install_os/tasks/upgrade/main_os_install.yaml

--- a/tests/integration/targets/nxos_nxapi/tests/cli/configure.yaml
+++ b/tests/integration/targets/nxos_nxapi/tests/cli/configure.yaml
@@ -25,13 +25,13 @@
         commands:
           - show nxapi | json
 
-    - ansible.builtin.include: tasks/platform/n7k/assert_changes_https.yaml
+    - ansible.builtin.include_tasks: tasks/platform/n7k/assert_changes_https.yaml
       when: platform is match('N7K')
 
-    - ansible.builtin.include: tasks/platform/n5k/assert_changes_https.yaml
+    - ansible.builtin.include_tasks: tasks/platform/n5k/assert_changes_https.yaml
       when: platform is search('N5K|N6K')
 
-    - ansible.builtin.include: tasks/platform/default/assert_changes_https.yaml
+    - ansible.builtin.include_tasks: tasks/platform/default/assert_changes_https.yaml
       when: platform is not search('N35|N5K|N6K|N7K')
 
     - name: Configure NX-API https again
@@ -56,13 +56,13 @@
         commands:
           - show nxapi | json
 
-    - ansible.builtin.include: tasks/platform/n7k/assert_changes_https_http.yaml
+    - ansible.builtin.include_tasks: tasks/platform/n7k/assert_changes_https_http.yaml
       when: platform is match('N7K')
 
-    - ansible.builtin.include: tasks/platform/n5k/assert_changes_https_http.yaml
+    - ansible.builtin.include_tasks: tasks/platform/n5k/assert_changes_https_http.yaml
       when: platform is match('N5K')
 
-    - ansible.builtin.include: tasks/platform/default/assert_changes_https_http.yaml
+    - ansible.builtin.include_tasks: tasks/platform/default/assert_changes_https_http.yaml
       when: platform is not search('N35|N5K|N6K|N7K')
 
     - name: Configure NX-API https & http again
@@ -86,13 +86,13 @@
         commands:
           - show nxapi | json
 
-    - ansible.builtin.include: tasks/platform/n7k/assert_changes_https_http_ports.yaml
+    - ansible.builtin.include_tasks: tasks/platform/n7k/assert_changes_https_http_ports.yaml
       when: platform is match('N7K')
 
-    - ansible.builtin.include: tasks/platform/n5k/assert_changes_https_http_ports.yaml
+    - ansible.builtin.include_tasks: tasks/platform/n5k/assert_changes_https_http_ports.yaml
       when: platform is match('N5K')
 
-    - ansible.builtin.include: tasks/platform/default/assert_changes_https_http_ports.yaml
+    - ansible.builtin.include_tasks: tasks/platform/default/assert_changes_https_http_ports.yaml
       when: platform is not search('N35|N5K|N6K|N7K')
 
     - name: Configure different NX-API https & http ports again
@@ -114,13 +114,13 @@
         commands:
           - show nxapi | json
 
-    - ansible.builtin.include: tasks/platform/n7k/assert_changes_http.yaml
+    - ansible.builtin.include_tasks: tasks/platform/n7k/assert_changes_http.yaml
       when: platform is match('N7K')
 
-    - ansible.builtin.include: tasks/platform/n5k/assert_changes_http.yaml
+    - ansible.builtin.include_tasks: tasks/platform/n5k/assert_changes_http.yaml
       when: platform is match('N5K')
 
-    - ansible.builtin.include: tasks/platform/default/assert_changes_http.yaml
+    - ansible.builtin.include_tasks: tasks/platform/default/assert_changes_http.yaml
       when: platform is not search('N35|N5K|N6K|N7K')
 
     - name: Configure NX-API http again

--- a/tests/integration/targets/nxos_overlay_global/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_overlay_global/tests/common/sanity.yaml
@@ -21,7 +21,7 @@
         nv_overlay_evpn: true
 
     - name: Apply N7K specific setup configuration
-      ansible.builtin.include: tasks/platform/n7k/setup.yaml
+      ansible.builtin.include_tasks: tasks/platform/n7k/setup.yaml
       when: platform is match('N7K')
 
     - name: Configure additional N7K requiste features
@@ -84,7 +84,7 @@
   when: overlay_global_supported
   always:
     - name: Apply N7K specific cleanup configuration
-      ansible.builtin.include: tasks/platform/n7k/cleanup.yaml
+      ansible.builtin.include_tasks: tasks/platform/n7k/cleanup.yaml
       when: platform is match('N7K')
 
     - name: Disable NV overlay EVPN

--- a/tests/integration/targets/nxos_smoke/tasks/cli.yaml
+++ b/tests/integration/targets/nxos_smoke/tasks/cli.yaml
@@ -39,12 +39,17 @@
 
 # Temporarily disabling connection=local tests for CI issues
 # - name: run test cases (connection=local)
-#   include: "{{ test_case_to_run }} ansible_connection=local connection={{ cli }}"
+#   ansible.builtin.include_tasks: "{{ test_case_to_run }}
+#   vars:
+#     ansible_connection: local
+#     connection: "{{ cli }}"
 #   with_items: "{{ test_items }}"
 #   loop_control:
 #     loop_var: test_case_to_run
 
 - name: Run test cases (connection=network_cli)
-  ansible.builtin.include:
-    "{{ role_path }}/tests/common/caching.yaml ansible_connection=ansible.netcommon.network_cli ansible_network_single_user_mode=True connection={{\
-    \ cli }}"
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/caching.yaml"
+  vars:
+    ansible_connection: ansible.netcommon.network_cli
+    ansible_network_single_user_mode: true
+    connection: "{{ cli }}"

--- a/tests/integration/targets/nxos_smoke/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_smoke/tasks/nxapi.yaml
@@ -32,7 +32,9 @@
     connection: "{{ nxapi }}"
 # Temporarily disabling connection=local tests for CI issues
 # - name: run test cases (connection=local)
-#   include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
+#   ansible.builtin.include_tasks: "{{ test_case_to_run }}
+#   vars:
+#     ansible_connection: local connection={{ nxapi }}
 #   with_items: "{{ test_items }}"
 #   loop_control:
 #    loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_vxlan_vtep/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep/tests/common/sanity.yaml
@@ -38,7 +38,7 @@
 
 - block:
     - name: Apply N7K specific setup configuration
-      ansible.builtin.include: targets/nxos_vxlan_vtep/tasks/platform/n7k/setup.yaml
+      ansible.builtin.include_tasks: targets/nxos_vxlan_vtep/tasks/platform/n7k/setup.yaml
       when: platform is match('N7K')
 
     - name: Enable 'feature nv overlay'
@@ -199,7 +199,7 @@
   when: (platform is search("N7K|N9K"))
   always:
     - name: Apply N7K specific cleanup configuration
-      ansible.builtin.include: targets/nxos_vxlan_vtep/tasks/platform/n7k/cleanup.yaml
+      ansible.builtin.include_tasks: targets/nxos_vxlan_vtep/tasks/platform/n7k/cleanup.yaml
       when: platform is match('N7K')
 
     - name: Disable NV overlay EVPN

--- a/tests/integration/targets/nxos_vxlan_vtep_vni/tests/common/sanity.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep_vni/tests/common/sanity.yaml
@@ -4,7 +4,7 @@
 
 - block:
     - name: Apply N7K specific setup configuration
-      ansible.builtin.include: targets/nxos_vxlan_vtep/tasks/platform/n7k/setup.yaml
+      ansible.builtin.include_tasks: targets/nxos_vxlan_vtep/tasks/platform/n7k/setup.yaml
       when: platform is match('N7K')
 
     - name: Enable 'feature nv overlay'
@@ -230,7 +230,7 @@
   when: (platform is search("N7K|N9K"))
   always:
     - name: Apply N7K specific cleanup configuration
-      ansible.builtin.include: targets/nxos_vxlan_vtep/tasks/platform/n7k/cleanup.yaml
+      ansible.builtin.include_tasks: targets/nxos_vxlan_vtep/tasks/platform/n7k/cleanup.yaml
       when: platform is match('N7K')
 
     - name: Remove vxlan_vtep


### PR DESCRIPTION
##### SUMMARY
Switch from include to include_tasks
include is being deprecated in 2.16 and emit WARNINGS

##### ISSUE TYPE
- content quality


##### COMPONENT NAME
tests

##### ADDITIONAL INFORMATION
Done manually
