### PR TITLE
Fix issue where Not sufficient TCAM bank error not being captured by error regex

### DIFF
--- a/changelogs/fragments/acls_fix.yml
+++ b/changelogs/fragments/acls_fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - nxos_acls - Fix issue where Not sufficient TCAM bank error not being captured by error regex.

--- a/plugins/terminal/nxos.py
+++ b/plugins/terminal/nxos.py
@@ -64,6 +64,7 @@ class TerminalModule(TerminalBase):
         ),
         re.compile(rb"No corresponding (.+) configured", re.I),
         re.compile(rb"(.+)please specify sequence number", re.I),
+        re.compile(rb"(.+sufficient free entries are not available in tcam bank.*)", re.I)
     ]
 
     terminal_config_prompt = re.compile(r"^.*\((?!maint-mode).*\)#$")


### PR DESCRIPTION
##### SUMMARY
Fix issue where Not sufficient TCAM bank error not being captured by error regex.

This PR aims to fix this by adding an error regex to capture this error and report it correctly.

##### ISSUE TYPE
- Bugfix Pull Request
- 
##### COMPONENT NAME
- `terminal/nxos.py`

##### ADDITIONAL INFORMATION
Resource module for cisco nxos acls does not report error message when tcam utilization has reached its maximum.
Error:
```sh
Sufficient free entries are not available in TCAM bank
```


