### PR TITLE
added overridden state for cisco.nxos_telemetry

### DIFF
--- a/changelogs/fragments/nxos_telemetry_overridden.yaml
+++ b/changelogs/fragments/nxos_telemetry_overridden.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "nxos_telemetry - Added support for 'overridden' state to provide complete configuration override capabilities."

--- a/changelogs/fragments/telemetry_overridden.yaml
+++ b/changelogs/fragments/telemetry_overridden.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-  - "nxos_telemetry - Added support for 'overridden' state to provide complete configuration override capabilities."

--- a/changelogs/fragments/telemetry_overridden.yaml
+++ b/changelogs/fragments/telemetry_overridden.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "nxos_telemetry - Added support for 'overridden' state to provide complete configuration override capabilities."

--- a/docs/cisco.nxos.nxos_telemetry_module.rst
+++ b/docs/cisco.nxos.nxos_telemetry_module.rst
@@ -565,6 +565,7 @@ Parameters
                                     <li>replaced</li>
                                     <li>deleted</li>
                                     <li>gathered</li>
+                                    <li>overridden</li>
                         </ul>
                 </td>
                 <td>
@@ -653,7 +654,7 @@ Examples
     # This action will replace telemetry configuration on the device with the
     # telemetry configuration defined in the playbook.
 
-    - name: Override Telemetry Configuration
+    - name: Replace Telemetry Configuration
       cisco.nxos.nxos_telemetry:
         config:
           certificate:
@@ -673,6 +674,31 @@ Examples
             - id: 5
               destination_group: 55
         state: replaced
+
+    # Using overridden
+    # This action will override all telemetry configuration on the device with the
+    # telemetry configuration defined in the playbook.
+
+    - name: Override Telemetry Configuration
+      cisco.nxos.nxos_telemetry:
+        config:
+          certificate:
+            key: /bootflash/server.key
+            hostname: localhost
+          compression: gzip
+          source_interface: Ethernet1/1
+          vrf: management
+          destination_groups:
+            - id: 2
+              destination:
+                ip: 192.168.0.2
+                port: 50001
+                protocol: gRPC
+                encoding: GPB
+          subscriptions:
+            - id: 5
+              destination_group: 55
+        state: overridden
 
 
 

--- a/plugins/module_utils/network/nxos/argspec/telemetry/telemetry.py
+++ b/plugins/module_utils/network/nxos/argspec/telemetry/telemetry.py
@@ -108,7 +108,7 @@ class TelemetryArgs(object):  # pylint: disable=R0903
             "type": "dict",
         },
         "state": {
-            "choices": ["merged", "replaced", "deleted", "gathered"],
+            "choices": ["merged", "replaced", "deleted", "gathered", "overridden"],
             "default": "merged",
             "type": "str",
         },

--- a/plugins/module_utils/network/nxos/config/telemetry/telemetry.py
+++ b/plugins/module_utils/network/nxos/config/telemetry/telemetry.py
@@ -82,8 +82,6 @@ class Telemetry(ConfigBase):
         warnings = list()
 
         state = self._module.params["state"]
-        if "overridden" in state:
-            self._module.fail_json(msg="State <overridden> is invalid for this module.")
         # When state is 'deleted', the module_params should not contain data
         # under the 'config' key
         if "deleted" in state and self._module.params.get("config"):
@@ -153,7 +151,7 @@ class Telemetry(ConfigBase):
         # and does not require any processing using NxosCmdRef objects.
         if state == "deleted":
             return self._state_deleted(want, have)
-        elif state == "replaced":
+        elif state in ["replaced", "overridden"]:
             if want == have:
                 return []
             return self._state_replaced(want, have)

--- a/plugins/modules/nxos_telemetry.py
+++ b/plugins/modules/nxos_telemetry.py
@@ -199,6 +199,7 @@ options:
     - replaced
     - deleted
     - gathered
+    - overridden
     default: merged
 
 """
@@ -267,7 +268,7 @@ EXAMPLES = """
 # This action will replace telemetry configuration on the device with the
 # telemetry configuration defined in the playbook.
 
-- name: Override Telemetry Configuration
+- name: Replace Telemetry Configuration
   cisco.nxos.nxos_telemetry:
     config:
       certificate:
@@ -287,6 +288,31 @@ EXAMPLES = """
         - id: 5
           destination_group: 55
     state: replaced
+
+# Using overridden
+# This action will override all telemetry configuration on the device with the
+# telemetry configuration defined in the playbook.
+
+- name: Override Telemetry Configuration
+  cisco.nxos.nxos_telemetry:
+    config:
+      certificate:
+        key: /bootflash/server.key
+        hostname: localhost
+      compression: gzip
+      source_interface: Ethernet1/1
+      vrf: management
+      destination_groups:
+        - id: 2
+          destination:
+            ip: 192.168.0.2
+            port: 50001
+            protocol: gRPC
+            encoding: GPB
+      subscriptions:
+        - id: 5
+          destination_group: 55
+    state: overridden
 """
 RETURN = """
 before:

--- a/tests/unit/modules/network/nxos/test_nxos_telemetry.py
+++ b/tests/unit/modules/network/nxos/test_nxos_telemetry.py
@@ -2091,6 +2091,8 @@ class TestNxosTelemetryModule(TestNxosModule):
                 "use-vrf blue",
             ],
         )
+
+
 def build_args(data, type, state=None, check_mode=None):
     if state is None:
         state = "merged"

--- a/tests/unit/modules/network/nxos/test_nxos_telemetry.py
+++ b/tests/unit/modules/network/nxos/test_nxos_telemetry.py
@@ -1997,7 +1997,100 @@ class TestNxosTelemetryModule(TestNxosModule):
         )
         self.execute_module(changed=False, commands=[])
 
-
+    def test_tms_overridden_n9k(self):
+        # Assumes feature telemetry is enabled
+        # Similar to replaced state:
+        # - Modify vrf global config, remove default all other global config.
+        # - destination-group 2 destination '192.168.0.1' idempotent
+        # - destination-group 2 destination '192.168.0.2' remove
+        # - remove all other destination-groups
+        # - Modify sensor-group 55 and delete all others
+        # - Modify subscription 7, add 10 and delete all others
+        self.execute_show_command.return_value = load_fixture(
+            "nxos_telemetry",
+            "N9K.cfg",
+        )
+        self.get_platform_shortname.return_value = "N9K"
+        set_module_args(
+            {
+                "state": "overridden",
+                "config": {
+                    "vrf": "blue",
+                    "destination_groups": [
+                        {
+                            "id": 2,
+                            "destination": {
+                                "ip": "192.168.0.1",
+                                "port": 50001,
+                                "protocol": "GRPC",
+                                "encoding": "GPB",
+                            },
+                        },
+                    ],
+                    "sensor_groups": [
+                        {
+                            "id": 55,
+                            "data_source": "NX-API",
+                            "path": {
+                                "name": "sys/bgp",
+                                "depth": 0,
+                                "query_condition": "query_condition_xyz",
+                                "filter_condition": "filter_condition_xyz",
+                            },
+                        },
+                    ],
+                    "subscriptions": [
+                        {
+                            "id": 7,
+                            "destination_group": 10,
+                            "sensor_group": {
+                                "id": 55,
+                                "sample_interval": 1000,
+                            },
+                        },
+                        {
+                            "id": 10,
+                            "destination_group": 2,
+                            "sensor_group": {
+                                "id": 55,
+                                "sample_interval": 1000,
+                            },
+                        },
+                    ],
+                },
+            },
+            ignore_provider_arg,
+        )
+        self.execute_module(
+            changed=True,
+            commands=[
+                "telemetry",
+                "no subscription 3",
+                "no subscription 5",
+                "no subscription 4",
+                "subscription 7",
+                "no snsr-grp 2 sample-interval 1000",
+                "no subscription 6",
+                "no sensor-group 56",
+                "no sensor-group 2",
+                "no destination-group 10",
+                "destination-group 2",
+                "no ip address 192.168.0.2 port 60001 protocol grpc encoding gpb",
+                "sensor-group 55",
+                "data-source NX-API",
+                "path sys/bgp depth 0 query-condition query_condition_xyz filter-condition filter_condition_xyz",
+                "subscription 10",
+                "dst-grp 2",
+                "snsr-grp 55 sample-interval 1000",
+                "subscription 7",
+                "snsr-grp 55 sample-interval 1000",
+                "no certificate /bootflash/server.key localhost",
+                "destination-profile",
+                "no use-compression gzip",
+                "no source-interface loopback55",
+                "use-vrf blue",
+            ],
+        )
 def build_args(data, type, state=None, check_mode=None):
     if state is None:
         state = "merged"


### PR DESCRIPTION
##### SUMMARY
Added support for 'overridden' state to cisco.nxos.telemetry module and included corresponding test cases. The overridden state functionality behaves similarly to the replaced state, allowing users to completely override the existing telemetry configuration with their specified configuration. 

##### COMPONENT NAME
cisco.nxos.telemetry


