### PR TITLE
Fix hardware subsets for nxos 9.3 version

### DIFF
--- a/changelogs/fragments/nxos_facts_cpu_utilization.yaml
+++ b/changelogs/fragments/nxos_facts_cpu_utilization.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Fixed hardware fact gathering failure for CPU utilization parsing on NX-OS 9.3(3) by handling both list and single value formats of onemin_percent"

--- a/plugins/module_utils/network/nxos/facts/legacy/base.py
+++ b/plugins/module_utils/network/nxos/facts/legacy/base.py
@@ -169,8 +169,8 @@ class Hardware(FactsBase):
             self.facts["cpu_utilization"] = self.parse_cpu_utilization(data)
 
     def parse_cpu_utilization(self, data):
-        onemin = data.get("onemin_percent", 0)
-        if isinstance(onemin, list):
+        onemin = data.get("onemin_percent",0)
+        if(isinstance(onemin,list)):
             onemin = onemin[1]
         return {
             "core": {

--- a/plugins/module_utils/network/nxos/facts/legacy/base.py
+++ b/plugins/module_utils/network/nxos/facts/legacy/base.py
@@ -169,7 +169,7 @@ class Hardware(FactsBase):
             self.facts["cpu_utilization"] = self.parse_cpu_utilization(data)
 
     def parse_cpu_utilization(self, data):
-        onemin = data.get("onemin_percent",0)
+        onemin = data.get("onemin_percent", 0)
         if isinstance(onemin, list):
             onemin = onemin[1]
         return {

--- a/plugins/module_utils/network/nxos/facts/legacy/base.py
+++ b/plugins/module_utils/network/nxos/facts/legacy/base.py
@@ -170,7 +170,7 @@ class Hardware(FactsBase):
 
     def parse_cpu_utilization(self, data):
         onemin = data.get(data.get("onemin_percent"))
-        if(isinstance(onemin,list)):
+        if isinstance(onemin, list):
             onemin = onemin[1]
         return {
             "core": {

--- a/plugins/module_utils/network/nxos/facts/legacy/base.py
+++ b/plugins/module_utils/network/nxos/facts/legacy/base.py
@@ -169,9 +169,10 @@ class Hardware(FactsBase):
             self.facts["cpu_utilization"] = self.parse_cpu_utilization(data)
 
     def parse_cpu_utilization(self, data):
-        onemin = data.get("onemin_percent", 0)
-        if isinstance(onemin, list):
-            onemin = onemin[1]
+        onemin = data.get("onemin_percent", ["0"])
+        if not isinstance(onemin, list):
+            onemin = [str(onemin)]
+        onemin_value = onemin[0]
         return {
             "core": {
                 "five_minutes": int(data.get("fivemin_percent", 0)),
@@ -181,7 +182,7 @@ class Hardware(FactsBase):
                 "five_seconds_interrupt": int(
                     data.get("fivesec_intr_percent", 0),
                 ),
-                "one_minute": int(onemin),
+                "one_minute": int(onemin_value),
             },
         }
 

--- a/plugins/module_utils/network/nxos/facts/legacy/base.py
+++ b/plugins/module_utils/network/nxos/facts/legacy/base.py
@@ -169,8 +169,8 @@ class Hardware(FactsBase):
             self.facts["cpu_utilization"] = self.parse_cpu_utilization(data)
 
     def parse_cpu_utilization(self, data):
-        onemin = data.get("onemin_percent",0)
-        if(isinstance(onemin,list)):
+        onemin = data.get("onemin_percent", 0)
+        if (isinstance(onemin, list)):
             onemin = onemin[1]
         return {
             "core": {

--- a/plugins/module_utils/network/nxos/facts/legacy/base.py
+++ b/plugins/module_utils/network/nxos/facts/legacy/base.py
@@ -169,7 +169,7 @@ class Hardware(FactsBase):
             self.facts["cpu_utilization"] = self.parse_cpu_utilization(data)
 
     def parse_cpu_utilization(self, data):
-        onemin = data.get(data.get("onemin_percent"))
+        onemin = data.get("onemin_percent",0)
         if isinstance(onemin, list):
             onemin = onemin[1]
         return {

--- a/plugins/module_utils/network/nxos/facts/legacy/base.py
+++ b/plugins/module_utils/network/nxos/facts/legacy/base.py
@@ -169,6 +169,9 @@ class Hardware(FactsBase):
             self.facts["cpu_utilization"] = self.parse_cpu_utilization(data)
 
     def parse_cpu_utilization(self, data):
+        onemin = data.get(data.get("onemin_percent"))
+        if(isinstance(onemin,list)):
+            onemin = onemin[1]
         return {
             "core": {
                 "five_minutes": int(data.get("fivemin_percent", 0)),
@@ -178,7 +181,7 @@ class Hardware(FactsBase):
                 "five_seconds_interrupt": int(
                     data.get("fivesec_intr_percent", 0),
                 ),
-                "one_minute": int(data.get("onemin_percent", 0)),
+                "one_minute": int(onemin),
             },
         }
 

--- a/plugins/module_utils/network/nxos/facts/legacy/base.py
+++ b/plugins/module_utils/network/nxos/facts/legacy/base.py
@@ -170,7 +170,7 @@ class Hardware(FactsBase):
 
     def parse_cpu_utilization(self, data):
         onemin = data.get("onemin_percent", 0)
-        if (isinstance(onemin, list)):
+        if isinstance(onemin, list):
             onemin = onemin[1]
         return {
             "core": {

--- a/tests/integration/targets/nxos_facts/vars/main.yml
+++ b/tests/integration/targets/nxos_facts/vars/main.yml
@@ -29,3 +29,5 @@ available_network_resources:
   - telemetry
   - vlans
   - vrf_global
+  - vrf_interfaces
+  - vrf_address_family


### PR DESCRIPTION
##### SUMMARY
Fixes #915 
Fixed nxos_facts gathering for hardware subset where CPU utilization parsing fails on NX-OS 9.3(3).
The issue occurs because NX-OS 9.3(3) returns CPU metrics differently than newer versions:
- NX-OS 9.3(3): `onemin_percent` is a list `["13", "12"]` 
- NX-OS 10.4+: Uses separate `onemin_percent` and `fivemin_percent` fields
-
##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
nxos_facts



