### PR TITLE
Fix nxos_user purge deleting non-locally configured users

### DIFF
--- a/plugins/modules/nxos_user.py
+++ b/plugins/modules/nxos_user.py
@@ -411,6 +411,14 @@ def update_objects(want, have):
                     updates.append((entry, item))
     return updates
 
+def get_configured_usernames(module):
+    config_output = run_commands(module, [{"command": "show running-config | section ^username", "output": "text"}])
+    usernames = set()
+    for line in config_output[0].splitlines():
+        if line.startswith("username "):
+            username = line.split()[1]
+            usernames.add(username)
+    return usernames
 
 def main():
     """main entry point for module execution"""
@@ -457,9 +465,11 @@ def main():
     commands = map_obj_to_commands(update_objects(want, have), module)
 
     if module.params["purge"]:
-        want_users = [x["name"] for x in want]
-        have_users = [x["name"] for x in have]
-        for item in set(have_users).difference(want_users):
+        want_users = set([x["name"] for x in want])
+        have_users = set([x["name"] for x in have])
+        configured_users = get_configured_usernames(module)
+
+        for item in have_users.difference(want_users).difference(configured_users):
             if item != "admin":
                 item = item.replace("\\", "\\\\")
                 commands.append("no username %s" % item)


### PR DESCRIPTION
##### SUMMARY

Fixes an issue in the nxos_user module where the purge option deleting the non-locally configured users displayed by the "show user-account" command, breaking idempotency. Now, only locally configured users are purged.



##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

nxos_user

##### ADDITIONAL INFORMATION

When the purge option was used, users authenticated via TACACS+ or users defined for SNMP were being deleted despite not being locally configured. This fix ensures only local users are purged.


