### PR TITLE
Bump netcommon dependency from 8.1.0 to 8.5.1

### DIFF
--- a/changelogs/fragments/ci_enhancement.yaml
+++ b/changelogs/fragments/ci_enhancement.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Updated ansible.netcommon dependency minimum required version from >=8.1.0 to >=8.5.1.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 authors:
   - Ansible Network Community (ansible-network)
 dependencies:
-  "ansible.netcommon": ">=8.1.0"
+  "ansible.netcommon": ">=8.5.1"
 license_file: LICENSE
 name: nxos
 namespace: cisco


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
Netcommon dependency version is getting increased due to compatibility with ansible-2.21

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New module (adding a new module to the collection)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Collection release
- [x] CI maintenance
- [ ] Workflow maintenance
- [ ] Configuration change