### PR TITLE
[interfaces] correctly enable interfaces on N3K

### DIFF
--- a/changelogs/fragments/fix_749.yaml
+++ b/changelogs/fragments/fix_749.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "nxos_interfaces - Correctly enable L3 interfaces on supported N3K platforms (https://github.com/ansible-collections/cisco.nxos/issues/749)."

--- a/plugins/module_utils/network/nxos/config/interfaces/interfaces.py
+++ b/plugins/module_utils/network/nxos/config/interfaces/interfaces.py
@@ -470,13 +470,13 @@ class Interfaces(ConfigBase):
         and enabled/shutdown states. The default values for user-defined-default
         configurations may be different for legacy platforms.
         Notes:
-        - L3 enabled default state is False on N9K,N7K but True for N3K,N6K
+        - L3 enabled default state is False on N9K,N7K,N3K but True for N5K,N6K
         - Changing L2-L3 modes may change the default enabled value.
         - '(no) system default switchport shutdown' only applies to L2 interfaces.
         Run through the gathered interfaces and tag their default enabled state.
         """
         intf_defs = {}
-        L3_enabled = True if re.search("N[356]K", self.get_platform()) else False
+        L3_enabled = True if re.search("N[56]K", self.get_platform()) else False
         intf_defs = {
             "sysdefs": {
                 "mode": None,

--- a/tests/unit/modules/network/nxos/test_nxos_interfaces.py
+++ b/tests/unit/modules/network/nxos/test_nxos_interfaces.py
@@ -84,7 +84,7 @@ class TestNxosInterfacesModule(TestNxosModule):
         self.edit_config.return_value = None
         if device == "legacy":
             # call execute_module() with device='legacy' to use this codepath
-            self.get_platform.return_value = "N3K-Cxxx"
+            self.get_platform.return_value = "N5K-Cxxx"
         else:
             self.get_platform.return_value = "N9K-Cxxx"
 


### PR DESCRIPTION
##### SUMMARY
- Fixes #749
- Supported N3K versions have L3 shutdown by default.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_interfaces.py