### PR TITLE
[static_routes] correctly generate commands when track param is specified

### DIFF
--- a/changelogs/fragments/ana_442.yaml
+++ b/changelogs/fragments/ana_442.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "nxos_static_routes - correctly generate command when track parameter is specified."

--- a/plugins/module_utils/network/nxos/facts/static_routes/static_routes.py
+++ b/plugins/module_utils/network/nxos/facts/static_routes/static_routes.py
@@ -10,6 +10,7 @@ It is in this file the configuration is collected from the device
 for a given resource, parsed, and the facts tree is populated
 based on the configuration.
 """
+
 from __future__ import absolute_import, division, print_function
 
 
@@ -28,7 +29,7 @@ from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.rm_templat
 class Static_routesFacts(object):
     """The nxos static_routes fact class"""
 
-    def __init__(self, module, subspec="config", options="options"):
+    def __init__(self, module):
         self._module = module
         self.argument_spec = Static_routesArgs.argument_spec
 
@@ -84,9 +85,13 @@ class Static_routesFacts(object):
             _triv_static_route = {"address_families": []}
 
             if afi_v4:
-                _triv_static_route["address_families"].append({"afi": "ipv4", "routes": afi_v4})
+                _triv_static_route["address_families"].append(
+                    {"afi": "ipv4", "routes": afi_v4},
+                )
             if afi_v6:
-                _triv_static_route["address_families"].append({"afi": "ipv6", "routes": afi_v6})
+                _triv_static_route["address_families"].append(
+                    {"afi": "ipv6", "routes": afi_v6},
+                )
 
             _static_route_facts.append(_triv_static_route)
 
@@ -100,9 +105,13 @@ class Static_routesFacts(object):
             }
 
             if afi_v4:
-                _vrf_static_route["address_families"].append({"afi": "ipv4", "routes": afi_v4})
+                _vrf_static_route["address_families"].append(
+                    {"afi": "ipv4", "routes": afi_v4},
+                )
             if afi_v6:
-                _vrf_static_route["address_families"].append({"afi": "ipv6", "routes": afi_v6})
+                _vrf_static_route["address_families"].append(
+                    {"afi": "ipv6", "routes": afi_v6},
+                )
 
             _static_route_facts.append(_vrf_static_route)
         return _static_route_facts
@@ -125,7 +134,10 @@ class Static_routesFacts(object):
             data = self.get_static_routes_data(connection)
 
         # parse native config using the Static_routes template
-        static_routes_parser = Static_routesTemplate(lines=data.splitlines(), module=self._module)
+        static_routes_parser = Static_routesTemplate(
+            lines=data.splitlines(),
+            module=self._module,
+        )
         objs = static_routes_parser.parse()
 
         strout = self.process_static_routes(objs)
@@ -134,7 +146,11 @@ class Static_routesFacts(object):
         ansible_facts["ansible_network_resources"].pop("static_routes", None)
 
         params = utils.remove_empties(
-            static_routes_parser.validate_config(self.argument_spec, {"config": objs}, redact=True),
+            static_routes_parser.validate_config(
+                self.argument_spec,
+                {"config": objs},
+                redact=True,
+            ),
         )
 
         facts["static_routes"] = params.get("config")

--- a/plugins/module_utils/network/nxos/rm_templates/static_routes.py
+++ b/plugins/module_utils/network/nxos/rm_templates/static_routes.py
@@ -24,7 +24,11 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.r
 
 class Static_routesTemplate(NetworkTemplate):
     def __init__(self, lines=None, module=None):
-        super(Static_routesTemplate, self).__init__(lines=lines, tmplt=self, module=module)
+        super(Static_routesTemplate, self).__init__(
+            lines=lines,
+            tmplt=self,
+            module=module,
+        )
 
     # fmt: off
     PARSERS = [
@@ -49,9 +53,9 @@ class Static_routesTemplate(NetworkTemplate):
                 (\s(?P<interface>(Ethernet|loopback|mgmt|Null|port-channel)\S+))?
                 (\s(?P<forward_router_address>\S+))?
                 (\svrf\s(?P<dest_vrf>\S+))?
+                (\strack\s(?P<track>\d+))?
                 (\sname\s(?P<route_name>\S+))?
                 (\stag\s(?P<tag>\d+))?
-                (\strack\s(?P<track>\d+))?
                 (\s(?P<admin_distance>\d+))?
                 $""", re.VERBOSE,
             ),
@@ -60,9 +64,9 @@ class Static_routesTemplate(NetworkTemplate):
             "{{ (' ' + ipv4.interface) if ipv4.interface is defined else '' }}"
             "{{ (' ' + ipv4.forward_router_address) if ipv4.forward_router_address is defined else '' }}"
             "{{ (' vrf ' + ipv4.dest_vrf) if ipv4.dest_vrf is defined else '' }}"
+            "{{ (' track ' + ipv4.track|string) if ipv4.track is defined else '' }}"
             "{{ (' name ' + ipv4.route_name) if ipv4.route_name is defined else '' }}"
             "{{ (' tag ' + ipv4.tag|string) if ipv4.tag is defined else '' }}"
-            "{{ (' track ' + ipv4.track|string) if ipv4.track is defined else '' }}"
             "{{ (' ' + ipv4.admin_distance|string) if ipv4.admin_distance is defined else '' }}",
             "result": {
                 "{{ dest }}_{{ namevrf|d() }}_ipv4": [
@@ -90,9 +94,9 @@ class Static_routesTemplate(NetworkTemplate):
                 (\s(?P<interface>(Ethernet|loopback|mgmt|Null|port-channel)\S+))?
                 (\s(?P<forward_router_address>\S+))?
                 (\svrf\s(?P<dest_vrf>\S+))?
+                (\strack\s(?P<track>\d+))?
                 (\sname\s(?P<route_name>\S+))?
                 (\stag\s(?P<tag>\d+))?
-                (\strack\s(?P<track>\d+))?
                 (\s(?P<admin_distance>\d+))?
                 $""", re.VERBOSE,
             ),
@@ -101,9 +105,9 @@ class Static_routesTemplate(NetworkTemplate):
             "{{ (' ' + ipv6.interface) if ipv6.interface is defined else '' }}"
             "{{ (' ' + ipv6.forward_router_address) if ipv6.forward_router_address is defined else '' }}"
             "{{ (' vrf ' + ipv6.dest_vrf) if ipv6.dest_vrf is defined else '' }}"
+            "{{ (' track ' + ipv6.track|string) if ipv6.track is defined else '' }}"
             "{{ (' name ' + ipv6.route_name) if ipv6.route_name is defined else '' }}"
             "{{ (' tag ' + ipv6.tag|string) if ipv6.tag is defined else '' }}"
-            "{{ (' track ' + ipv6.track|string) if ipv6.track is defined else '' }}"
             "{{ (' ' + ipv6.admin_distance|string) if ipv6.admin_distance is defined else '' }}",
             "result": {
                 "{{ dest }}_{{ namevrf|d() }}_ipv6": [

--- a/tests/unit/modules/network/nxos/test_nxos_static_routes.py
+++ b/tests/unit/modules/network/nxos/test_nxos_static_routes.py
@@ -90,7 +90,9 @@ class TestNxosStaticRoutesModule(TestNxosModule):
                                 "dest": "192.0.2.16/28",
                             },
                             {
-                                "next_hops": [{"forward_router_address": "192.0.2.26", "tag": 12}],
+                                "next_hops": [
+                                    {"forward_router_address": "192.0.2.26", "tag": 12},
+                                ],
                                 "dest": "192.0.2.80/28",
                             },
                         ],
@@ -124,7 +126,9 @@ class TestNxosStaticRoutesModule(TestNxosModule):
                         "afi": "ipv4",
                         "routes": [
                             {
-                                "next_hops": [{"forward_router_address": "192.168.255.1"}],
+                                "next_hops": [
+                                    {"forward_router_address": "192.168.255.1"},
+                                ],
                                 "dest": "0.0.0.0/0",
                             },
                         ],
@@ -268,7 +272,10 @@ class TestNxosStaticRoutesModule(TestNxosModule):
                                     },
                                     {
                                         "next_hops": [
-                                            {"forward_router_address": "192.0.2.26", "tag": 12},
+                                            {
+                                                "forward_router_address": "192.0.2.26",
+                                                "tag": 12,
+                                            },
                                         ],
                                         "dest": "192.0.2.80/28",
                                     },
@@ -303,7 +310,9 @@ class TestNxosStaticRoutesModule(TestNxosModule):
                                 "afi": "ipv4",
                                 "routes": [
                                     {
-                                        "next_hops": [{"forward_router_address": "192.168.255.1"}],
+                                        "next_hops": [
+                                            {"forward_router_address": "192.168.255.1"},
+                                        ],
                                         "dest": "0.0.0.0/0",
                                     },
                                 ],
@@ -352,6 +361,16 @@ class TestNxosStaticRoutesModule(TestNxosModule):
                                         ],
                                         "dest": "192.0.2.48/28",
                                     },
+                                    {
+                                        "next_hops": [
+                                            {
+                                                "forward_router_address": "192.0.2.15",
+                                                "track": 1,
+                                                "route_name": "new_route",
+                                            },
+                                        ],
+                                        "dest": "192.0.2.49/28",
+                                    },
                                 ],
                             },
                             {
@@ -395,7 +414,10 @@ class TestNxosStaticRoutesModule(TestNxosModule):
                                 "routes": [
                                     {
                                         "next_hops": [
-                                            {"forward_router_address": "192.0.2.22", "tag": 4},
+                                            {
+                                                "forward_router_address": "192.0.2.22",
+                                                "tag": 4,
+                                            },
                                             {
                                                 "forward_router_address": "192.0.2.23",
                                                 "admin_distance": 1,
@@ -420,6 +442,7 @@ class TestNxosStaticRoutesModule(TestNxosModule):
             "ip route 10.0.11.0/25 10.0.11.10 tag 22 11",
             "ip route 10.0.11.0/25 10.0.11.12 vrf Test tag 22 11",
             "ip route 192.0.2.48/28 loopback22 192.0.2.13",
+            "ip route 192.0.2.49/28 192.0.2.15 track 1 name new_route",
             "ipv6 route 2200:10::/36 2048:ae12::1 vrf dest 5",
             "ipv6 route 2200:10::/36 mgmt0 2048:ae12::1 tag 22 11",
             "ipv6 route 2200:10::/36 port-channel22 2048:ae12::1",
@@ -487,7 +510,10 @@ class TestNxosStaticRoutesModule(TestNxosModule):
                                     },
                                     {
                                         "next_hops": [
-                                            {"forward_router_address": "192.0.2.27", "tag": 13},
+                                            {
+                                                "forward_router_address": "192.0.2.27",
+                                                "tag": 13,
+                                            },
                                         ],
                                         "dest": "192.0.2.80/28",
                                     },
@@ -582,7 +608,10 @@ class TestNxosStaticRoutesModule(TestNxosModule):
                                     },
                                     {
                                         "next_hops": [
-                                            {"forward_router_address": "192.0.2.27", "tag": 13},
+                                            {
+                                                "forward_router_address": "192.0.2.27",
+                                                "tag": 13,
+                                            },
                                         ],
                                         "dest": "192.0.2.80/28",
                                     },
@@ -749,7 +778,9 @@ class TestNxosStaticRoutesModule(TestNxosModule):
                 config=[
                     dict(
                         vrf="Test",
-                        address_families=[dict(afi="ipv4", routes=[dict(dest="192.0.2.48/28")])],
+                        address_families=[
+                            dict(afi="ipv4", routes=[dict(dest="192.0.2.48/28")]),
+                        ],
                     ),
                 ],
                 state="deleted",
@@ -815,7 +846,10 @@ class TestNxosStaticRoutesModule(TestNxosModule):
                                     },
                                     {
                                         "next_hops": [
-                                            {"forward_router_address": "192.0.2.26", "tag": 12},
+                                            {
+                                                "forward_router_address": "192.0.2.26",
+                                                "tag": 12,
+                                            },
                                         ],
                                         "dest": "192.0.2.80/28",
                                     },
@@ -948,7 +982,9 @@ class TestNxosStaticRoutesModule(TestNxosModule):
                                 "dest": "192.0.2.16/28",
                             },
                             {
-                                "next_hops": [{"forward_router_address": "192.0.2.26", "tag": 12}],
+                                "next_hops": [
+                                    {"forward_router_address": "192.0.2.26", "tag": 12},
+                                ],
                                 "dest": "192.0.2.80/28",
                             },
                         ],
@@ -964,7 +1000,10 @@ class TestNxosStaticRoutesModule(TestNxosModule):
                             {
                                 "next_hops": [
                                     {"forward_router_address": "192.0.2.13"},
-                                    {"forward_router_address": "192.0.2.14", "admin_distance": 5},
+                                    {
+                                        "forward_router_address": "192.0.2.14",
+                                        "admin_distance": 5,
+                                    },
                                 ],
                                 "dest": "192.0.2.48/28",
                             },
@@ -979,7 +1018,9 @@ class TestNxosStaticRoutesModule(TestNxosModule):
                         "afi": "ipv4",
                         "routes": [
                             {
-                                "next_hops": [{"forward_router_address": "192.168.255.1"}],
+                                "next_hops": [
+                                    {"forward_router_address": "192.168.255.1"},
+                                ],
                                 "dest": "0.0.0.0/0",
                             },
                         ],
@@ -1138,7 +1179,9 @@ class TestNxosStaticRoutesModule(TestNxosModule):
                                 "dest": "192.0.2.17/28",
                             },
                             {
-                                "next_hops": [{"forward_router_address": "192.0.2.26", "tag": 12}],
+                                "next_hops": [
+                                    {"forward_router_address": "192.0.2.26", "tag": 12},
+                                ],
                                 "dest": "192.0.2.79/28",
                             },
                         ],
@@ -1154,7 +1197,10 @@ class TestNxosStaticRoutesModule(TestNxosModule):
                             {
                                 "next_hops": [
                                     {"forward_router_address": "192.0.2.13"},
-                                    {"forward_router_address": "192.0.2.14", "admin_distance": 5},
+                                    {
+                                        "forward_router_address": "192.0.2.14",
+                                        "admin_distance": 5,
+                                    },
                                 ],
                                 "dest": "192.0.2.48/28",
                             },
@@ -1169,7 +1215,9 @@ class TestNxosStaticRoutesModule(TestNxosModule):
                         "afi": "ipv4",
                         "routes": [
                             {
-                                "next_hops": [{"forward_router_address": "192.168.255.1"}],
+                                "next_hops": [
+                                    {"forward_router_address": "192.168.255.1"},
+                                ],
                                 "dest": "0.0.0.0/0",
                             },
                         ],


### PR DESCRIPTION

##### SUMMARY
- nxos_static_routes command formation is erroneous when `track` param is specified.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_static_routes.py
