### PR TITLE
[facts] Parse module info correctly when TABLE_modinfo is a list

### DIFF
--- a/changelogs/fragments/nxos_facts.yaml
+++ b/changelogs/fragments/nxos_facts.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "`nxos_facts` - Fixes parsing of module info json data when TABLE_modinfo entry is a list (https://github.com/ansible-collections/cisco.nxos/issues/559)."

--- a/plugins/module_utils/network/nxos/facts/legacy/base.py
+++ b/plugins/module_utils/network/nxos/facts/legacy/base.py
@@ -636,10 +636,17 @@ class Legacy(FactsBase):
         return objects
 
     def parse_structured_module(self, data):
-        data = data["TABLE_modinfo"]["ROW_modinfo"]
-        if isinstance(data, dict):
-            data = [data]
-        objects = list(self.transform_iterable(data, self.MODULE_MAP))
+        modinfo = data["TABLE_modinfo"]
+        if isinstance(modinfo, dict):
+            modinfo = [modinfo]
+
+        objects = []
+        for entry in modinfo:
+            entry = entry["ROW_modinfo"]
+            if isinstance(entry, dict):
+                entry = [entry]
+            entry_objects = list(self.transform_iterable(entry, self.MODULE_MAP))
+            objects.extend(entry_objects)
         return objects
 
     def parse_structured_fan_info(self, data):


### PR DESCRIPTION
##### SUMMARY
- Fixes #559 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_facts
