### PR TITLE
[nxos_user] add hashed_password option

### DIFF
--- a/plugins/modules/nxos_user.py
+++ b/plugins/modules/nxos_user.py
@@ -57,6 +57,11 @@ options:
         - The password to be configured on the network device. The password needs to be
           provided in cleartext and it will be encrypted on the device.
         type: str
+      hashed_password:
+        description:
+        - The hashed password to be configured on the network device. The password needs to 
+          already be encrypted.
+        type: str
       update_password:
         description:
         - Since passwords are encrypted in the device running config, this argument will
@@ -100,6 +105,11 @@ options:
     description:
     - The password to be configured on the network device. The password needs to be
       provided in cleartext and it will be encrypted on the device.
+    type: str
+  hashed_password:
+    description:
+    - The hashed password to be configured on the network device. The password needs to 
+      already be encrypted.
     type: str
   update_password:
     description:
@@ -278,6 +288,10 @@ def map_obj_to_commands(updates, module):
             if update_password == "always" or not have:
                 add("password %s" % want["configured_password"])
 
+        if needs_update("hashed_password"):
+            if update_password == "always" or not have:
+                add("password 5 %s" % want["hashed_password"])
+
         if needs_update("sshkey"):
             add("sshkey %s" % want["sshkey"])
 
@@ -315,6 +329,7 @@ def map_config_to_obj(module):
             {
                 "name": item["usr_name"],
                 "configured_password": parse_password(item),
+                "hashed_password": parse_password(item),
                 "sshkey": item.get("sshkey_info"),
                 "roles": parse_roles(item),
                 "state": "present",
@@ -364,6 +379,7 @@ def map_params_to_obj(module):
         item.update(
             {
                 "configured_password": get_value("configured_password"),
+                "hashed_password": get_value("hashed_password"),
                 "sshkey": get_value("sshkey"),
                 "roles": get_value("roles"),
                 "state": get_value("state"),
@@ -400,6 +416,7 @@ def main():
     element_spec = dict(
         name=dict(),
         configured_password=dict(no_log=True),
+        hashed_password=dict(no_log=True),
         update_password=dict(default="always", choices=["on_create", "always"]),
         roles=dict(type="list", aliases=["role"], elements="str"),
         sshkey=dict(no_log=False),
@@ -423,7 +440,7 @@ def main():
 
     argument_spec.update(element_spec)
 
-    mutually_exclusive = [("name", "aggregate")]
+    mutually_exclusive = [("name", "aggregate"),("configured_password", "hashed_password")]
 
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -452,6 +469,13 @@ def main():
     # a nice failure message
     if "no username admin" in commands:
         module.fail_json(msg="cannot delete the `admin` account")
+
+    # check if provided hashed password is infact a hash
+    if 'hashed_password' in module.params:
+        if not re.match(r"^\$5\$......\$.*$", module.params['hashed_password']):
+            module.fail_json(msg="Provided hash is not valid")
+            
+        
 
     if commands:
         if not module.check_mode:


### PR DESCRIPTION
##### SUMMARY
Adds a 'hashed_password' argument to nxos_user to allow user to provide an already hashed password.
 
Closes:
#370 

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
nxos_user

##### ADDITIONAL INFORMATION
Used the same "hashed_password" key name for continuity from cisco.ios collection. However I chose to KISS and make it a string rather than a dict containing 'type' and 'value', as NX-OS does not have multiple encryption algorithms to chose from unlike IOS.
'hashed_password' and 'configured_password' set as mutually exclusive.
Tests provided value with a quick regex to try and validate a hashed password has been provided.

Tested on Nexus 9300v
NXOS: version 10.1(1)