### PR TITLE
Change order of deletion for speed and duplex issue #868

### DIFF
--- a/plugins/module_utils/network/nxos/config/interfaces/interfaces.py
+++ b/plugins/module_utils/network/nxos/config/interfaces/interfaces.py
@@ -377,10 +377,10 @@ class Interfaces(ConfigBase):
             commands.append(no_cmd + "switchport")
         if "description" in obj:
             commands.append("no description")
-        if "speed" in obj:
-            commands.append("no speed")
         if "duplex" in obj:
             commands.append("no duplex")
+        if "speed" in obj:
+            commands.append("no speed")
         if "enabled" in obj:
             sysdef_enabled = self.default_enabled(have=obj, action="delete")
             if obj["enabled"] is False and sysdef_enabled is True:


### PR DESCRIPTION
##### SUMMARY
This is to fix https://github.com/ansible-collections/cisco.nxos/issues/868

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
nxos interfaces

##### ADDITIONAL INFORMATION

This just changes the order of operation for the speed and duplex when deleting them. Doing it that way doesn't cause the error that was described in bug 868