### PR TITLE
[route_maps] Enable handling of route-maps without set/match

### DIFF
--- a/changelogs/fragments/route_maps.yaml
+++ b/changelogs/fragments/route_maps.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "route_maps - support simple route-maps that do not contain set or match statements. it allows for the creation and management of purely basic route-map entries like 'route-map test-1 permit 10'."

--- a/changelogs/fragments/route_maps.yaml
+++ b/changelogs/fragments/route_maps.yaml
@@ -1,3 +1,4 @@
 ---
 minor_changes:
-  - "route_maps - support simple route-maps that do not contain set or match statements. it allows for the creation and management of purely basic route-map entries like 'route-map test-1 permit 10'."
+  - "route_maps - support simple route-maps that do not contain set or match statements.
+    it allows for the creation and management of purely basic route-map entries like 'route-map test-1 permit 10'."

--- a/plugins/module_utils/network/nxos/config/route_maps/route_maps.py
+++ b/plugins/module_utils/network/nxos/config/route_maps/route_maps.py
@@ -47,6 +47,7 @@ class Route_maps(ResourceModule):
             tmplt=Route_mapsTemplate(),
         )
         self.linear_parsers = [
+            "route_map",
             "description",
             "continue_sequence",
             "set.as_path.prepend.last_as",

--- a/tests/unit/modules/network/nxos/test_nxos_route_maps.py
+++ b/tests/unit/modules/network/nxos/test_nxos_route_maps.py
@@ -1493,3 +1493,92 @@ class TestNxosRouteMapsModule(TestNxosModule):
         ]
         result = self.execute_module(changed=True)
         self.assertEqual(set(result["commands"]), set(commands))
+
+    def test_nxos_route_maps_without_match_and_set_merged(self):
+        self.get_config.return_value = dedent(
+            """\
+            route-map test-1 permit 10
+            """
+        )
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        route_map="test-1",
+                        entries=[
+                            dict(
+                                action="permit",
+                                sequence=20,
+                            ),
+                        ],
+                    ),
+                ],
+                state="merged",
+            )
+        )
+        commands = [
+            "route-map test-1 permit 20",
+        ]
+        result = self.execute_module(changed=True)
+        self.assertEqual(set(result["commands"]), set(commands))
+
+    def test_nxos_route_maps_without_match_and_set_overridden(self):
+        self.get_config.return_value = dedent(
+            """\
+            route-map test-1 permit 10
+            """
+        )
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        route_map="test-2",
+                        entries=[
+                            dict(
+                                action="permit",
+                                sequence=10,
+                            ),
+                        ],
+                    ),
+                ],
+                state="overridden",
+            )
+        )
+        commands = [
+            "no route-map test-1 permit 10",
+            "route-map test-2 permit 10",
+        ]
+        result = self.execute_module(changed=True)
+        self.assertEqual(set(result["commands"]), set(commands))
+
+    def test_nxos_route_maps_without_match_and_set_replaced(self):
+        self.get_config.return_value = dedent(
+            """\
+            route-map test-1 permit 10
+            route-map test-1 permit 20
+            route-map test-2 permit 10
+            """
+        )
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        route_map="test-1",
+                        entries=[
+                            dict(
+                                action="permit",
+                                sequence=30,
+                            ),
+                        ],
+                    ),
+                ],
+                state="replaced",
+            )
+        )
+        commands = [
+            "no route-map test-1 permit 10",
+            "no route-map test-1 permit 20",
+            "route-map test-1 permit 30",
+        ]
+        result = self.execute_module(changed=True)
+        self.assertEqual(set(result["commands"]), set(commands))

--- a/tests/unit/modules/network/nxos/test_nxos_route_maps.py
+++ b/tests/unit/modules/network/nxos/test_nxos_route_maps.py
@@ -1498,7 +1498,7 @@ class TestNxosRouteMapsModule(TestNxosModule):
         self.get_config.return_value = dedent(
             """\
             route-map test-1 permit 10
-            """
+            """,
         )
         set_module_args(
             dict(
@@ -1514,7 +1514,7 @@ class TestNxosRouteMapsModule(TestNxosModule):
                     ),
                 ],
                 state="merged",
-            )
+            ),
         )
         commands = [
             "route-map test-1 permit 20",
@@ -1526,7 +1526,7 @@ class TestNxosRouteMapsModule(TestNxosModule):
         self.get_config.return_value = dedent(
             """\
             route-map test-1 permit 10
-            """
+            """,
         )
         set_module_args(
             dict(
@@ -1542,7 +1542,7 @@ class TestNxosRouteMapsModule(TestNxosModule):
                     ),
                 ],
                 state="overridden",
-            )
+            ),
         )
         commands = [
             "no route-map test-1 permit 10",
@@ -1557,7 +1557,7 @@ class TestNxosRouteMapsModule(TestNxosModule):
             route-map test-1 permit 10
             route-map test-1 permit 20
             route-map test-2 permit 10
-            """
+            """,
         )
         set_module_args(
             dict(
@@ -1573,7 +1573,7 @@ class TestNxosRouteMapsModule(TestNxosModule):
                     ),
                 ],
                 state="replaced",
-            )
+            ),
         )
         commands = [
             "no route-map test-1 permit 10",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This commit introduces the ability to handle simple route-maps that do not contain set or match statements.

It allows for the creation and management of purely basic route-map entries like 'route-map test-1 permit 10'.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cisco.nxos.nxos_route_maps

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
cisco.nxos.nxos_route_maps module cannot handle following task which does not have a set, a match and a description section for now.

See also unit tests.
```
- name: Sample Task
  cisco.nxos.nxos_route_maps:
    config:
      - route_map: rmap1
        entries:
          - sequence: 10
            action: permit
    state: merged
```
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Paste verbatim command output below, e.g. before and after your change -->

###### pytest result after editing source code.

```
% pytest tests/unit/modules/network/nxos/test_nxos_route_maps.py 
========================================================== test session starts ==========================================================
platform darwin -- Python 3.10.14, pytest-8.1.1, pluggy-1.4.0
ansible: 2.16.5
rootdir: /Users/me/Documents/programming/PycharmProjects/cisco.nxos
configfile: pyproject.toml
plugins: ansible-24.1.2, xdist-3.5.0
collected 21 items                                                                                                                      

tests/unit/modules/network/nxos/test_nxos_route_maps.py .....................                                                     [100%]

========================================================== 21 passed in 0.82s ===========================================================
```

###### pytest result when just adding tests and without editing source code.
```
% pytest tests/unit/modules/network/nxos/test_nxos_route_maps.py
========================================================== test session starts ==========================================================
platform darwin -- Python 3.10.14, pytest-8.1.1, pluggy-1.4.0
ansible: 2.16.5
rootdir: /Users/me/Documents/programming/PycharmProjects/cisco.nxos
configfile: pyproject.toml
plugins: ansible-24.1.2, xdist-3.5.0
collected 21 items                                                                                                                      

tests/unit/modules/network/nxos/test_nxos_route_maps.py ..................FFF                                                     [100%]

=============================================================== FAILURES ================================================================
_______________________________ TestNxosRouteMapsModule.test_nxos_route_maps_without_match_and_set_merged _______________________________

self = <tests.unit.modules.network.nxos.test_nxos_route_maps.TestNxosRouteMapsModule testMethod=test_nxos_route_maps_without_match_and_set_merged>

    def test_nxos_route_maps_without_match_and_set_merged(self):
        self.get_config.return_value = dedent(
            """\
            route-map test-1 permit 10
            """
        )
        set_module_args(
            dict(
                config=[
                    dict(
                        route_map="test-1",
                        entries=[
                            dict(
                                action="permit",
                                sequence=20,
                            ),
                        ],
                    ),
                ],
                state="merged",
            )
        )
        commands = [
            "route-map test-1 permit 20",
        ]
>       result = self.execute_module(changed=True)

tests/unit/modules/network/nxos/test_nxos_route_maps.py:1522: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/unit/modules/network/nxos/nxos_module.py:98: in execute_module
    result = self.changed(changed)
tests/unit/modules/network/nxos/nxos_module.py:124: in changed
    self.assertEqual(result["changed"], changed, result)
E   AssertionError: False != True : {'warnings': [], 'commands': [], 'before': [{'route_map': 'test-1', 'entries': [{'sequence': 10, 'action': 'permit'}]}], 'changed': False}
_____________________________ TestNxosRouteMapsModule.test_nxos_route_maps_without_match_and_set_overridden _____________________________

self = <tests.unit.modules.network.nxos.test_nxos_route_maps.TestNxosRouteMapsModule testMethod=test_nxos_route_maps_without_match_and_set_overridden>

    def test_nxos_route_maps_without_match_and_set_overridden(self):
        self.get_config.return_value = dedent(
            """\
            route-map test-1 permit 10
            """
        )
        set_module_args(
            dict(
                config=[
                    dict(
                        route_map="test-2",
                        entries=[
                            dict(
                                action="permit",
                                sequence=10,
                            ),
                        ],
                    ),
                ],
                state="overridden",
            )
        )
        commands = [
            "no route-map test-1 permit 10",
            "route-map test-2 permit 10",
        ]
        result = self.execute_module(changed=True)
>       self.assertEqual(set(result["commands"]), set(commands))
E       AssertionError: Items in the second set but not the first:
E       'route-map test-2 permit 10'

tests/unit/modules/network/nxos/test_nxos_route_maps.py:1552: AssertionError
______________________________ TestNxosRouteMapsModule.test_nxos_route_maps_without_match_and_set_replaced ______________________________

self = <tests.unit.modules.network.nxos.test_nxos_route_maps.TestNxosRouteMapsModule testMethod=test_nxos_route_maps_without_match_and_set_replaced>

    def test_nxos_route_maps_without_match_and_set_replaced(self):
        self.get_config.return_value = dedent(
            """\
            route-map test-1 permit 10
            route-map test-1 permit 20
            route-map test-2 permit 10
            """
        )
        set_module_args(
            dict(
                config=[
                    dict(
                        route_map="test-1",
                        entries=[
                            dict(
                                action="permit",
                                sequence=30,
                            ),
                        ],
                    ),
                ],
                state="replaced",
            )
        )
        commands = [
            "no route-map test-1 permit 10",
            "no route-map test-1 permit 20",
            "route-map test-1 permit 30",
        ]
        result = self.execute_module(changed=True)
>       self.assertEqual(set(result["commands"]), set(commands))
E       AssertionError: Items in the second set but not the first:
E       'route-map test-1 permit 30'

tests/unit/modules/network/nxos/test_nxos_route_maps.py:1584: AssertionError
======================================================== short test summary info ========================================================
FAILED tests/unit/modules/network/nxos/test_nxos_route_maps.py::TestNxosRouteMapsModule::test_nxos_route_maps_without_match_and_set_merged - AssertionError: False != True : {'warnings': [], 'commands': [], 'before': [{'route_map': 'test-1', 'entries': [{'sequence': 10, 'ac...
FAILED tests/unit/modules/network/nxos/test_nxos_route_maps.py::TestNxosRouteMapsModule::test_nxos_route_maps_without_match_and_set_overridden - AssertionError: Items in the second set but not the first:
FAILED tests/unit/modules/network/nxos/test_nxos_route_maps.py::TestNxosRouteMapsModule::test_nxos_route_maps_without_match_and_set_replaced - AssertionError: Items in the second set but not the first:
===================================================== 3 failed, 18 passed in 0.86s ======================================================
```

