### PR TITLE
added codecov via gha

### DIFF
--- a/.github/workflows/covflow.yml
+++ b/.github/workflows/covflow.yml
@@ -1,0 +1,75 @@
+name: CodeCoverage, dependencies from source
+on:
+  workflow_call:
+    inputs:
+      collection_pre_install:
+        required: true
+        type: string
+jobs:
+  codecoverage:
+    env:
+      PY_COLORS: "1"
+      source_directory: "./source"
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        ansible-version:
+          - Latest
+        python-version:
+          - "3.10"
+    runs-on: ${{ matrix.os }}
+
+    name: "Code Coverage ${{ matrix.python-version }} / ${{ matrix.os }} / ${{ matrix.ansible-version }}"
+    steps:
+      - name: Checkout the collection repository
+        uses: actions/checkout@v3
+        with:
+          path: ${{ env.source_directory }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: "0"
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install ansible-core (${{ matrix.ansible-version }})
+        run: python3 -m pip install ansible-core
+
+      - name: Read collection metadata from galaxy.yml
+        id: identify
+        uses: ansible-network/github_actions/.github/actions/identify_collection@main
+        with:
+          source_path: ${{ env.source_directory }}
+
+      - name: Pre install collections dependencies first so the collection install does not
+        run: ansible-galaxy collection install ${{ inputs.collection_pre_install }} -p /home/runner/collections
+        if: inputs.collection_pre_install != ''
+
+      - name: Build and install the collection
+        uses: ansible-network/github_actions/.github/actions/build_install_collection@main
+        with:
+          install_python_dependencies: true
+          source_path: ${{ env.source_directory }}
+          collection_path: ${{ steps.identify.outputs.collection_path }}
+          tar_file: ${{ steps.identify.outputs.tar_file }}
+
+      - name: Print the ansible version
+        run: ansible --version
+
+      - name: Print the python dependencies
+        run: python3 -m pip list
+
+      - name: Run Coverage tests
+        run: |
+          ansible-test units --python ${{ matrix.python-version }} --coverage --requirements
+          ansible-test coverage xml
+        working-directory: ${{ steps.identify.outputs.collection_path }}
+
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          directory: ${{ steps.identify.outputs.collection_path }}
+          fail_ci_if_error: true

--- a/.github/workflows/runcov.yml
+++ b/.github/workflows/runcov.yml
@@ -1,0 +1,15 @@
+name: run-cov
+
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  #codecoverage
+  codecov:
+    uses: ./.github/workflows/covflow.yml
+    with:
+      collection_pre_install: >-
+        git+https://github.com/ansible-collections/ansible.utils.git
+        git+https://github.com/ansible-collections/ansible.netcommon.git

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 # Cisco NX-OS Collection
 [![CI](https://zuul-ci.org/gated.svg)](https://dashboard.zuul.ansible.com/t/ansible/project/github.com/ansible-collections/cisco.nxos) <!--[![Codecov](https://img.shields.io/codecov/c/github/ansible-collections/vyos)](https://codecov.io/gh/ansible-collections/cisco.nxos)-->
+[![Codecov](https://codecov.io/gh/ansible-collections/cisco.nxos/branch/main/graph/badge.svg)](https://codecov.io/gh/ansible-collections/cisco.nxos)
 
 The Ansible Cisco NX-OS collection includes a variety of Ansible content to help automate the management of Cisco NX-OS network appliances.
 

--- a/changelogs/fragments/ci_codecov.yml
+++ b/changelogs/fragments/ci_codecov.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - added codecov to the CI pipeline

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+---
+codecov:
+  require_ci_to_pass: true
+comment: false
+coverage:
+  status:
+    patch: false
+    project:
+      default:
+        threshold: 0.3%


### PR DESCRIPTION
##### SUMMARY
Added Code Coverage to the repo.

Tool used : codecov

Threshold value being set in `codecov.yml` file in the root directory. The target being current coverage value and the threshold being 0.5% ( which means we have 0.5% wiggle room with the coverage ).

##### ISSUE TYPE
- Test Code Cov

##### COMPONENT NAME
- `.github/workflows/codecoverage.yml`
- `.github/workflows/test.yml`
- `codecov.yml`
- `readme.md`

##### CHECKLIST
- [x] Add code coverage to CI with GHA
- [x] Fail CI on PR code coverage if less than a benchmark
- [x] Add/ Enable badge in Readme to show test coverage