### PR TITLE
[bgp_templates] update show commands used to fetch config

### DIFF
--- a/changelogs/fragments/fix_ana_569.yaml
+++ b/changelogs/fragments/fix_ana_569.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "[bgp_templates] - fix the show commands used to ensure task does not fail if BGP is not enabled on the device."

--- a/plugins/module_utils/network/nxos/facts/bgp_templates/bgp_templates.py
+++ b/plugins/module_utils/network/nxos/facts/bgp_templates/bgp_templates.py
@@ -37,8 +37,8 @@ class Bgp_templatesFacts(object):
         """Wrapper method for `connection.get()`
         This method exists solely to allow the unit test framework to mock device connection calls.
         """
-        as_number = connection.get("show running-config bgp | include 'router bgp'")
-        templates = connection.get("show running-config bgp | section 'template'")
+        as_number = connection.get("show running-config | include 'router bgp'")
+        templates = connection.get("show running-config | section 'template'")
 
         return as_number + "\n" + templates
 


### PR DESCRIPTION
##### SUMMARY
- If `feature bgp` is disabled, the existing show command caused the task to fail complaining about invalid command.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_bgp_templates.py
