### PR TITLE
Fix AF detection logic

### DIFF
--- a/plugins/module_utils/network/nxos/config/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/nxos/config/bgp_global/bgp_global.py
@@ -408,8 +408,8 @@ class Bgp_global(ResourceModule):
                     # we are inspecting neighbor within a VRF
                     # if the given neighbor has AF we return True
                     has_af = True
-                else:
-                    # we are inspecting VRF as a whole
+                elif not neighbor:
+                    # we are inspecting only VRF as a whole
                     # if there is at least one neighbor
                     # with AF or VRF has AF itself return True
                     if vrf_nbr_has_af or vrf_has_af:


### PR DESCRIPTION


This should be the ideal so that the device is not left with invalid configuration and the user change the setting more granularly.

##### SUMMARY
Now VRF removal will fail if the VRF has AF and any of it's neighbors have AF. Neighbor removal will fail if it itself has AF. But neighbor removal will succeed if the neighbor doesn't have AF.7

Fixes #1017 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_bgp_global

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Now if you have configuration like this: (notice the neighbor has already the AF removed )
```
router bgp 64421
  vrf mmsc_radius
    local-as 4194304237
    address-family ipv4 unicast
      maximum-paths 32
    neighbor 10.107.5.177
      remote-as 4194304236
      description bgp peer vlan 621 - leaf_switch_a_id 301
      address-family ipv4 unicast
        send-community
    neighbor 10.107.5.178
      remote-as 4194304236
      description bgp peer vlan 621 - leaf_switch_b_id 302
```

You can remove the neighbor by running:
```
  tasks:
    - name: Only set one VRF with one neighbor
      cisco.nxos.nxos_bgp_global:
        state: replaced
        config:
          as_number: 64421
          vrfs:
            - vrf: mmsc_radius
              local_as: 4194304237
              neighbors:
                - neighbor_address: 10.107.5.177
                  description: bgp peer vlan 621 - leaf_switch_a_id 301
                  remote_as: 4194304236
```

