### PR TITLE
[nxapi] Add `vrf` option to `nxos_nxapi` module

### DIFF
--- a/changelogs/fragments/nxos_nxapi.yaml
+++ b/changelogs/fragments/nxos_nxapi.yaml
@@ -1,3 +1,4 @@
 ---
 minor_changes:
   - "nxos_nxapi - Add vrf parameter to nxos_nxapi module"
+  - "nxos_nxapi - Fix ssl_strong_ciphers option is not working over version 10"

--- a/changelogs/fragments/nxos_nxapi.yaml
+++ b/changelogs/fragments/nxos_nxapi.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "nxos_nxapi - Add vrf parameter to nxos_nxapi module"

--- a/changelogs/fragments/nxos_nxapi.yaml
+++ b/changelogs/fragments/nxos_nxapi.yaml
@@ -1,4 +1,5 @@
 ---
 minor_changes:
   - "nxos_nxapi - Add vrf parameter to nxos_nxapi module"
+bugfixes:
   - "nxos_nxapi - Fix ssl_strong_ciphers option is not working over version 10"

--- a/docs/cisco.nxos.nxos_nxapi_module.rst
+++ b/docs/cisco.nxos.nxos_nxapi_module.rst
@@ -232,7 +232,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Controls the vrf used to be used for NXAPI communication. By default (if not specify this parameter), all Layer 3 interfaces are used for NXAPI communication. If specify this parameter, only the Layer 3 interfaces in the specified VRF are used for NXAPI communication. The nxapi use-vrf feature is introduced in Cisco NX-OS Release 8.2(3) at N7K, and in Cisco NX-OS Release 7.0(3)I7(1) at N3K, N5K, N6K, and N9K.</div>
+                        <div>Controls the vrf used to be used for NXAPI communication. By default (if not specify this parameter), all Layer 3 interfaces are used for NXAPI communication. If specify this parameter, only the Layer 3 interfaces in the specified VRF are used for NXAPI communication. The nxapi use-vrf feature is introduced in Cisco NX-OS Release 8.2(3) at N7K, and in Cisco NX-OS Release 7.0 at N3K and N9K.</div>
                 </td>
             </tr>
     </table>

--- a/docs/cisco.nxos.nxos_nxapi_module.rst
+++ b/docs/cisco.nxos.nxos_nxapi_module.rst
@@ -220,6 +220,21 @@ Parameters
                         <div>Controls the use of the Transport Layer Security version 1.2 is configured.  By default, this feature is disabled.  To enable the use of TLSV1.2, set the value of this argument to True.</div>
                 </td>
             </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>vrf</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Controls the vrf used to be used for NXAPI communication. By default (if not specify this parameter), all Layer 3 interfaces are used for NXAPI communication. If specify this parameter, only the Layer 3 interfaces in the specified VRF are used for NXAPI communication. The nxapi use-vrf feature is introduced in Cisco NX-OS Release 8.2(3) at N7K, and in Cisco NX-OS Release 7.0(3)I7(1) at N3K, N5K, N6K, and N9K.</div>
+                </td>
+            </tr>
     </table>
     <br/>
 

--- a/plugins/module_utils/network/nxos/utils/utils.py
+++ b/plugins/module_utils/network/nxos/utils/utils.py
@@ -189,7 +189,7 @@ class Version:
     """Simple class to compare arbitrary versions"""
 
     def __init__(self, version_string):
-        self.components = version_string.split(".")
+        self.components = list(map(int, version_string.split(".")))
 
     def __eq__(self, other):
         other = _coerce(other)

--- a/plugins/modules/nxos_nxapi.py
+++ b/plugins/modules/nxos_nxapi.py
@@ -188,7 +188,9 @@ def check_args(module, warnings, capabilities):
             msg="sandbox or enable_sandbox is supported on NX-OS 7K series of switches",
         )
     os_version = extract_major_minor_version(capabilities["device_info"]["network_os_version"])
-    if module.params.get("vrf") and ((os_version < "8.2" and "7K" in os_platform) or os_version < "7.0"):
+    if module.params.get("vrf") and (
+        (os_version < "8.2" and "7K" in os_platform) or os_version < "7.0"
+    ):
         module.fail_json(
             msg=(
                 "vrf is supported on NX-OS 7K series of switches starting from 8.2(3)"

--- a/plugins/modules/nxos_nxapi.py
+++ b/plugins/modules/nxos_nxapi.py
@@ -134,7 +134,7 @@ options:
       By default (if not specify this parameter), all Layer 3 interfaces are used for NXAPI communication.
       If specify this parameter, only the Layer 3 interfaces in the specified VRF are used for NXAPI communication.
       The nxapi use-vrf feature is introduced in Cisco NX-OS Release 8.2(3) at N7K,
-      and in Cisco NX-OS Release 7.0(3)I7(1) at N3K, N5K, N6K, and N9K.
+      and in Cisco NX-OS Release 7.0 at N3K and N9K.
     required: false
     type: str
 """

--- a/plugins/modules/nxos_nxapi.py
+++ b/plugins/modules/nxos_nxapi.py
@@ -191,9 +191,9 @@ def check_args(module, warnings, capabilities):
     if (os_version < "8.2" and "7K" in os_platform) or os_version < "7.0":
         module.fail_json(
             msg=(
-                  "vrf is supported on NX-OS 7K series of switches starting from 8.2(3)"
-                  " and on other platforms starting from 7.0"
-              ),
+                "vrf is supported on NX-OS 7K series of switches starting from 8.2(3)"
+                " and on other platforms starting from 7.0"
+            ),
         )
 
     state = module.params["state"]

--- a/plugins/modules/nxos_nxapi.py
+++ b/plugins/modules/nxos_nxapi.py
@@ -188,7 +188,7 @@ def check_args(module, warnings, capabilities):
             msg="sandbox or enable_sandbox is supported on NX-OS 7K series of switches",
         )
     os_version = Version(capabilities["device_info"]["network_os_version"][:3])
-    if (os_version < "8.2" and "7K" in os_platform) or os_version < "7.0":
+    if module.params.get("vrf") and ((os_version < "8.2" and "7K" in os_platform) or os_version < "7.0"):
         module.fail_json(
             msg=(
                 "vrf is supported on NX-OS 7K series of switches starting from 8.2(3)"

--- a/tests/unit/modules/network/nxos/test_nxos_nxapi.py
+++ b/tests/unit/modules/network/nxos/test_nxos_nxapi.py
@@ -142,3 +142,43 @@ class TestNxosNxapiModule(TestNxosModule):
             ),
         )
         self.execute_module_devices(changed=False, commands=[])
+
+    def test_nxos_nxapi_two_digit_version(self):
+        self.get_capabilities.return_value = {
+            "device_info": {
+                "network_os_platform": "N7K-C7018",
+                "network_os_version": "10.3(1)",
+            },
+            "network_api": "cliconf",
+        }
+        set_module_args(
+            dict(
+                http=True,
+                https=False,
+                http_port=80,
+                https_port=443,
+                sandbox=False,
+                vrf="default",
+            ),
+        )
+        self.execute_module_devices(changed=True, commands=["nxapi use-vrf default"])
+
+    def test_nxos_nxapi_ssl_strong_ciphers_two_digit_version(self):
+        self.get_capabilities.return_value = {
+            "device_info": {
+                "network_os_platform": "N9K-C7018",
+                "network_os_version": "9.10(1)",
+            },
+            "network_api": "cliconf",
+        }
+        set_module_args(
+            dict(
+                http=True,
+                https=False,
+                http_port=80,
+                https_port=443,
+                sandbox=False,
+                ssl_strong_ciphers=True,
+            ),
+        )
+        self.execute_module_devices(changed=True, commands=["no nxapi ssl ciphers weak", "nxapi ssl protocols TLSv1 "])

--- a/tests/unit/modules/network/nxos/test_nxos_nxapi.py
+++ b/tests/unit/modules/network/nxos/test_nxos_nxapi.py
@@ -99,3 +99,7 @@ class TestNxosNxapiModule(TestNxosModule):
             changed=True,
             commands=["no nxapi http", "nxapi https port 8443"],
         )
+
+    def test_nxos_nxapi_use_vrf(self):
+        set_module_args(dict(vrf="management"))
+        self.execute_module_devices(changed=True, commands=["nxapi use-vrf management"])

--- a/tests/unit/modules/network/nxos/test_nxos_nxapi.py
+++ b/tests/unit/modules/network/nxos/test_nxos_nxapi.py
@@ -103,3 +103,42 @@ class TestNxosNxapiModule(TestNxosModule):
     def test_nxos_nxapi_use_vrf(self):
         set_module_args(dict(vrf="management"))
         self.execute_module_devices(changed=True, commands=["nxapi use-vrf management"])
+
+    def test_nxos_nxapi_failed_when_vrf_is_used_in_unsupported_version(self):
+        self.get_capabilities.return_value = {
+            "device_info": {
+                "network_os_platform": "N7K-C7018",
+                "network_os_version": "7.0(1)",
+            },
+            "network_api": "cliconf",
+        }
+        set_module_args(
+            dict(
+                http=True,
+                https=False,
+                http_port=80,
+                https_port=443,
+                sandbox=False,
+                vrf="management",
+            ),
+        )
+        self.execute_module_devices(failed=True)
+
+    def test_nxos_nxapi_not_failed_in_old_version(self):
+        self.get_capabilities.return_value = {
+            "device_info": {
+                "network_os_platform": "N7K-C7018",
+                "network_os_version": "7.0(1)",
+            },
+            "network_api": "cliconf",
+        }
+        set_module_args(
+            dict(
+                http=True,
+                https=False,
+                http_port=80,
+                https_port=443,
+                sandbox=False,
+            ),
+        )
+        self.execute_module_devices(changed=False, commands=[])

--- a/tests/unit/modules/network/nxos/test_nxos_nxapi.py
+++ b/tests/unit/modules/network/nxos/test_nxos_nxapi.py
@@ -181,4 +181,6 @@ class TestNxosNxapiModule(TestNxosModule):
                 ssl_strong_ciphers=True,
             ),
         )
-        self.execute_module_devices(changed=True, commands=["no nxapi ssl ciphers weak", "nxapi ssl protocols TLSv1 "])
+        self.execute_module_devices(
+            changed=True, commands=["no nxapi ssl ciphers weak", "nxapi ssl protocols TLSv1 "]
+        )

--- a/tests/unit/modules/network/nxos/test_nxos_nxapi.py
+++ b/tests/unit/modules/network/nxos/test_nxos_nxapi.py
@@ -182,5 +182,6 @@ class TestNxosNxapiModule(TestNxosModule):
             ),
         )
         self.execute_module_devices(
-            changed=True, commands=["no nxapi ssl ciphers weak", "nxapi ssl protocols TLSv1 "]
+            changed=True,
+            commands=["no nxapi ssl ciphers weak", "nxapi ssl protocols TLSv1 "],
         )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add `vrf` option to `nxos_nxapi` module.

###### Comments on the design:
It's an old module with only state: present / absent. As far as I can see, when state: present is specified, it does not change parameters that are not mentioned. For example, if the `nxapi sandbox` command is already present on the device but the sandbox parameter is not specified in the playbook, it results that no deletion or other actions are taken.

Therefore, the vrf option follows this design.

Not applying the `nxapi use-vrf` command at all means enabling nxapi for all VRFs. However, in my implementation of this module, there is currently no way to remove an already applied nxapi use-vrf <xxxxx> configuration at all. This is because while it is possible to specify another VRF, but there is no way to reflect the absence of a parameter. This aligns with the aforementioned behavior of state: `present` where nothing is done if a parameter is not specified.

This implementation method was chosen to maintain consistency within the module, avoid disrupting environments using the existing nxos_nxapi module, and keep the parameters simple.

Other possible approaches:
- Implementing a behavior similar to the state: overriden in other modules, meaning if no VRF is specified, the existing nxapi use-vrf setting would be deleted.
- Making the parameter more complex. For example, explicitly enabling or disabling as follows:
```
vrf:
  limit_to_vrf: bool
  vrf_name: xxx
```

If you prefer to select one of other two approaches I mentioned, or an entirely different approach, please let me know.  I am willing to make adjustments accordingly.


###### Reference for the supported versions of use-vrf:
- For N9K: 
  - At least, supported in version 7.0(3)I3(1)
    - https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/7-x/command_references/configuration_commands/b_Using_N9K_Config_Commands/b_N9K_Bookmap_chapter_01111.html#wp4568333650 
  - Also, it is not supported in version 6.1(2)I2(2)
    - https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/6-x/command_reference/config_612I22/b_n9k_command_ref/b_n9k_command_ref_chapter_010000.html#wp2897910537
  - I am unsure of the exact version where it was released. I have reviewed all the release notes, but there is no mention of it.
- For N7K:
  - > The nxapi use-vrf feature is introduced in Cisco NX-OS Release 8.2(3), which helps to secure NX-API by binding the NX-API to a particular VRF.
  
    - https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus7000/sw/programmability/guide/cisco_nexus7000_programmability_guide_8x/b-cisco-nexus7000-programmability-guide-8x_chapter_011.html

- For N3K:
  - At least, supported in version 7.0(3)I4(1)
    - https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus3000/sw/command/reference/703i74m3k/config/b_N3K_Config_Commands_703i74/b_N3K_Config_Commands_703i74_chapter_01111.html#wp1351653258


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_nxapi_module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
