### PR TITLE
add typing_extensions in test_requirements.txt

### DIFF
--- a/changelogs/fragments/fix_ci.yaml
+++ b/changelogs/fragments/fix_ci.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - add missing dependency typing-extensions to test-requirements.txt

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,3 +5,4 @@ virl2-client==2.6.1
 pytest-ansible
 pytest-xdist
 pytest-cov
+typing-extensions


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The upstream CI is failing due to a missing dependency required by pytest-ansible for testing Ansible collections. This PR fixes that error and is consistent across all our collections.
`ModuleNotFoundError: No module named 'typing_extensions'`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- CI fix Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
https://github.com/ansible-collections/cisco.nxos/actions/runs/15914933171/job/44890627340
```
