### PR TITLE
[file_copy] timeout calculation fixes

### DIFF
--- a/changelogs/fragments/file_copy.yaml
+++ b/changelogs/fragments/file_copy.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "nxos_file_copy - fix setting file_pull_timeout/persistent_command_timeout value."

--- a/plugins/action/nxos.py
+++ b/plugins/action/nxos.py
@@ -58,7 +58,7 @@ class ActionModule(ActionNetworkModule):
                 return {
                     "failed": True,
                     "msg": (
-                        f"Connection type must be fully qualified name for"
+                        f"Connection type must be fully qualified name for "
                         f"network_cli connection type, got {self._play_context.connection}"
                     )
                     % self._play_context.connection,


### PR DESCRIPTION
##### SUMMARY
 - The file_pull_timeout was overriding command_timeout always, even in cases where it's not supposed to.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_file_copy.py
