### PR TITLE
fixes a bug in cisco.nxos.nxos_vlans after return var

### DIFF
--- a/changelogs/fragments/nxos_vlans_after_regex.yaml
+++ b/changelogs/fragments/nxos_vlans_after_regex.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cisco.nxos.nxos_vlans - fix vlans regex pattern that ignores vlans missing a name, even though the vlan has a vn-segment. (https://github.com/ansible-collections/cisco.nxos/pull/938).

--- a/plugins/module_utils/network/nxos/facts/vlans/vlans.py
+++ b/plugins/module_utils/network/nxos/facts/vlans/vlans.py
@@ -188,7 +188,7 @@ class VlansFacts(object):
                 # Sample match lines
                 # 202\n  name Production-Segment-100101\n  vn-segment 100101
                 # 5\n  state suspend\n  shutdown\n  name test-changeme\n  vn-segment 942
-                pattern = r"^{0}\s+\S.*vn-segment".format(v["vlan_id"])
+                pattern = r"^{0}\s+.*vn-segment".format(v["vlan_id"])
                 if re.search(pattern, item, flags=re.DOTALL):
                     vlan["run_cfg"] = item
                     break

--- a/tests/unit/modules/network/nxos/fixtures/nxos_vlans/show_running-config
+++ b/tests/unit/modules/network/nxos/fixtures/nxos_vlans/show_running-config
@@ -1,6 +1,8 @@
 vlan 1,3-5,8
 vlan 3
   name test-vlan3
+vlan 4
+  vn-segment 402
 vlan 5
   shutdown
   name test-changeme


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
regex pattern did not work when the 'name' was missing from a vlan adds fixture to show_running_config with this scenario for future tests
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cisco.nxos.nxos_vlans
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
vlan 200
  vn-segment 200

after: { "vlan_id": 200, "mapped_vni": 200}
```
