### PR TITLE
[telemetry] assorted fixes for destination and sensor groups

### DIFF
--- a/changelogs/fragments/telemetry.yaml
+++ b/changelogs/fragments/telemetry.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - "`nxos_telemetry` - Allow destination-group & sensor-group id to be strings."
+  - "`nxos_telemetry` - Allow sensor-group paths to be generated without additional properties."

--- a/docs/cisco.nxos.nxos_telemetry_module.rst
+++ b/docs/cisco.nxos.nxos_telemetry_module.rst
@@ -245,14 +245,14 @@ Parameters
                     <b>id</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">integer</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
                 </td>
                 <td>
                         <div>Destination group identifier.</div>
-                        <div>Value must be a int representing the destination group identifier.</div>
+                        <div>Value must be an integer or string representing the destination group identifier.</div>
                 </td>
             </tr>
 
@@ -303,14 +303,14 @@ Parameters
                     <b>id</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">integer</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
                 </td>
                 <td>
                         <div>Sensor group identifier.</div>
-                        <div>Value must be a int representing the sensor group identifier.</div>
+                        <div>Value must be a integer or a string representing the sensor group identifier.</div>
                 </td>
             </tr>
             <tr>
@@ -449,7 +449,7 @@ Parameters
                     <b>destination_group</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">integer</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
@@ -466,14 +466,14 @@ Parameters
                     <b>id</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">integer</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>
                 </td>
                 <td>
                         <div>Subscription identifier.</div>
-                        <div>Value must be a int representing the subscription identifier.</div>
+                        <div>Value must be an integer or string representing the subscription identifier.</div>
                 </td>
             </tr>
             <tr>
@@ -503,7 +503,7 @@ Parameters
                     <b>id</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">integer</span>
+                        <span style="color: purple">string</span>
                     </div>
                 </td>
                 <td>

--- a/plugins/module_utils/network/nxos/argspec/telemetry/telemetry.py
+++ b/plugins/module_utils/network/nxos/argspec/telemetry/telemetry.py
@@ -64,7 +64,7 @@ class TelemetryArgs(object):  # pylint: disable=R0903
                             },
                             "type": "dict",
                         },
-                        "id": {"type": "int"},
+                        "id": {"type": "str"},
                     },
                     "type": "list",
                     "elements": "raw",
@@ -75,7 +75,7 @@ class TelemetryArgs(object):  # pylint: disable=R0903
                             "choices": ["NX-API", "DME", "YANG"],
                             "type": "str",
                         },
-                        "id": {"type": "int"},
+                        "id": {"type": "str"},
                         "path": {
                             "options": {
                                 "depth": {"type": "str"},
@@ -91,11 +91,11 @@ class TelemetryArgs(object):  # pylint: disable=R0903
                 },
                 "subscriptions": {
                     "options": {
-                        "destination_group": {"type": "int"},
-                        "id": {"type": "int"},
+                        "destination_group": {"type": "str"},
+                        "id": {"type": "str"},
                         "sensor_group": {
                             "options": {
-                                "id": {"type": "int"},
+                                "id": {"type": "str"},
                                 "sample_interval": {"type": "int"},
                             },
                             "type": "dict",

--- a/plugins/module_utils/network/nxos/cmdref/telemetry/telemetry.py
+++ b/plugins/module_utils/network/nxos/cmdref/telemetry/telemetry.py
@@ -131,7 +131,7 @@ _template: # _template holds common settings for all commands
 destination_group:
   _exclude: ['N3K', 'N5K', 'N6k', 'N7k']
   multiple: true
-  kind: int
+  kind: str
   getval: dst-grp (\\S+)$
   setval: 'dst-grp {0}'
   default: ~

--- a/plugins/module_utils/network/nxos/nxos.py
+++ b/plugins/module_utils/network/nxos/nxos.py
@@ -1108,7 +1108,17 @@ class NxosCmdRef:
             # match up with the getval regex named group keys; e.g.
             #   getval: my-cmd (?P<foo>\d+) bar (?P<baz>\d+)
             #   setval: my-cmd {foo} bar {baz}
-            cmd = ref[k]["setval"].format(**playval)
+            if ref[k]["setval"].startswith("path"):
+                tmplt = "path {name}"
+                if "depth" in playval:
+                    tmplt += " depth {depth}"
+                if "query_condition" in playval:
+                    tmplt += " query-condition {query_condition}"
+                if "filter_condition" in playval:
+                    tmplt += " filter-condition {filter_condition}"
+                cmd = tmplt.format(**playval)
+            else:
+                cmd = ref[k]["setval"].format(**playval)
         elif "str" == kind:
             if "deleted" in playval:
                 if existing:

--- a/plugins/module_utils/network/nxos/nxos.py
+++ b/plugins/module_utils/network/nxos/nxos.py
@@ -1120,7 +1120,7 @@ class NxosCmdRef:
             else:
                 cmd = ref[k]["setval"].format(**playval)
         elif "str" == kind:
-            if "deleted" in playval:
+            if "deleted" in str(playval):
                 if existing:
                     cmd = "no " + ref[k]["setval"].format(existing)
             else:
@@ -1156,7 +1156,7 @@ class NxosCmdRef:
             if ref["_state"] in self.present_states:
                 if existing is None:
                     return False
-                elif playval == existing:
+                elif str(playval) == str(existing):
                     return True
                 elif isinstance(existing, dict) and playval in existing.values():
                     return True

--- a/plugins/module_utils/network/nxos/utils/telemetry/telemetry.py
+++ b/plugins/module_utils/network/nxos/utils/telemetry/telemetry.py
@@ -97,9 +97,9 @@ def get_instance_data(key, cr_key, cr, existing_key):
         instance = cr._ref[cr_key]["existing"][existing_key]
 
     patterns = {
-        "destination_groups": r"destination-group (\d+)",
-        "sensor_groups": r"sensor-group (\d+)",
-        "subscriptions": r"subscription (\d+)",
+        "destination_groups": r"destination-group (\S+)",
+        "sensor_groups": r"sensor-group (\S+)",
+        "subscriptions": r"subscription (\S+)",
     }
     if key in patterns.keys():
         m = re.search(patterns[key], cr._ref["_resource_key"])

--- a/plugins/modules/nxos_telemetry.py
+++ b/plugins/modules/nxos_telemetry.py
@@ -83,10 +83,10 @@ options:
         elements: raw
         suboptions:
           id:
-            type: int
+            type: str
             description:
             - Destination group identifier.
-            - Value must be a int representing the destination group identifier.
+            - Value must be an integer or string representing the destination group identifier.
           destination:
             type: dict
             description:
@@ -124,10 +124,10 @@ options:
         elements: raw
         suboptions:
           id:
-            type: int
+            type: str
             description:
             - Sensor group identifier.
-            - Value must be a int representing the sensor group identifier.
+            - Value must be a integer or a string representing the sensor group identifier.
           data_source:
             type: str
             description:
@@ -168,12 +168,12 @@ options:
         elements: raw
         suboptions:
           id:
-            type: int
+            type: str
             description:
             - Subscription identifier.
-            - Value must be a int representing the subscription identifier.
+            - Value must be an integer or string representing the subscription identifier.
           destination_group:
-            type: int
+            type: str
             description:
             - Associated destination group.
           sensor_group:
@@ -183,7 +183,7 @@ options:
             - Value must be a dict defining values for keys (id, sample_interval).
             suboptions:
               id:
-                type: int
+                type: str
                 description:
                 - Associated sensor group id.
               sample_interval:

--- a/tests/unit/modules/network/nxos/test_nxos_telemetry.py
+++ b/tests/unit/modules/network/nxos/test_nxos_telemetry.py
@@ -1800,6 +1800,122 @@ class TestNxosTelemetryModule(TestNxosModule):
         result = self.execute_module(changed=False)
         self.assertEqual(result["gathered"], gathered)
 
+    def test_tms_names(self):
+        # TMS input with strings
+        self.execute_show_command.return_value = ""
+        self.get_platform_shortname.return_value = "N9K"
+        set_module_args(
+            dict(
+                config=dict(
+                    destination_groups=[
+                        dict(
+                            id="collector",
+                            destination=dict(
+                                ip="192.168.1.100",
+                                port=50051,
+                                protocol="gRPC",
+                                encoding="GPB",
+                            )
+                        )
+                    ],
+                    sensor_groups=[
+                        dict(
+                            id="dme_bgp",
+                            data_source="DME",
+                            path=dict(
+                                name="sys/bd",
+                                depth="unbounded",
+                            ),
+                        )
+                    ],
+                    subscriptions=[
+                        dict(
+                            id="collector_sub",
+                            destination_group="collector",
+                            sensor_group=dict(
+                                id="dme_bgp",
+                                sample_interval=1000,
+                            )
+                        )
+                    ]
+                ),
+                state="merged",
+            ),
+            ignore_provider_arg
+        )
+        self.execute_module(
+            changed=True,
+            commands=[
+                'feature telemetry',
+                'telemetry',
+                'destination-group collector',
+                'ip address 192.168.1.100 port 50051 protocol grpc encoding gpb',
+                'sensor-group dme_bgp',
+                'data-source DME',
+                'path sys/bd depth unbounded',
+                'subscription collector_sub',
+                'dst-grp collector',
+                'snsr-grp dme_bgp sample-interval 1000',
+            ]
+        )
+
+    def test_tms_names_idempotent(self):
+        # TMS input with strings
+        self.execute_show_command.return_value = dedent(
+            """\
+            feature telemetry
+            telemetry
+              destination-group collector
+                ip address 192.168.1.100 port 50051 protocol grpc encoding gpb
+              sensor-group dme_bgp
+                data-source DME
+                path sys/bd depth unbounded
+              subscription collector_sub
+                dst-grp collector
+                snsr-grp dme_bgp sample-interval 1000
+            """)
+        self.get_platform_shortname.return_value = "N9K"
+        set_module_args(
+            dict(
+                config=dict(
+                    destination_groups=[
+                        dict(
+                            id="collector",
+                            destination=dict(
+                                ip="192.168.1.100",
+                                port=50051,
+                                protocol="gRPC",
+                                encoding="GPB",
+                            )
+                        )
+                    ],
+                    sensor_groups=[
+                        dict(
+                            id="dme_bgp",
+                            data_source="DME",
+                            path=dict(
+                                name="sys/bd",
+                                depth="unbounded",
+                            ),
+                        )
+                    ],
+                    subscriptions=[
+                        dict(
+                            id="collector_sub",
+                            destination_group="collector",
+                            sensor_group=dict(
+                                id="dme_bgp",
+                                sample_interval=1000,
+                            )
+                        )
+                    ]
+                ),
+                state="merged",
+            ),
+            ignore_provider_arg
+        )
+        self.execute_module(changed=False, commands=[])
+
 
 def build_args(data, type, state=None, check_mode=None):
     if state is None:

--- a/tests/unit/modules/network/nxos/test_nxos_telemetry.py
+++ b/tests/unit/modules/network/nxos/test_nxos_telemetry.py
@@ -1815,8 +1815,8 @@ class TestNxosTelemetryModule(TestNxosModule):
                                 port=50051,
                                 protocol="gRPC",
                                 encoding="GPB",
-                            )
-                        )
+                            ),
+                        ),
                     ],
                     sensor_groups=[
                         dict(
@@ -1826,7 +1826,7 @@ class TestNxosTelemetryModule(TestNxosModule):
                                 name="sys/bd",
                                 depth="unbounded",
                             ),
-                        )
+                        ),
                     ],
                     subscriptions=[
                         dict(
@@ -1835,28 +1835,28 @@ class TestNxosTelemetryModule(TestNxosModule):
                             sensor_group=dict(
                                 id="dme_bgp",
                                 sample_interval=1000,
-                            )
-                        )
-                    ]
+                            ),
+                        ),
+                    ],
                 ),
                 state="merged",
             ),
-            ignore_provider_arg
+            ignore_provider_arg,
         )
         self.execute_module(
             changed=True,
             commands=[
-                'feature telemetry',
-                'telemetry',
-                'destination-group collector',
-                'ip address 192.168.1.100 port 50051 protocol grpc encoding gpb',
-                'sensor-group dme_bgp',
-                'data-source DME',
-                'path sys/bd depth unbounded',
-                'subscription collector_sub',
-                'dst-grp collector',
-                'snsr-grp dme_bgp sample-interval 1000',
-            ]
+                "feature telemetry",
+                "telemetry",
+                "destination-group collector",
+                "ip address 192.168.1.100 port 50051 protocol grpc encoding gpb",
+                "sensor-group dme_bgp",
+                "data-source DME",
+                "path sys/bd depth unbounded",
+                "subscription collector_sub",
+                "dst-grp collector",
+                "snsr-grp dme_bgp sample-interval 1000",
+            ],
         )
 
     def test_tms_names_idempotent(self):
@@ -1873,7 +1873,8 @@ class TestNxosTelemetryModule(TestNxosModule):
               subscription collector_sub
                 dst-grp collector
                 snsr-grp dme_bgp sample-interval 1000
-            """)
+            """,
+        )
         self.get_platform_shortname.return_value = "N9K"
         set_module_args(
             dict(
@@ -1886,8 +1887,8 @@ class TestNxosTelemetryModule(TestNxosModule):
                                 port=50051,
                                 protocol="gRPC",
                                 encoding="GPB",
-                            )
-                        )
+                            ),
+                        ),
                     ],
                     sensor_groups=[
                         dict(
@@ -1897,7 +1898,7 @@ class TestNxosTelemetryModule(TestNxosModule):
                                 name="sys/bd",
                                 depth="unbounded",
                             ),
-                        )
+                        ),
                     ],
                     subscriptions=[
                         dict(
@@ -1906,13 +1907,13 @@ class TestNxosTelemetryModule(TestNxosModule):
                             sensor_group=dict(
                                 id="dme_bgp",
                                 sample_interval=1000,
-                            )
-                        )
-                    ]
+                            ),
+                        ),
+                    ],
                 ),
                 state="merged",
             ),
-            ignore_provider_arg
+            ignore_provider_arg,
         )
         self.execute_module(changed=False, commands=[])
 


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Allow destination-group & sensor-group id to be strings.
- Allow sensor-group paths to be generated without additional properties.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_telemetry.py