### PR TITLE
Handle Empty LLDP Neighbor Information in facts

### DIFF
--- a/changelogs/fragments/lldp_facts.yaml
+++ b/changelogs/fragments/lldp_facts.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - facts - Fixes issue where the LLDP neighbor information returns an error when empty.

--- a/plugins/module_utils/network/nxos/facts/legacy/base.py
+++ b/plugins/module_utils/network/nxos/facts/legacy/base.py
@@ -344,19 +344,19 @@ class Interfaces(FactsBase):
         objects = dict()
         try:
             data = data["TABLE_nbor"]["ROW_nbor"]
-
-            if isinstance(data, dict):
-                data = [data]
-
-            for item in data:
-                local_intf = normalize_interface(item["l_port_id"])
-                objects[local_intf] = list()
-                nbor = dict()
-                nbor["port"] = item["port_id"]
-                nbor["host"] = nbor["sysname"] = item["chassis_id"]
-                objects[local_intf].append(nbor)
         except KeyError:
-            pass  # No neighbors found as the TABLE_nbor key is missing
+            return objects  # No neighbors found as the TABLE_nbor key is missing and return empty dict
+
+        if isinstance(data, dict):
+            data = [data]
+
+        for item in data:
+            local_intf = normalize_interface(item["l_port_id"])
+            objects[local_intf] = list()
+            nbor = dict()
+            nbor["port"] = item["port_id"]
+            nbor["host"] = nbor["sysname"] = item["chassis_id"]
+            objects[local_intf].append(nbor)
 
         return objects  # Return empty dict if no neighbors found else return the neighbors
 

--- a/plugins/module_utils/network/nxos/facts/legacy/base.py
+++ b/plugins/module_utils/network/nxos/facts/legacy/base.py
@@ -278,7 +278,7 @@ class Interfaces(FactsBase):
                 )
             else:
                 self.facts["neighbors"].update(self.populate_neighbors(data))
-        except Exception as e:
+        except KeyError:
             pass  # Do nothing as there is no lldp neighbors
 
         data = self.run("show cdp neighbors detail", output="json")

--- a/plugins/module_utils/network/nxos/facts/legacy/base.py
+++ b/plugins/module_utils/network/nxos/facts/legacy/base.py
@@ -279,8 +279,7 @@ class Interfaces(FactsBase):
             else:
                 self.facts["neighbors"].update(self.populate_neighbors(data))
         except Exception as e:
-            pass # Do nothing as there is no lldp neighbors
-            
+            pass  # Do nothing as there is no lldp neighbors
 
         data = self.run("show cdp neighbors detail", output="json")
         if data:

--- a/plugins/module_utils/network/nxos/facts/legacy/base.py
+++ b/plugins/module_utils/network/nxos/facts/legacy/base.py
@@ -345,7 +345,9 @@ class Interfaces(FactsBase):
         try:
             data = data["TABLE_nbor"]["ROW_nbor"]
         except KeyError:
-            return objects  # No neighbors found as the TABLE_nbor key is missing and return empty dict
+            return (
+                objects  # No neighbors found as the TABLE_nbor key is missing and return empty dict
+            )
 
         if isinstance(data, dict):
             data = [data]

--- a/plugins/module_utils/network/nxos/facts/legacy/base.py
+++ b/plugins/module_utils/network/nxos/facts/legacy/base.py
@@ -270,7 +270,7 @@ class Interfaces(FactsBase):
                 self.populate_ipv6_interfaces(interfaces)
 
         data = self.run("show lldp neighbors", output="json")
-        
+
         try:
             if isinstance(data, dict):
                 self.facts["neighbors"].update(
@@ -279,8 +279,7 @@ class Interfaces(FactsBase):
             else:
                 self.facts["neighbors"].update(self.populate_neighbors(data))
         except Exception as e:
-            pass ### Do nothing as there is no lldp neighbors
-            
+            pass  ### Do nothing as there is no lldp neighbors
 
         data = self.run("show cdp neighbors detail", output="json")
         if data:

--- a/plugins/module_utils/network/nxos/facts/legacy/base.py
+++ b/plugins/module_utils/network/nxos/facts/legacy/base.py
@@ -360,7 +360,7 @@ class Interfaces(FactsBase):
             nbor["host"] = nbor["sysname"] = item["chassis_id"]
             objects[local_intf].append(nbor)
 
-        return objects  # Return empty dict if no neighbors found else return the neighbors
+        return objects
 
     def populate_structured_neighbors_cdp(self, data):
         objects = dict()

--- a/plugins/module_utils/network/nxos/facts/legacy/base.py
+++ b/plugins/module_utils/network/nxos/facts/legacy/base.py
@@ -270,7 +270,7 @@ class Interfaces(FactsBase):
                 self.populate_ipv6_interfaces(interfaces)
 
         data = self.run("show lldp neighbors", output="json")
-        
+
         if data:
             if isinstance(data, dict):
                 self.facts["neighbors"].update(
@@ -278,7 +278,6 @@ class Interfaces(FactsBase):
                 )
             else:
                 self.facts["neighbors"].update(self.populate_neighbors(data))
-
 
         data = self.run("show cdp neighbors detail", output="json")
         if data:
@@ -358,9 +357,9 @@ class Interfaces(FactsBase):
                 nbor["host"] = nbor["sysname"] = item["chassis_id"]
                 objects[local_intf].append(nbor)
         except KeyError:
-            pass # No neighbors found as the TABLE_nbor key is missing
+            pass  # No neighbors found as the TABLE_nbor key is missing
 
-        return objects # Return empty dict if no neighbors found else return the neighbors
+        return objects  # Return empty dict if no neighbors found else return the neighbors
 
     def populate_structured_neighbors_cdp(self, data):
         objects = dict()

--- a/plugins/module_utils/network/nxos/facts/legacy/base.py
+++ b/plugins/module_utils/network/nxos/facts/legacy/base.py
@@ -270,7 +270,8 @@ class Interfaces(FactsBase):
                 self.populate_ipv6_interfaces(interfaces)
 
         data = self.run("show lldp neighbors", output="json")
-        if data:
+        neigh_count = data.get("neigh_count", '0')
+        if data and int(neigh_count) != 0:
             if isinstance(data, dict):
                 self.facts["neighbors"].update(
                     self.populate_structured_neighbors_lldp(data),

--- a/plugins/module_utils/network/nxos/facts/legacy/base.py
+++ b/plugins/module_utils/network/nxos/facts/legacy/base.py
@@ -270,7 +270,7 @@ class Interfaces(FactsBase):
                 self.populate_ipv6_interfaces(interfaces)
 
         data = self.run("show lldp neighbors", output="json")
-        neigh_count = data.get("neigh_count", '0')
+        neigh_count = data.get("neigh_count", "0")
         if data and int(neigh_count) != 0:
             if isinstance(data, dict):
                 self.facts["neighbors"].update(

--- a/plugins/module_utils/network/nxos/facts/legacy/base.py
+++ b/plugins/module_utils/network/nxos/facts/legacy/base.py
@@ -270,7 +270,6 @@ class Interfaces(FactsBase):
                 self.populate_ipv6_interfaces(interfaces)
 
         data = self.run("show lldp neighbors", output="json")
-
         if data:
             if isinstance(data, dict):
                 self.facts["neighbors"].update(

--- a/plugins/module_utils/network/nxos/facts/legacy/base.py
+++ b/plugins/module_utils/network/nxos/facts/legacy/base.py
@@ -270,14 +270,17 @@ class Interfaces(FactsBase):
                 self.populate_ipv6_interfaces(interfaces)
 
         data = self.run("show lldp neighbors", output="json")
-        neigh_count = data.get("neigh_count", "0")
-        if data and int(neigh_count) != 0:
+        
+        try:
             if isinstance(data, dict):
                 self.facts["neighbors"].update(
                     self.populate_structured_neighbors_lldp(data),
                 )
             else:
                 self.facts["neighbors"].update(self.populate_neighbors(data))
+        except Exception as e:
+            pass ### Do nothing as there is no lldp neighbors
+            
 
         data = self.run("show cdp neighbors detail", output="json")
         if data:

--- a/plugins/module_utils/network/nxos/facts/legacy/base.py
+++ b/plugins/module_utils/network/nxos/facts/legacy/base.py
@@ -279,7 +279,8 @@ class Interfaces(FactsBase):
             else:
                 self.facts["neighbors"].update(self.populate_neighbors(data))
         except Exception as e:
-            pass  ### Do nothing as there is no lldp neighbors
+            pass # Do nothing as there is no lldp neighbors
+            
 
         data = self.run("show cdp neighbors detail", output="json")
         if data:


### PR DESCRIPTION
##### SUMMARY
Fixes an issue where the LLDP neighbor information returns an error when empty.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
- legacy/base.py

##### ADDITIONAL INFORMATION
Fixes:
Below error when lldp neighbours empty
```json
{
  "module_stdout": "",
  "module_stderr": "'TABLE_nbor'",
  "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
  "_ansible_no_log": false,
  "changed": false
}
```

Facts when no neighbours:
```
    ansible_net_neighbors:
      mgmt0:
      - host: NXOS9000v(9FLFSK4RT9R)
        port: mgmt0
        sysname: NXOS9000v(9FLFSK4RT9R)
```

Facts when neighbours exists:
```
    ansible_net_neighbors:
      Ethernet1/1:
      - host: NXOS9000v(9FLFSK4RT9R)
        port: Ethernet1/1
        sysname: NXOS9000v(9FLFSK4RT9R)
      mgmt0:
      - host: NXOS9000v(9FLFSK4RT9R)
        port: mgmt0
        sysname: NXOS9000v(9FLFSK4RT9R)
```

