### PR TITLE
Explicitly setting *secondary: false* on l3_interface results in change

### DIFF
--- a/plugins/module_utils/network/nxos/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/nxos/config/l3_interfaces/l3_interfaces.py
@@ -269,8 +269,10 @@ class L3_interfaces(ConfigBase):
         # Normalize inputs (add tag key if not present)
         for i in want:
             i["tag"] = i.get("tag")
+            i["secondary"] = i.get("secondary", False)
         for i in have:
             i["tag"] = i.get("tag")
+            i["secondary"] = i.get("secondary", False)
 
         merged = True if state == "merged" else False
         replaced = True if state == "replaced" else False


### PR DESCRIPTION
##### SUMMARY

When diffing the want and have for an IPv4 address, if the user has explicitly set secondary to false the diff result will always be truthy and result in a "change".  Like *tag* this change sets a the default value for secondary on both want and have such that the diff will work as expected.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

cisco.nxos.nxos_l3_interfaces
