### PR TITLE
fix OSPF interface related modules failing with subinterfaces

### DIFF
--- a/changelogs/fragments/ospf_subinterface_failure.yaml
+++ b/changelogs/fragments/ospf_subinterface_failure.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Modules related to OSPF interfaces fail when the target NXOS device has subinterfaces

--- a/plugins/module_utils/network/nxos/facts/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/nxos/facts/ospf_interfaces/ospf_interfaces.py
@@ -76,7 +76,9 @@ class Ospf_interfacesFacts(object):
 
             objs = sorted(
                 objs,
-                key=lambda i: [int(k) if k.isdigit() else k for k in i["name"].split("/")],
+                key=lambda i: [
+                    int(k) if k.isdigit() else k for k in i["name"].replace(".", "/").split("/")
+                ],
             )
 
         ansible_facts["ansible_network_resources"].pop("ospf_interfaces", None)


### PR DESCRIPTION
##### SUMMARY
When the target NXOS device has sub-interfaces, some modules like `nxos_ospf_interfaces` and `nxos_facts`, which use fact `ospf_interfaces`, fail with the following error:
```
  msg: '''<'' not supported between instances of ''str'' and ''int'''
```

If the target NXOS device has sub-interfaces, these modules fail even when sub-interfaces are not mentioned in your playbook.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
`plugins/module_utils/network/nxos/facts/ospf_interfaces/ospf_interfaces.py`

##### ADDITIONAL INFORMATION
With PR #360 , the sorting of interfaces retrieved as a part of OSPF interfaces fact got improved. However, it introduced a bug where any modules using the said fact under the hood fail when the target device has sub-interfaces.

After the fix in this PR, fact `ospf_interfaces` won't fail even when the target NXOS device has sub-interfaces like below:
```
    ansible_network_resources:
      ospf_interfaces:
      - name: Ethernet1/1
      - name: Ethernet1/1.7
      - name: Ethernet1/2
      - name: Ethernet1/2.30
      - name: Ethernet1/2.31
```