### PR TITLE
FIX: no duplex command before no speed

### DIFF
--- a/changelogs/fragments/interfaces.yml
+++ b/changelogs/fragments/interfaces.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - interfaces: 'This change avoids error that occurs when duplex is set and speed is auto'
+  - interfaces: "This change avoids error that occurs when duplex is set and speed is auto"

--- a/changelogs/fragments/interfaces.yml
+++ b/changelogs/fragments/interfaces.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - interfaces: 'This change avoids error that occurs when duplex is set and speed is auto'

--- a/plugins/module_utils/network/nxos/config/interfaces/interfaces.py
+++ b/plugins/module_utils/network/nxos/config/interfaces/interfaces.py
@@ -377,10 +377,10 @@ class Interfaces(ConfigBase):
             commands.append(no_cmd + "switchport")
         if "description" in obj:
             commands.append("no description")
-        if "speed" in obj:
-            commands.append("no speed")
         if "duplex" in obj:
             commands.append("no duplex")
+        if "speed" in obj:
+            commands.append("no speed")
         if "enabled" in obj:
             sysdef_enabled = self.default_enabled(have=obj, action="delete")
             if obj["enabled"] is False and sysdef_enabled is True:


### PR DESCRIPTION
##### SUMMARY
Change the order of removal for `speed` and `duplex` options to comply with Nexus platform constraints.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request  
Error occurs when attempting to remove `duplex` before `speed`:  
`ERROR: Duplex cannot be configured when speed is auto`

- Docs Pull Request

On Cisco Nexus devices, attempting to configure duplex mode (full/half) results in an error if the interface speed is not manually set.  
Duplex mode can only be configured when the interface speed is **not set to `auto`**.

This is due to the fact that **autonegotiation**, which is enabled by default when `speed auto` is set, handles both speed and duplex settings.  
Therefore, if `speed` is left in auto mode, the duplex is negotiated automatically and cannot be manually overridden.

- Feature Pull Request  
Change the order of removal for `speed` and `duplex` options to prevent configuration errors.

##### COMPONENT NAME
nxos_duplex

##### ADDITIONAL INFORMATION
This change avoids the following error that occurs when `duplex` is removed before `speed`:

```bash
ERROR: Duplex cannot be configured when speed is auto
