### PR TITLE
Issue #974 Interface Enable State Idempotency

### DIFF
--- a/plugins/module_utils/network/nxos/config/interfaces/interfaces.py
+++ b/plugins/module_utils/network/nxos/config/interfaces/interfaces.py
@@ -31,14 +31,14 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.u
 from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.facts.facts import (
     Facts,
 )
+from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.nxos import (
+    default_intf_enabled,
+)
 from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.rm_templates.interfaces import (
     InterfacesTemplate,
 )
 from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.utils.utils import (
     normalize_interface,
-)
-from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.nxos import (
-    default_intf_enabled,
 )
 
 

--- a/plugins/module_utils/network/nxos/rm_templates/interfaces.py
+++ b/plugins/module_utils/network/nxos/rm_templates/interfaces.py
@@ -68,7 +68,7 @@ class InterfacesTemplate(NetworkTemplate):
             "setval": "shutdown",
             "result": {
                 '{{ name }}': {
-                    'enabled': "{{ False if shutdown is defined and negate is not defined else True }}",
+                    'enabled': "{{ True if negate is defined and shutdown is defined else False if shutdown is defined else None }}",
                 },
             },
         },

--- a/tests/unit/modules/network/nxos/test_nxos_interfaces.py
+++ b/tests/unit/modules/network/nxos/test_nxos_interfaces.py
@@ -451,15 +451,12 @@ class TestNxosInterfacesModule(TestNxosModule):
         )
         merged = [
             "interface Ethernet1/1",
-            "no shutdown",
             "no switchport",
             "interface Ethernet1/2",
             "shutdown",
             "interface loopback1",
             "shutdown",
             "interface loopback2",
-            "no shutdown",
-            "interface loopback3",
             "no shutdown",
             "interface port-channel3",
             "no shutdown",
@@ -474,6 +471,11 @@ class TestNxosInterfacesModule(TestNxosModule):
         self.assertEqual(sorted(result["commands"]), sorted(merged))
 
         # Test with an older image version which has different defaults
+        self.exec_get_defaults.return_value = {
+            "default_mode": "layer2",
+            "L2_enabled": False,
+        }
+
         merged_legacy = [
             "interface Ethernet1/1",
             "no shutdown",
@@ -484,8 +486,6 @@ class TestNxosInterfacesModule(TestNxosModule):
             "shutdown",
             "interface loopback2",
             "no shutdown",
-            "interface loopback3",
-            "no shutdown",
             "interface port-channel3",
             "no shutdown",
             "interface loopback4",
@@ -493,12 +493,16 @@ class TestNxosInterfacesModule(TestNxosModule):
             "interface port-channel4",
             "no shutdown",
         ]
-        result = self.execute_module(changed=True, device="legacy")
+        result = self.execute_module(changed=True)
         self.assertEqual(sorted(result["commands"]), sorted(merged_legacy))
 
         deleted = [
             "interface Ethernet1/2",
             "switchport",
+            "shutdown",
+            "interface loopback1",
+            "shutdown",
+            "interface loopback3",
             "shutdown",
         ]
         playbook["state"] = "deleted"
@@ -515,8 +519,6 @@ class TestNxosInterfacesModule(TestNxosModule):
             "interface Ethernet1/2",
             "shutdown",
             "interface loopback2",
-            "no shutdown",
-            "interface loopback3",
             "no shutdown",
             "interface port-channel3",
             "no shutdown",


### PR DESCRIPTION
##### SUMMARY

v10.2.0 removed the use of `module_utils.network.nxos.nxos.default_intf_enabled()` to determine the targets default state of various interface types.

This change re-instates that behaviour, to resolve idempotency issues.  Tests are adjusted to suit.

Fixes #974

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Module: interfaces

