### PR TITLE
[nxos_prefix_lists] Fix idempotency issues caused by IP prefix notation discrepancies

### DIFF
--- a/changelogs/fragments/nxos_prefix_lists.yaml
+++ b/changelogs/fragments/nxos_prefix_lists.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "nxos_prefix_lists - Fix idempotency issues caused by IP prefix notation discrepancies"

--- a/plugins/module_utils/network/nxos/config/prefix_lists/prefix_lists.py
+++ b/plugins/module_utils/network/nxos/config/prefix_lists/prefix_lists.py
@@ -18,6 +18,14 @@ necessary to bring the current configuration to its desired end-state is
 created.
 """
 
+try:
+    import ipaddress
+    HAS_IPADDRESS = True
+except ImportError:
+    HAS_IPADDRESS = False
+
+import copy
+
 from ansible.module_utils.six import iteritems
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.rm_base.resource_module import (
     ResourceModule,
@@ -117,7 +125,7 @@ class Prefix_lists(ResourceModule):
     def _compare_seqs(self, want, have):
         for wseq, wentry in iteritems(want):
             hentry = have.pop(wseq, {})
-            if hentry != wentry:
+            if not self._compare_entry(wentry, hentry):
                 if hentry:
                     if self.state == "merged":
                         self._module.fail_json(
@@ -133,6 +141,39 @@ class Prefix_lists(ResourceModule):
         # remove remaining entries from have prefix list
         for hseq in have.values():
             self.addcmd(hseq, "entry", negate=True)
+
+    def _compare_entry(self, want_entry, have_entry):
+        if HAS_IPADDRESS:
+            want_entry_to_compare = copy.deepcopy(want_entry)
+            have_entry_to_compare = copy.deepcopy(have_entry)
+            if "prefix" in want_entry_to_compare and "prefix" in have_entry_to_compare:
+                try:
+                    want_entry_to_compare["prefix"] = ipaddress.ip_network(
+                        want_entry_to_compare["prefix"], strict=False
+                    )
+                    have_entry_to_compare["prefix"] = ipaddress.ip_network(
+                        have_entry_to_compare["prefix"], strict=False
+                    )
+                except ValueError as e:
+                    self._module.fail_json(
+                        msg="Cannot parse prefix. {0}.".format(str(e)),
+                    )
+            return want_entry_to_compare == have_entry_to_compare
+        else:
+            self.warnings.append(
+                (
+                    "The ipaddress package was not found. Prefix standardization "
+                    "will not be performed. Please ensure that the prefix arguments in the "
+                    "playbook and the running-config are exactly the same, or install the ipaddress "
+                    "package. If there is a discrepancy in prefix notation between the playbook "
+                    "and the running-config in this state, idempotency will not be maintained, "
+                    "resulting in the deletion and re-addition of existing configurations. For "
+                    "example, if the playbook specifies prefix: ::0/, the running-config will "
+                    "display it as 0::0/0. In this case, running the playbook multiple times will "
+                    "cause the existing config to be deleted and re-added each time."
+                )
+            )
+        return want_entry == have_entry
 
     def _prefix_list_transform(self, entry):
         for afi, value in iteritems(entry):

--- a/plugins/module_utils/network/nxos/config/prefix_lists/prefix_lists.py
+++ b/plugins/module_utils/network/nxos/config/prefix_lists/prefix_lists.py
@@ -20,6 +20,7 @@ created.
 
 try:
     import ipaddress
+
     HAS_IPADDRESS = True
 except ImportError:
     HAS_IPADDRESS = False
@@ -149,10 +150,12 @@ class Prefix_lists(ResourceModule):
             if "prefix" in want_entry_to_compare and "prefix" in have_entry_to_compare:
                 try:
                     want_entry_to_compare["prefix"] = ipaddress.ip_network(
-                        want_entry_to_compare["prefix"], strict=False
+                        want_entry_to_compare["prefix"],
+                        strict=False,
                     )
                     have_entry_to_compare["prefix"] = ipaddress.ip_network(
-                        have_entry_to_compare["prefix"], strict=False
+                        have_entry_to_compare["prefix"],
+                        strict=False,
                     )
                 except ValueError as e:
                     self._module.fail_json(
@@ -171,7 +174,7 @@ class Prefix_lists(ResourceModule):
                     "example, if the playbook specifies prefix: ::0/, the running-config will "
                     "display it as 0::0/0. In this case, running the playbook multiple times will "
                     "cause the existing config to be deleted and re-added each time."
-                )
+                ),
             )
         return want_entry == have_entry
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed an issue where idempotency was not maintained due to discrepancies in the notation of IP prefixes. By introducing the `ipaddress` module to standardize prefixes, we ensure that the playbook and running-config prefixes are compared accurately, preventing unnecessary configuration changes.

For example, previously, a playbook specifying `prefix: ::0/` and a running-config showing `ipv6 prefix-list plist1 seq 10 permit 0::/0`, or a playbook specifying `prefix: 10.0.0.8/24` and a running-config showing `ip prefix-list plist2 seq 10 permit 10.0.0.0/24`, would result in unnecessary changes. With this update, such discrepancies are handled, maintaining idempotency and ensuring existing configurations are not repeatedly deleted and re-added.

Supplementary Information:
The notation you enter in configure terminal and the notation in the `show run` output may differ on Nexus devices. Therefore, a simple text comparison could break idempotency.

An example is shown below.
```
# conf t
(config)# ipv6 prefix-list plist1 seq 10 permit ::/0
(config)# ip prefix-list plist2 seq 10 permit 10.0.0.8/24
(config)# exit
# show run | inc plist 
ip prefix-list plist2 seq 10 permit 10.0.0.0/24
ipv6 prefix-list plist1 seq 10 permit 0::/0
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_prefix_lists

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Paste verbatim command output below, e.g. before and after your change -->
Before this change, when I executed the playbook below multiple times, the result would always be changed, and plist1 would be deleted and added each time.

```paste below
- hosts: all
  gather_facts: no
  vars:
    ansible_connection: network_cli
    ansible_user: "hoo"
    ansible_password: "bar"
    ansible_network_os: cisco.nxos.nxos
  tasks:
    - name: prefixlists_always_changed
      cisco.nxos.nxos_prefix_lists:
        state: "overridden"
        config:
          - afi: ipv6
            prefix_lists:
            - entries:
              - action: permit
                prefix: ::0/0
                sequence: 10
              name: "plist1"
```
