### PR TITLE
Add to_text for vrf names

### DIFF
--- a/plugins/module_utils/network/nxos/facts/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/nxos/facts/bgp_global/bgp_global.py
@@ -15,6 +15,7 @@ for a given resource, parsed, and the facts tree is populated
 based on the configuration.
 """
 
+from ansible.module_utils._text import to_text
 from ansible.module_utils.six import iteritems
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils
 
@@ -71,7 +72,7 @@ class Bgp_globalFacts(object):
 
         # transform vrfs into a list
         if vrfs:
-            obj["vrfs"] = sorted(list(obj["vrfs"].values()), key=lambda k, sk="vrf": k[sk])
+            obj["vrfs"] = sorted(list(obj["vrfs"].values()), key=lambda k, to_text(sk="vrf": k[sk]))
             for vrf in obj["vrfs"]:
                 self._post_parse(vrf)
 

--- a/plugins/module_utils/network/nxos/facts/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/nxos/facts/bgp_global/bgp_global.py
@@ -72,7 +72,7 @@ class Bgp_globalFacts(object):
 
         # transform vrfs into a list
         if vrfs:
-            obj["vrfs"] = sorted(list(obj["vrfs"].values()), key=lambda k, to_text(sk="vrf": k[sk]))
+            obj["vrfs"] = sorted(list(obj["vrfs"].values()), key=lambda k, sk="vrf": to_text(k[sk]))
             for vrf in obj["vrfs"]:
                 self._post_parse(vrf)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cisco.nxos.nxos_bgp_global
##### ADDITIONAL INFORMATION
The cisco.nxos.nxos_bgp_global suffers the same edge case as was fixed in snmp last year. If there are mixed vrf names some having all digits and some having letters the same error occurs in sorted() when it tries to compare int to string.
This is the same code change as was done in snmp_server.

This proposed change may cause some issue for anyone using purely numeric vrf names as "9" will now sort after "10" and the section will be re-ordered.
