### PR TITLE
[cliconf] changes required after cliconfbase updates in ansible.netcommon#640

### DIFF
--- a/plugins/cliconf/nxos.py
+++ b/plugins/cliconf/nxos.py
@@ -215,9 +215,16 @@ class Cliconf(CliconfBase):
         candidate=None,
         commit=True,
         replace=None,
+        diff=False,
         comment=None,
         err_responses=None,
     ):
+        if diff:
+            self._connection.queue_message(
+                "warning",
+                message="setting `diff=True` in edit_config() no effect for platform cisco.nxos",
+            )
+
         resp = {}
         operations = self.get_device_operations()
         self.check_edit_config_capability(


### PR DESCRIPTION
##### SUMMARY
- Mostly described in https://github.com/ansible-collections/ansible.netcommon/pull/640.
- Summary: `err_responses` cannot be added in edit_config base signature, this breaks other platforms. The fact that edit_config base has `diff` kwarg and nxos cliconf edit_config doesn't results in sanity/pylint to trip if `err_responses` isn't added in edit_config base.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
cliconf/nxos.py

