### PR TITLE
Add support for cli_restore functionality provided with in netcommon …

### DIFF
--- a/changelogs/add_restore_support.yaml
+++ b/changelogs/add_restore_support.yaml
@@ -1,0 +1,4 @@
+major_changes:
+  - Add support for cli_restore functionality.
+  - cli_restore module is part of netcommon.
+  - Please refer the PR to know more about core changes (https://github.com/ansible-collections/ansible.netcommon/pull/618).

--- a/changelogs/add_restore_support.yaml
+++ b/changelogs/add_restore_support.yaml
@@ -1,4 +1,6 @@
-major_changes:
+minor_changes:
+  - Update the netcommon base version 6.1.0 to support cli_restore plugin.
+minor_changes:
   - Add support for cli_restore functionality.
   - cli_restore module is part of netcommon.
   - Please refer the PR to know more about core changes (https://github.com/ansible-collections/ansible.netcommon/pull/618).

--- a/changelogs/add_restore_support.yaml
+++ b/changelogs/add_restore_support.yaml
@@ -1,4 +1,4 @@
-minor_changes:
+major_changes:
   - Update the netcommon base version 6.1.0 to support cli_restore plugin.
 minor_changes:
   - Add support for cli_restore functionality.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 authors:
   - Ansible Network Community (ansible-network)
 dependencies:
-  "ansible.netcommon": ">=6.0.0"
+  "ansible.netcommon": ">=6.1.0"
 license_file: LICENSE
 name: nxos
 namespace: cisco
@@ -10,4 +10,4 @@ readme: README.md
 repository: https://github.com/ansible-collections/cisco.nxos
 issues: https://github.com/ansible-collections/cisco.nxos/issues
 tags: [cisco, nxos, networking, nxapi, netconf]
-version: 7.0.0
+version: 8.0.0

--- a/plugins/cliconf/nxos.py
+++ b/plugins/cliconf/nxos.py
@@ -134,6 +134,13 @@ class Cliconf(CliconfBase):
 
         return self._device_info
 
+    def restore(self, filename=None, path=""):
+        if not filename:
+            raise ValueError("'file_name' value is required for restore")
+        cmd = f"configure replace {path}{filename} best-effort"
+        return self.send_command(cmd)
+
+
     def get_diff(
         self,
         candidate=None,

--- a/plugins/cliconf/nxos.py
+++ b/plugins/cliconf/nxos.py
@@ -140,7 +140,6 @@ class Cliconf(CliconfBase):
         cmd = f"configure replace {path}{filename} best-effort"
         return self.send_command(cmd)
 
-
     def get_diff(
         self,
         candidate=None,


### PR DESCRIPTION
…module

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Depends-On: https://github.com/ansible-collections/ansible.netcommon/pull/618

Add support for cli_restore functionality.
cli_restore module is part of netcommon.
Please refer the PR to know more about core changes (https://github.com/ansible-collections/ansible.netcommon/pull/618).
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
