### PR TITLE
fix None value handling in l2 interfaces

### DIFF
--- a/changelogs/fragments/nxos_l2_interfaces.yaml
+++ b/changelogs/fragments/nxos_l2_interfaces.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "nxos_l2_interfaces - Fixed handling of 'none' value in allowed_vlans to properly set trunk VLAN none"

--- a/plugins/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
@@ -145,9 +145,13 @@ class L2_interfaces(ConfigBase):
             return None
         if "trunk" in d and d["trunk"]:
             if "allowed_vlans" in d["trunk"]:
-                allowed_vlans = vlan_range_to_list(d["trunk"]["allowed_vlans"])
-                vlans_list = [str(line) for line in sorted(allowed_vlans)]
-                d["trunk"]["allowed_vlans"] = ",".join(vlans_list)
+                if d["trunk"]["allowed_vlans"]:
+                    if d["trunk"]["allowed_vlans"].lower() == "none":
+                        return
+                    else:
+                        allowed_vlans = vlan_range_to_list(d["trunk"]["allowed_vlans"])
+                        vlans_list = [str(line) for line in sorted(allowed_vlans)]
+                        d["trunk"]["allowed_vlans"] = ",".join(vlans_list)
 
     def set_state(self, want, have):
         """Select the appropriate function based on the state provided
@@ -347,5 +351,8 @@ class L2_interfaces(ConfigBase):
             )
             if match:
                 data = match.groupdict()
-                unparsed = vlan_list_to_range(data["vlans"].split(","))
+                if data["vlans"].lower() != "none":
+                    unparsed = vlan_list_to_range(data["vlans"].split(","))
+                else:
+                    unparsed = "none"
                 cmds[idx] = data["cmd"] + " " + unparsed

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/_populate_config.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/_populate_config.yaml
@@ -17,3 +17,12 @@
     parents: "interface {{ nxos_int2 }}"
   vars:
     ansible_connection: ansible.netcommon.network_cli
+
+- name: Set VLAN trunking properties with "none"
+  cisco.nxos.nxos_config:
+    lines:
+      - "switchport"
+      - "switchport trunk allowed vlan none"
+    parents: "interface {{ nxos_int3 }}"
+  vars:
+    ansible_connection: ansible.netcommon.network_cli

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/replaced.yaml
@@ -2,10 +2,11 @@
 - ansible.builtin.debug:
     msg: Start nxos_l2_interfaces replaced integration tests connection={{ ansible_connection }}
 
-- name: Set a fact for 'test_int1' and 'test_int2'
+- name: Set a fact for 'test_int1','test_int2'name and 'test_int3'
   ansible.builtin.set_fact:
     test_int1: "{{ nxos_int1 }}"
     test_int2: "{{ nxos_int2 }}"
+    test_int3: "{{ nxos_int3 }}"
 
 - name: Setup1
   ignore_errors: true
@@ -13,6 +14,7 @@
     lines:
       - "default interface {{ test_int1 }}"
       - "default interface {{ test_int2 }}"
+      - "default interface {{ test_int3 }}"
 
 - block:
     - name: Setup2
@@ -29,6 +31,13 @@
           - "switchport trunk native vlan 15"
           - "switchport trunk allowed vlan 25-27"
         parents: "interface {{ test_int2 }}"
+
+    - name: Setup4
+      cisco.nxos.nxos_config:
+        lines:
+          - "switchport"
+          - "switchport trunk allowed vlan 100-200"
+        parents: "interface {{ test_int3 }}"
 
     - name: Gather l2_interfaces facts
       cisco.nxos.nxos_facts: &id001
@@ -50,6 +59,10 @@
           - name: "{{ test_int2 }}"
             trunk:
               allowed_vlans: 25-27
+
+          - name: "{{ test_int3 }}"
+            trunk:
+              allowed_vlans: none
         state: replaced
 
     - ansible.builtin.assert:
@@ -60,7 +73,9 @@
           - "'switchport trunk allowed vlan 10-12' in result.commands"
           - "'interface {{ test_int2 }}' in result.commands"
           - "'no switchport trunk native vlan' in result.commands"
-          - result.commands|length == 5
+          - "'interface {{ test_int3 }}' in result.commands"
+          - "'switchport trunk allowed vlan none' in result.commands"
+          - result.commands|length == 7
 
     - name: Gather l2_interfaces post facts
       cisco.nxos.nxos_facts: *id001


### PR DESCRIPTION
##### SUMMARY
Fixes handling of "none" value in allowed_vlans configuration for nxos_l2_interfaces module. Currently, when configuring allowed_vlans: none with state: replaced, the module either fails with int conversion error or removes the VLAN configuration entirely, making the port allow all VLANs instead of setting it to none.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
cisco.nxos.nxos_l2_interfaces




