### PR TITLE
Fixes nxos vpc failed to get kickstart_ver_str

### DIFF
--- a/changelogs/fragments/bug_nxos_vpc.yaml
+++ b/changelogs/fragments/bug_nxos_vpc.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - nxos_vpc - Fixes an error where failed to gather facts for kickstart_ver_str

--- a/plugins/modules/nxos_vpc.py
+++ b/plugins/modules/nxos_vpc.py
@@ -220,7 +220,7 @@ def get_auto_recovery_default(module):
         auto = True
     elif re.search(r"N9K", pid):
         data = run_commands(module, ["show hardware | json"])[0]
-        ver = data["kickstart_ver_str"]
+        ver = data.get("kickstart_ver_str", "")
         if re.search(r"7.0\(3\)F", ver):
             auto = True
 


### PR DESCRIPTION
##### SUMMARY
Fixes nxos vpc failed to get kickstart_ver_str

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
- nxos_vpc
