### PR TITLE
Issue #988: Make l2_interfaces `mode: access` idempotent

### DIFF
--- a/plugins/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
@@ -18,9 +18,8 @@ necessary to bring the current configuration to its desired end-state is
 created.
 """
 
-from ansible.module_utils.six import iteritems
 from ansible.errors import AnsibleError
-
+from ansible.module_utils.six import iteritems
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.rm_base.resource_module import (
     ResourceModule,
 )
@@ -87,10 +86,8 @@ class L2_interfaces(ResourceModule):
                 raise AnsibleError(
                     "Interface %s is not available on the target device or it is "
                     "not configured as a Layer2 interface. Use the nxos_interfaces "
-                    "module to first configure the interface as a layer2 interface"
-                    %(name,)
+                    "module to first configure the interface as a layer2 interface" % (name,),
                 )
-
 
         for each in wantd, haved:
             self.process_list_attrs(each)
@@ -128,7 +125,6 @@ class L2_interfaces(ResourceModule):
 
         if len(self.commands) != begin:
             self.commands.insert(begin, self._tmplt.render(want or have, "name", False))
-
 
     def _compare_lists(self, want, have):
         """Compare list attributes"""

--- a/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
@@ -23,12 +23,11 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common i
 from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.argspec.l2_interfaces.l2_interfaces import (
     L2_interfacesArgs,
 )
-from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.rm_templates.l2_interfaces import (
-    L2_interfacesTemplate,
-)
-
 from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.nxos import (
     default_intf_layer,
+)
+from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.rm_templates.l2_interfaces import (
+    L2_interfacesTemplate,
 )
 
 
@@ -77,17 +76,19 @@ class L2_interfacesFacts(object):
         """Only include layer 2 interfaces in layer 2 facts"""
 
         for o in parsed_config:
-            print("detected layer %s for %s" %(
-                o.get('layer', default_intf_layer(o.get("name"), sysdefault)),
-                o.get("name")
-
-            ))
+            print(
+                "detected layer %s for %s"
+                % (
+                    o.get("layer", default_intf_layer(o.get("name"), sysdefault)),
+                    o.get("name"),
+                ),
+            )
 
         return [
-            o for o in parsed_config
+            o
+            for o in parsed_config
             if o.pop("layer", default_intf_layer(o.get("name"), sysdefault)) == "layer2"
         ]
-
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """Populate the facts for L2_interfaces network resource
@@ -112,7 +113,7 @@ class L2_interfacesFacts(object):
         objs = self._fix_allowed_vlans(objs)
         objs = self._set_default_mode_access(objs)
 
-        print("layer 2 objs: %s" %(objs,))
+        print("layer 2 objs: %s" % (objs,))
 
         ansible_facts["ansible_network_resources"].pop("l2_interfaces", None)
 
@@ -138,4 +139,3 @@ class L2_interfacesFacts(object):
         match = re.search(pat, switchport_data, re.MULTILINE)
         if match:
             return "layer3" if "no " in match.groups() else "layer2"
-

--- a/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
@@ -14,6 +14,7 @@ It is in this file the configuration is collected from the device
 for a given resource, parsed, and the facts tree is populated
 based on the configuration.
 """
+import re
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     utils,
@@ -26,6 +27,10 @@ from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.rm_templat
     L2_interfacesTemplate,
 )
 
+from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.nxos import (
+    default_intf_layer,
+)
+
 
 class L2_interfacesFacts(object):
     """The nxos l2_interfaces facts class"""
@@ -33,6 +38,13 @@ class L2_interfacesFacts(object):
     def __init__(self, module, subspec="config", options="options"):
         self._module = module
         self.argument_spec = L2_interfacesArgs.argument_spec
+
+    def _get_switchport_defaults(self, connection):
+        """Get the default port mode from the platform when switchport is not shown in the running-config"""
+
+        return connection.get(
+            "show running-config all | incl 'system default switchport'",
+        )
 
     def _get_interface_config(self, connection):
         return connection.get("show running-config | section ^interface")
@@ -48,6 +60,34 @@ class L2_interfacesFacts(object):
                 trunk["allowed_vlans"] = ",".join(map(str, allowed_vlans))
 
         return parsed_config
+
+    def _set_default_mode_access(self, parsed_config):
+        """show running-config does not show `switchport mode access` when ports are access ports
+        set the mode to `access` if the mode doesnt exist
+        """
+
+        for interface in parsed_config:
+            mode = interface.get("mode", None)
+            if mode is None:
+                interface["mode"] = "access"
+
+        return parsed_config
+
+    def _filter_non_layer2(self, parsed_config, sysdefault):
+        """Only include layer 2 interfaces in layer 2 facts"""
+
+        for o in parsed_config:
+            print("detected layer %s for %s" %(
+                o.get('layer', default_intf_layer(o.get("name"), sysdefault)),
+                o.get("name")
+
+            ))
+
+        return [
+            o for o in parsed_config
+            if o.pop("layer", default_intf_layer(o.get("name"), sysdefault)) == "layer2"
+        ]
+
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """Populate the facts for L2_interfaces network resource
@@ -68,14 +108,18 @@ class L2_interfacesFacts(object):
         # parse native config using the L2_interfaces template
         l2_interfaces_parser = L2_interfacesTemplate(lines=data.splitlines(), module=self._module)
         objs = list(l2_interfaces_parser.parse().values())
-        final_objs = self._fix_allowed_vlans(objs)
+        objs = self._filter_non_layer2(objs, self.get_default_interface_layer(connection))
+        objs = self._fix_allowed_vlans(objs)
+        objs = self._set_default_mode_access(objs)
+
+        print("layer 2 objs: %s" %(objs,))
 
         ansible_facts["ansible_network_resources"].pop("l2_interfaces", None)
 
         params = utils.remove_empties(
             l2_interfaces_parser.validate_config(
                 self.argument_spec,
-                {"config": final_objs},
+                {"config": objs},
                 redact=True,
             ),
         )
@@ -84,3 +128,14 @@ class L2_interfacesFacts(object):
         ansible_facts["ansible_network_resources"].update(facts)
 
         return ansible_facts
+
+    def get_default_interface_layer(self, connection):
+        """Determines if an interface is currently operating at layer 2 or 3"""
+        switchport_data = self._get_switchport_defaults(connection)
+
+        # Layer 2/3 mode defaults
+        pat = "(no )*system default switchport$"
+        match = re.search(pat, switchport_data, re.MULTILINE)
+        if match:
+            return "layer3" if "no " in match.groups() else "layer2"
+

--- a/plugins/module_utils/network/nxos/nxos.py
+++ b/plugins/module_utils/network/nxos/nxos.py
@@ -986,9 +986,31 @@ def get_interface_type(interface):
         return "portchannel"
     elif interface.upper().startswith("NV"):
         return "nve"
-    else:
-        return "unknown"
 
+    return "unknown"
+
+def default_intf_layer(name="", default=None):
+    """Get the default layer for an interface based on type and provided system
+    default configuration
+    """
+
+    if not name:
+        return None
+
+    name = normalize_interface(name)
+    iftype = get_interface_type(name)
+    resubintf = re.compile(r"\d+\.\d+$")
+
+    if iftype in ("ethernet", "portchannel"):
+        if re.search(r"\d+\.\d+$", name):
+            # sub interfaces are layer 3
+            return "layer3"
+        return default
+
+    if iftype in ("svi", "loopback", "management", "nve"):
+        return "layer3"
+
+    return default
 
 def default_intf_enabled(name="", sysdefs=None, mode=None):
     """Get device/version/interface-specific default 'enabled' state.

--- a/plugins/module_utils/network/nxos/nxos.py
+++ b/plugins/module_utils/network/nxos/nxos.py
@@ -989,6 +989,7 @@ def get_interface_type(interface):
 
     return "unknown"
 
+
 def default_intf_layer(name="", default=None):
     """Get the default layer for an interface based on type and provided system
     default configuration
@@ -1011,6 +1012,7 @@ def default_intf_layer(name="", default=None):
         return "layer3"
 
     return default
+
 
 def default_intf_enabled(name="", sysdefs=None, mode=None):
     """Get device/version/interface-specific default 'enabled' state.

--- a/plugins/module_utils/network/nxos/rm_templates/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/rm_templates/l2_interfaces.py
@@ -43,6 +43,21 @@ class L2_interfacesTemplate(NetworkTemplate):
             },
             "shared": True,
         },
+        {  # only applicable for switches
+            "name": "layer",
+            "getval": re.compile(
+                r"""
+                (?P<negate>\s+no)?
+                (?P<switchport>\s+switchport)
+                $""", re.VERBOSE,
+            ),
+            "setval": "",
+            "result": {
+                '{{ name }}': {
+                    'layer': "{{ 'layer3' if negate is defined and switchport is defined else 'layer2' if switchport is defined else None }}",
+                },
+            },
+        },
         {
             "name": "mode",
             "getval": re.compile(

--- a/plugins/modules/nxos_l2_interfaces.py
+++ b/plugins/modules/nxos_l2_interfaces.py
@@ -62,9 +62,6 @@ options:
       mode:
         description:
         - Mode in which interface needs to be configured.
-        - Access mode is not shown in interface facts, so idempotency will not be
-          maintained for switchport mode access and every time the output will come
-          as changed=True.
         type: str
         choices:
         - dot1q-tunnel

--- a/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
+++ b/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
@@ -68,7 +68,7 @@ class TestNxosL2InterfacesModule(TestNxosModule):
             """
             system default switchport
             system default switchport shutdown
-            """
+            """,
         )
 
     def tearDown(self):
@@ -114,7 +114,7 @@ class TestNxosL2InterfacesModule(TestNxosModule):
             ),
         )
 
-        with pytest.raises(AnsibleError, match=r'^Interface Vlan10 is not available.+'):
+        with pytest.raises(AnsibleError, match=r"^Interface Vlan10 is not available.+"):
             self.execute_module(changed=True)
 
     def test_l2_interfaces_gathered(self):

--- a/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
+++ b/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
@@ -19,6 +19,10 @@
 
 from __future__ import absolute_import, division, print_function
 
+import pytest
+
+from ansible.errors import AnsibleError
+
 
 __metaclass__ = type
 
@@ -52,12 +56,66 @@ class TestNxosL2InterfacesModule(TestNxosModule):
         )
         self.execute_show_command = self.mock_execute_show_command.start()
 
+        self.mock_execute_system_defaults_command = patch(
+            "ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.facts.l2_interfaces.l2_interfaces."
+            "L2_interfacesFacts._get_switchport_defaults",
+        )
+        self.execute_system_defaults_command = self.mock_execute_system_defaults_command.start()
+
         self.maxDiff = None
+
+        self.execute_system_defaults_command.return_value = dedent(
+            """
+            system default switchport
+            system default switchport shutdown
+            """
+        )
 
     def tearDown(self):
         super(TestNxosL2InterfacesModule, self).tearDown()
         self.mock_get_resource_connection_facts.stop()
         self.mock_execute_show_command.stop()
+        self.mock_execute_system_defaults_command.stop()
+
+    def test_l2_attempt_to_configure_l3(self):
+        self.execute_show_command.return_value = dedent(
+            """
+            interface Ethernet1/6
+             switchport
+             switchport mode trunk
+             switchport access vlan 20
+             switchport trunk native vlan 40
+             switchport trunk allowed vlan 30-45,47
+            interface Vlan10
+             description A layer3 interface
+             no shutdown
+            """,
+        )
+
+        set_module_args(
+            dict(
+                config=[
+                    {
+                        "name": "Ethernet1/6",
+                        "mode": "trunk",
+                        "trunk": {
+                            "allowed_vlans": "10-12",
+                        },
+                    },
+                    {
+                        "name": "Vlan10",
+                        "mode": "trunk",
+                        "trunk": {
+                            "allowed_vlans": "10-12",
+                        },
+                    },
+                ],
+                state="merged",
+            ),
+        )
+
+        with pytest.raises(AnsibleError, match=r'^Interface Vlan10 is not available.+'):
+            self.execute_module(changed=True)
 
     def test_l2_interfaces_gathered(self):
         self.execute_show_command.return_value = dedent(
@@ -105,6 +163,7 @@ class TestNxosL2InterfacesModule(TestNxosModule):
             },
             {
                 "name": "Ethernet1/4",
+                "mode": "access",
             },
         ]
 
@@ -125,13 +184,24 @@ class TestNxosL2InterfacesModule(TestNxosModule):
                      switchport mode dot1q-tunnel
                     interface Ethernet1/800
                      switchport access vlan 18
-                     switchport trunk allowed vlan 210
                     interface Ethernet1/801
-                     switchport trunk allowed vlan 2,4,15
+                     switchport mode trunk
+                     switchport trunk allowed vlan 210
                     interface Ethernet1/802
-                     switchport mode fex-fabric
+                     switchport mode trunk
+                     switchport trunk allowed vlan 2,4,15
                     interface Ethernet1/803
+                     switchport mode fex-fabric
+                    interface Ethernet1/804
                      switchport mode fabricpath
+                    interface Ethernet1/810
+                     no switchport
+                    interface Ethernet1/810.10
+                     ip address 10.1.1.1/24
+                     no shutdown
+                    interface Vlan10
+                     ip address 10.1.2.1/24
+                     no shutdown
                     interface loopback1
                     """,
                 ),
@@ -141,37 +211,37 @@ class TestNxosL2InterfacesModule(TestNxosModule):
 
         expected = [
             {
-                "name": "nve1",
-            },
-            {
                 "mode": "dot1q-tunnel",
                 "name": "Ethernet1/799",
             },
             {
+                "name": "Ethernet1/800",
+                "mode": "access",
                 "access": {
                     "vlan": 18,
                 },
-                "name": "Ethernet1/800",
+            },
+            {
+                "name": "Ethernet1/801",
+                "mode": "trunk",
                 "trunk": {
                     "allowed_vlans": "210",
                 },
             },
             {
-                "name": "Ethernet1/801",
+                "name": "Ethernet1/802",
+                "mode": "trunk",
                 "trunk": {
                     "allowed_vlans": "2,4,15",
                 },
             },
             {
                 "mode": "fex-fabric",
-                "name": "Ethernet1/802",
-            },
-            {
-                "mode": "fabricpath",
                 "name": "Ethernet1/803",
             },
             {
-                "name": "loopback1",
+                "mode": "fabricpath",
+                "name": "Ethernet1/804",
             },
         ]
 


### PR DESCRIPTION
This change does the following:

* detects where the mode is access by default and reports it in the facts
* it limits operations to interfaces which are configured as layer2 interfaces

By augmenting the facts with `mode: access` where it was not previously, the use of `mode: access` becomes idempotent.

BREAKING:  If an input configuration is supplied that attempts to apply L2 configuration to an interface that is L3 (or doesn't exist), an exception will be raised telling the user that they should use `nxos_interfaces` to first configure the interface for L2.

Fixes: #988

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME

nxos_l2_interfaces 
