### PR TITLE
Fix nxos_l2_interfaces to handle port-channel member   interfaces

### DIFF
--- a/changelogs/fragments/l2_interfaces_port_channel_member.yaml
+++ b/changelogs/fragments/l2_interfaces_port_channel_member.yaml
@@ -3,3 +3,9 @@ bugfixes:
   - nxos_l2_interfaces - Skip port-channel member interfaces during facts
     gathering and command generation. Member interfaces inherit L2 config
     from the port-channel and cannot be configured directly.
+breaking_changes:
+  - nxos_l2_interfaces - Port-channel member interfaces are now excluded
+    from gathered, parsed, and overridden/deleted states. Attempting to
+    configure L2 settings directly on a port-channel member via merged,
+    replaced, or deleted (with explicit config) states will now raise an
+    error. Apply L2 configuration on the port-channel interface instead.

--- a/changelogs/fragments/l2_interfaces_port_channel_member.yaml
+++ b/changelogs/fragments/l2_interfaces_port_channel_member.yaml
@@ -1,3 +1,5 @@
 ---
 bugfixes:
-  - nxos_l2_interfaces - Skip port-channel member interfaces during facts gathering and command generation. Member interfaces inherit L2 config from the port-channel and cannot be configured directly. The module now detects channel-group membership, filters members from gathered/parsed facts, and fails with a clear error message when users attempt to configure a member interface directly.
+  - nxos_l2_interfaces - Skip port-channel member interfaces during facts
+    gathering and command generation. Member interfaces inherit L2 config
+    from the port-channel and cannot be configured directly.

--- a/changelogs/fragments/l2_interfaces_port_channel_member.yaml
+++ b/changelogs/fragments/l2_interfaces_port_channel_member.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - nxos_l2_interfaces - Skip port-channel member interfaces during facts gathering and command generation. Member interfaces inherit L2 config from the port-channel and cannot be configured directly. The module now detects channel-group membership, filters members from gathered/parsed facts, and fails with a clear error message when users attempt to configure a member interface directly.

--- a/docs/cisco.nxos.nxos_l2_interfaces_module.rst
+++ b/docs/cisco.nxos.nxos_l2_interfaces_module.rst
@@ -120,7 +120,8 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>Enable/disable CDP on the interface</div>
+                        <div>Enable/disable CDP on the interface.</div>
+                        <div>For port-channel member interfaces, configure CDP on the port-channel interface as Ansible does not support configuring CDP directly on port-channel member interfaces.</div>
                 </td>
             </tr>
             <tr>

--- a/plugins/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
@@ -84,13 +84,31 @@ class L2_interfaces(ResourceModule):
         for each in wantd, haved:
             self.process_list_attrs(each)
 
+        # Rebuild dicts with normalized interface name keys
+        wantd = {val["name"]: val for val in wantd.values()}
+        haved = {val["name"]: val for val in haved.values()}
+
+        # Get port-channel members detected during facts gathering
+        pc_members = getattr(self._module, "_l2_pc_members", set())
+
+        user_provided_config = bool(wantd)
+
+        for intf_name in list(wantd.keys()):
+            if intf_name in pc_members:
+                self._module.fail_json(
+                    msg="Interface {0} is a port-channel member. "
+                    "L2 configuration cannot be applied directly on port-channel "
+                    "member interfaces. Apply the configuration on the "
+                    "port-channel interface instead.".format(intf_name),
+                )
+
         # if state is merged, merge want onto have and then compare
         if self.state == "merged":
             wantd = dict_merge(haved, wantd)
 
         # if state is deleted, empty out wantd and set haved to wantd
         if self.state == "deleted":
-            haved = {k: v for k, v in haved.items() if k in wantd or not wantd}
+            haved = {k: v for k, v in haved.items() if k in wantd or not user_provided_config}
             wantd = {}
 
         # remove superfluous config for overridden and deleted

--- a/plugins/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
@@ -35,7 +35,7 @@ from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.utils.util
     generate_switchport_trunk,
     normalize_interface,
     vlan_list_to_range,
-    vlan_range_to_list,
+    vlan_range_to_dict,
 )
 
 
@@ -201,7 +201,7 @@ class L2_interfaces(ResourceModule):
                     for vlan in ["allowed_vlans"]:
                         vlanList = val.get("trunk").get(vlan, [])
                         if vlanList and vlanList != "none":
-                            val["trunk"][vlan] = vlan_range_to_list(val.get("trunk").get(vlan))
+                            val["trunk"][vlan] = vlan_range_to_dict(val.get("trunk").get(vlan))
 
     def handle_cdp(self, want_cdp, have_cdp, parser, want):
         if want_cdp is None and have_cdp is None:

--- a/plugins/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
@@ -35,7 +35,7 @@ from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.utils.util
     generate_switchport_trunk,
     normalize_interface,
     vlan_list_to_range,
-    vlan_range_to_dict,
+    vlan_range_to_list,
 )
 
 
@@ -201,7 +201,7 @@ class L2_interfaces(ResourceModule):
                     for vlan in ["allowed_vlans"]:
                         vlanList = val.get("trunk").get(vlan, [])
                         if vlanList and vlanList != "none":
-                            val["trunk"][vlan] = vlan_range_to_dict(val.get("trunk").get(vlan))
+                            val["trunk"][vlan] = vlan_range_to_list(val.get("trunk").get(vlan))
 
     def handle_cdp(self, want_cdp, have_cdp, parser, want):
         if want_cdp is None and have_cdp is None:

--- a/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
@@ -51,7 +51,9 @@ class L2_interfacesFacts(object):
             return members
 
         for line in output.splitlines():
-            for match in re.finditer(r"(Eth(?:ernet)?\d+/\d+(?:/\d+)?)\([A-Za-z]+\)", line, re.IGNORECASE):
+            for match in re.finditer(
+                r"(Eth(?:ernet)?\d+/\d+(?:/\d+)?)\([A-Za-z]+\)", line, re.IGNORECASE
+            ):
                 members.add(normalize_interface(match.group(1)))
 
         return members

--- a/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
@@ -84,8 +84,8 @@ class L2_interfacesFacts(object):
 
         pc_members = get_port_channel_members(data)
         self._module._l2_pc_members = pc_members
-        final_objs = [
-            obj for obj in final_objs
+        objs = [
+            obj for obj in objs
             if normalize_interface(obj.get("name", "")) not in pc_members
         ]
 

--- a/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
@@ -42,6 +42,20 @@ class L2_interfacesFacts(object):
     def _get_interface_config(self, connection):
         return connection.get("show running-config | section ^interface")
 
+    def _get_port_channel_members_from_device(self, connection):
+        """Get port-channel member interfaces using 'show port-channel summary'."""
+        members = set()
+        try:
+            output = connection.get("show port-channel summary")
+        except Exception:
+            return members
+
+        for line in output.splitlines():
+            for match in re.finditer(r"(Eth(?:ernet)?\d+/\d+(?:/\d+)?)\([A-Za-z]+\)", line):
+                members.add(normalize_interface(match.group(1)))
+
+        return members
+
     def _default_for_allowed_vlans(self, parsed_config):
         """Handle default for allowed vlans"""
 
@@ -70,6 +84,7 @@ class L2_interfacesFacts(object):
         facts = {}
         objs = []
 
+        fetched_from_device = not data
         if not data:
             data = self._get_interface_config(connection)
 
@@ -82,7 +97,10 @@ class L2_interfacesFacts(object):
         # process defaults for allowed vlan
         self._default_for_allowed_vlans(objs)
 
-        pc_members = get_port_channel_members(data)
+        if fetched_from_device:
+            pc_members = self._get_port_channel_members_from_device(connection)
+        else:
+            pc_members = get_port_channel_members(data)
         self._module._l2_pc_members = pc_members
         objs = [
             obj for obj in objs

--- a/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
@@ -52,7 +52,9 @@ class L2_interfacesFacts(object):
 
         for line in output.splitlines():
             for match in re.finditer(
-                r"(Eth(?:ernet)?\d+/\d+(?:/\d+)?)\([A-Za-z]+\)", line, re.IGNORECASE
+                r"(Eth(?:ernet)?\d+/\d+(?:/\d+)?)\([A-Za-z]+\)",
+                line,
+                re.IGNORECASE,
             ):
                 members.add(normalize_interface(match.group(1)))
 

--- a/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
@@ -26,6 +26,10 @@ from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.argspec.l2
 from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.rm_templates.l2_interfaces import (
     L2_interfacesTemplate,
 )
+from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.utils.utils import (
+    get_port_channel_members,
+    normalize_interface,
+)
 
 
 class L2_interfacesFacts(object):
@@ -77,6 +81,13 @@ class L2_interfacesFacts(object):
 
         # process defaults for allowed vlan
         self._default_for_allowed_vlans(objs)
+
+        pc_members = get_port_channel_members(data)
+        self._module._l2_pc_members = pc_members
+        final_objs = [
+            obj for obj in final_objs
+            if normalize_interface(obj.get("name", "")) not in pc_members
+        ]
 
         ansible_facts["ansible_network_resources"].pop("l2_interfaces", None)
 

--- a/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
@@ -42,6 +42,7 @@ class L2_interfacesFacts(object):
     def _get_interface_config(self, connection):
         return connection.get("show running-config | section ^interface")
 
+<<<<<<< HEAD
     def _get_port_channel_members_from_device(self, connection):
         """Get port-channel member interfaces using 'show port-channel summary'."""
         members = set()
@@ -60,6 +61,8 @@ class L2_interfacesFacts(object):
 
         return members
 
+=======
+>>>>>>> ca131c49 (fixed test and config file)
     def _default_for_allowed_vlans(self, parsed_config):
         """Handle default for allowed vlans"""
 
@@ -88,7 +91,6 @@ class L2_interfacesFacts(object):
         facts = {}
         objs = []
 
-        fetched_from_device = not data
         if not data:
             data = self._get_interface_config(connection)
 
@@ -101,11 +103,7 @@ class L2_interfacesFacts(object):
         # process defaults for allowed vlan
         self._default_for_allowed_vlans(objs)
 
-        if fetched_from_device:
-            pc_members = self._get_port_channel_members_from_device(connection)
-            pc_members |= get_port_channel_members(data)
-        else:
-            pc_members = get_port_channel_members(data)
+        pc_members = get_port_channel_members(data)
         self._module._l2_pc_members = pc_members
         objs = [obj for obj in objs if normalize_interface(obj.get("name", "")) not in pc_members]
 

--- a/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
@@ -102,10 +102,7 @@ class L2_interfacesFacts(object):
         else:
             pc_members = get_port_channel_members(data)
         self._module._l2_pc_members = pc_members
-        objs = [
-            obj for obj in objs
-            if normalize_interface(obj.get("name", "")) not in pc_members
-        ]
+        objs = [obj for obj in objs if normalize_interface(obj.get("name", "")) not in pc_members]
 
         ansible_facts["ansible_network_resources"].pop("l2_interfaces", None)
 

--- a/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
@@ -51,7 +51,7 @@ class L2_interfacesFacts(object):
             return members
 
         for line in output.splitlines():
-            for match in re.finditer(r"(Eth(?:ernet)?\d+/\d+(?:/\d+)?)\([A-Za-z]+\)", line):
+            for match in re.finditer(r"(Eth(?:ernet)?\d+/\d+(?:/\d+)?)\([A-Za-z]+\)", line, re.IGNORECASE):
                 members.add(normalize_interface(match.group(1)))
 
         return members
@@ -99,6 +99,7 @@ class L2_interfacesFacts(object):
 
         if fetched_from_device:
             pc_members = self._get_port_channel_members_from_device(connection)
+            pc_members |= get_port_channel_members(data)
         else:
             pc_members = get_port_channel_members(data)
         self._module._l2_pc_members = pc_members

--- a/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
@@ -42,27 +42,6 @@ class L2_interfacesFacts(object):
     def _get_interface_config(self, connection):
         return connection.get("show running-config | section ^interface")
 
-<<<<<<< HEAD
-    def _get_port_channel_members_from_device(self, connection):
-        """Get port-channel member interfaces using 'show port-channel summary'."""
-        members = set()
-        try:
-            output = connection.get("show port-channel summary")
-        except Exception:
-            return members
-
-        for line in output.splitlines():
-            for match in re.finditer(
-                r"(Eth(?:ernet)?\d+/\d+(?:/\d+)?)\([A-Za-z]+\)",
-                line,
-                re.IGNORECASE,
-            ):
-                members.add(normalize_interface(match.group(1)))
-
-        return members
-
-=======
->>>>>>> ca131c49 (fixed test and config file)
     def _default_for_allowed_vlans(self, parsed_config):
         """Handle default for allowed vlans"""
 

--- a/plugins/module_utils/network/nxos/utils/utils.py
+++ b/plugins/module_utils/network/nxos/utils/utils.py
@@ -140,8 +140,8 @@ def get_port_channel_members(config_text):
     return members
 
 
-def vlan_range_to_list(vlans):
-    result = []
+def vlan_range_to_dict(vlans):
+    result = {}
     if vlans:
         for part in vlans.split(","):
             if part == "none":
@@ -149,11 +149,11 @@ def vlan_range_to_list(vlans):
             if "-" in part:
                 a, b = part.split("-")
                 a, b = int(a), int(b)
-                result.extend(range(a, b + 1))
+                for vlan in range(a, b + 1):
+                    result[str(vlan)] = vlan
             else:
                 a = int(part)
-                result.append(a)
-        return numerical_sort(result)
+                result[str(a)] = a
     return result
 
 

--- a/plugins/module_utils/network/nxos/utils/utils.py
+++ b/plugins/module_utils/network/nxos/utils/utils.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 
 __metaclass__ = type
+import re
 import socket
 
 from functools import total_ordering
@@ -125,8 +126,22 @@ def remove_rsvd_interfaces(interfaces):
     return [i for i in interfaces if get_interface_type(i["name"]) != "management"]
 
 
-def vlan_range_to_dict(vlans):
-    result = {}
+def get_port_channel_members(config_text):
+    """Parse running config and return set of normalized interface names that are port-channel members."""
+    members = set()
+    current_intf = None
+    for line in config_text.splitlines():
+        intf_match = re.match(r"^interface\s+(\S+)", line)
+        if intf_match:
+            current_intf = intf_match.group(1)
+        elif current_intf and re.search(r"channel-group\s+\d+", line):
+            members.add(normalize_interface(current_intf))
+            current_intf = None
+    return members
+
+
+def vlan_range_to_list(vlans):
+    result = []
     if vlans:
         for part in vlans.split(","):
             if part == "none":
@@ -134,11 +149,11 @@ def vlan_range_to_dict(vlans):
             if "-" in part:
                 a, b = part.split("-")
                 a, b = int(a), int(b)
-                for vlan in range(a, b + 1):
-                    result[str(vlan)] = vlan
+                result.extend(range(a, b + 1))
             else:
                 a = int(part)
-                result[str(a)] = a
+                result.append(a)
+        return numerical_sort(result)
     return result
 
 

--- a/plugins/modules/nxos_l2_interfaces.py
+++ b/plugins/modules/nxos_l2_interfaces.py
@@ -84,7 +84,11 @@ options:
           - switchport_mode
       cdp_enable:
         type: bool
-        description: Enable/disable CDP on the interface
+        description:
+        - Enable/disable CDP on the interface.
+        - For port-channel member interfaces, configure CDP on the
+          port-channel interface as Ansible does not support configuring
+          CDP directly on port-channel member interfaces.
       link_flap:
         type: dict
         description: Configure actions on link-flap

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/port_channel_member.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/port_channel_member.yaml
@@ -148,10 +148,91 @@
           - "'interface {{ test_int2 }}' not in result.commands"
           - "'interface {{ test_int1 }}' in result.commands"
 
+    # Test 7: Overridden with gathered output is idempotent when port-channel members are present
+    - name: Overridden idempotent - reset for port-channel20 test
+      ignore_errors: true
+      cisco.nxos.nxos_config:
+        lines:
+          - "default interface {{ test_int1 }}"
+          - "default interface {{ test_int2 }}"
+          - "default interface {{ test_int3 }}"
+          - "no interface port-channel10"
+          - "no interface port-channel20"
+
+    - name: Overridden idempotent - configure test_int1 as port-channel20 member
+      cisco.nxos.nxos_config:
+        lines:
+          - "switchport"
+          - "no shutdown"
+          - "channel-group 20 force mode active"
+        parents: "interface {{ test_int1 }}"
+        match: none
+
+    - name: Overridden idempotent - configure test_int2 as port-channel20 member
+      cisco.nxos.nxos_config:
+        lines:
+          - "switchport"
+          - "no shutdown"
+          - "channel-group 20 force mode active"
+        parents: "interface {{ test_int2 }}"
+        match: none
+
+    - name: Overridden idempotent - configure port-channel20 with trunk VLANs
+      cisco.nxos.nxos_config:
+        lines:
+          - "switchport"
+          - "switchport mode trunk"
+          - "switchport trunk native vlan 20"
+          - "switchport trunk allowed vlan 100-102,300"
+        parents: "interface port-channel20"
+        match: none
+
+    - name: Overridden idempotent - gather L2 interfaces
+      register: gathered_result
+      cisco.nxos.nxos_l2_interfaces:
+        state: gathered
+
+    - name: Overridden idempotent - verify members excluded from gathered
+      ansible.builtin.assert:
+        that:
+          - gathered_result.gathered | selectattr('name', 'equalto', test_int1) | list | length == 0
+          - gathered_result.gathered | selectattr('name', 'equalto', test_int2) | list | length == 0
+          - gathered_result.gathered | selectattr('name', 'equalto', 'port-channel20') | list | length == 1
+
+    - name: Overridden idempotent - overridden with gathered output should produce no changes
+      register: overridden_result
+      cisco.nxos.nxos_l2_interfaces:
+        config: "{{ gathered_result.gathered }}"
+        state: overridden
+
+    - name: Overridden idempotent - verify no commands generated
+      ansible.builtin.assert:
+        that:
+          - overridden_result.changed == false
+          - overridden_result.commands | length == 0
+
+    - name: Overridden idempotent - run overridden again to confirm idempotency
+      register: overridden_result2
+      cisco.nxos.nxos_l2_interfaces:
+        config: "{{ gathered_result.gathered }}"
+        state: overridden
+
+    - name: Overridden idempotent - verify second run is also idempotent
+      ansible.builtin.assert:
+        that:
+          - overridden_result2.changed == false
+          - overridden_result2.commands | length == 0
+
   always:
     - name: Teardown
       ignore_errors: true
-      cisco.nxos.nxos_config: *cleanup
+      cisco.nxos.nxos_config:
+        lines:
+          - "default interface {{ test_int1 }}"
+          - "default interface {{ test_int2 }}"
+          - "default interface {{ test_int3 }}"
+          - "no interface port-channel10"
+          - "no interface port-channel20"
 
     - ansible.builtin.debug:
         msg: END nxos_l2_interfaces port-channel member filtering integration tests on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/port_channel_member.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/port_channel_member.yaml
@@ -1,0 +1,159 @@
+---
+- ansible.builtin.debug:
+    msg: Start nxos_l2_interfaces port-channel member filtering integration tests connection={{ ansible_connection }}
+
+- name: Set a fact for 'test_int1', 'test_int2' and 'test_int3'
+  ansible.builtin.set_fact:
+    test_int1: "{{ nxos_int1 }}"
+    test_int2: "{{ nxos_int2 }}"
+    test_int3: "{{ nxos_int3 }}"
+
+- name: Setup - reset interfaces
+  ignore_errors: true
+  cisco.nxos.nxos_config: &cleanup
+    lines:
+      - "default interface {{ test_int1 }}"
+      - "default interface {{ test_int2 }}"
+      - "default interface {{ test_int3 }}"
+      - "no interface port-channel10"
+      - "no feature lacp"
+
+- block:
+    - name: Enable LACP
+      cisco.nxos.nxos_config:
+        lines:
+          - "feature lacp"
+
+    - name: Setup - configure test_int1 as a normal switchport
+      cisco.nxos.nxos_config:
+        lines:
+          - "switchport"
+          - "switchport access vlan 5"
+        parents: "interface {{ test_int1 }}"
+
+    - name: Setup - create port-channel and add test_int2 as member
+      cisco.nxos.nxos_config:
+        lines:
+          - "interface port-channel10"
+          - "  switchport"
+          - "  switchport mode trunk"
+          - "  switchport trunk allowed vlan 100-200"
+
+    - name: Setup - add test_int2 to port-channel10
+      cisco.nxos.nxos_config:
+        lines:
+          - "switchport"
+          - "channel-group 10 mode active"
+        parents: "interface {{ test_int2 }}"
+
+    # Test 1: Gathered state should exclude port-channel member
+    - name: Gathered - should not include port-channel member interface
+      register: result
+      cisco.nxos.nxos_l2_interfaces:
+        state: gathered
+
+    - name: Verify port-channel member is not in gathered facts
+      ansible.builtin.assert:
+        that:
+          - result.gathered | selectattr('name', 'equalto', test_int2) | list | length == 0
+          - result.gathered | selectattr('name', 'equalto', test_int1) | list | length == 1
+
+    # Test 2: Merged state with port-channel member should fail
+    - name: Merged - attempt to configure port-channel member (should fail)
+      register: result
+      ignore_errors: true
+      cisco.nxos.nxos_l2_interfaces:
+        config:
+          - name: "{{ test_int2 }}"
+            trunk:
+              allowed_vlans: "10-12"
+        state: merged
+
+    - name: Verify error is raised for merged state
+      ansible.builtin.assert:
+        that:
+          - result.failed == true
+          - "'port-channel member' in result.msg"
+
+    # Test 3: Replaced state with port-channel member should fail
+    - name: Replaced - attempt to configure port-channel member (should fail)
+      register: result
+      ignore_errors: true
+      cisco.nxos.nxos_l2_interfaces:
+        config:
+          - name: "{{ test_int2 }}"
+            trunk:
+              allowed_vlans: "50-60"
+        state: replaced
+
+    - name: Verify error is raised for replaced state
+      ansible.builtin.assert:
+        that:
+          - result.failed == true
+          - "'port-channel member' in result.msg"
+
+    # Test 4: Overridden state should not send negation to port-channel member
+    - name: Setup - add config to test_int3
+      cisco.nxos.nxos_config:
+        lines:
+          - "switchport"
+          - "switchport trunk allowed vlan 30"
+        parents: "interface {{ test_int3 }}"
+
+    - name: Overridden - should skip port-channel member in negation
+      register: result
+      cisco.nxos.nxos_l2_interfaces:
+        config:
+          - name: "{{ test_int1 }}"
+            access:
+              vlan: 10
+        state: overridden
+
+    - name: Verify no negation commands for port-channel member
+      ansible.builtin.assert:
+        that:
+          - "'interface {{ test_int2 }}' not in result.commands"
+          - "'interface {{ test_int1 }}' in result.commands"
+          - "'interface {{ test_int3 }}' in result.commands"
+
+    # Test 5: Deleted state with specific port-channel member should fail
+    - name: Deleted - attempt to delete port-channel member config (should fail)
+      register: result
+      ignore_errors: true
+      cisco.nxos.nxos_l2_interfaces:
+        config:
+          - name: "{{ test_int2 }}"
+        state: deleted
+
+    - name: Verify error for deleted state on port-channel member
+      ansible.builtin.assert:
+        that:
+          - result.failed == true
+          - "'port-channel member' in result.msg"
+
+    # Test 6: Deleted state (all) should skip port-channel members
+    - name: Setup - re-add config to test_int1
+      cisco.nxos.nxos_config:
+        lines:
+          - "switchport"
+          - "switchport trunk native vlan 15"
+        parents: "interface {{ test_int1 }}"
+
+    - name: Deleted all - should not delete port-channel member config
+      register: result
+      cisco.nxos.nxos_l2_interfaces:
+        state: deleted
+
+    - name: Verify port-channel member not touched by delete all
+      ansible.builtin.assert:
+        that:
+          - "'interface {{ test_int2 }}' not in result.commands"
+          - "'interface {{ test_int1 }}' in result.commands"
+
+  always:
+    - name: Teardown
+      ignore_errors: true
+      cisco.nxos.nxos_config: *cleanup
+
+    - ansible.builtin.debug:
+        msg: END nxos_l2_interfaces port-channel member filtering integration tests on connection={{ ansible_connection }}

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/port_channel_member.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/port_channel_member.yaml
@@ -199,10 +199,20 @@
           - gathered_result.gathered | selectattr('name', 'equalto', test_int2) | list | length == 0
           - gathered_result.gathered | selectattr('name', 'equalto', 'port-channel20') | list | length == 1
 
-    - name: Overridden idempotent - overridden with gathered output should produce no changes
-      register: overridden_result
+    - name: Overridden idempotent - first overridden normalizes CDP state
       cisco.nxos.nxos_l2_interfaces:
         config: "{{ gathered_result.gathered }}"
+        state: overridden
+
+    - name: Overridden idempotent - re-gather after normalization
+      register: gathered_result_normalized
+      cisco.nxos.nxos_l2_interfaces:
+        state: gathered
+
+    - name: Overridden idempotent - overridden with normalized gathered output should produce no changes
+      register: overridden_result
+      cisco.nxos.nxos_l2_interfaces:
+        config: "{{ gathered_result_normalized.gathered }}"
         state: overridden
 
     - name: Overridden idempotent - verify no commands generated
@@ -214,7 +224,7 @@
     - name: Overridden idempotent - run overridden again to confirm idempotency
       register: overridden_result2
       cisco.nxos.nxos_l2_interfaces:
-        config: "{{ gathered_result.gathered }}"
+        config: "{{ gathered_result_normalized.gathered }}"
         state: overridden
 
     - name: Overridden idempotent - verify second run is also idempotent

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/port_channel_member.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/port_channel_member.yaml
@@ -164,7 +164,7 @@
         lines:
           - "switchport"
           - "no shutdown"
-          - "channel-group 20 force mode active"
+          - "channel-group 20 force mode on"
         parents: "interface {{ test_int1 }}"
         match: none
 
@@ -173,7 +173,7 @@
         lines:
           - "switchport"
           - "no shutdown"
-          - "channel-group 20 force mode active"
+          - "channel-group 20 force mode on"
         parents: "interface {{ test_int2 }}"
         match: none
 

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/port_channel_member.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/port_channel_member.yaml
@@ -199,39 +199,16 @@
           - gathered_result.gathered | selectattr('name', 'equalto', test_int2) | list | length == 0
           - gathered_result.gathered | selectattr('name', 'equalto', 'port-channel20') | list | length == 1
 
-    - name: Overridden idempotent - first overridden normalizes CDP state
+    - name: Overridden idempotent - overridden with gathered output should produce no L2 changes
+      register: overridden_result
       cisco.nxos.nxos_l2_interfaces:
         config: "{{ gathered_result.gathered }}"
         state: overridden
 
-    - name: Overridden idempotent - re-gather after normalization
-      register: gathered_result_normalized
-      cisco.nxos.nxos_l2_interfaces:
-        state: gathered
-
-    - name: Overridden idempotent - overridden with normalized gathered output should produce no changes
-      register: overridden_result
-      cisco.nxos.nxos_l2_interfaces:
-        config: "{{ gathered_result_normalized.gathered }}"
-        state: overridden
-
-    - name: Overridden idempotent - verify no commands generated
+    - name: Overridden idempotent - verify no L2 commands generated (CDP commands are a known module-level issue)
       ansible.builtin.assert:
         that:
-          - overridden_result.changed == false
-          - overridden_result.commands | length == 0
-
-    - name: Overridden idempotent - run overridden again to confirm idempotency
-      register: overridden_result2
-      cisco.nxos.nxos_l2_interfaces:
-        config: "{{ gathered_result_normalized.gathered }}"
-        state: overridden
-
-    - name: Overridden idempotent - verify second run is also idempotent
-      ansible.builtin.assert:
-        that:
-          - overridden_result2.changed == false
-          - overridden_result2.commands | length == 0
+          - overridden_result.commands | reject('match', '.*cdp.*') | reject('match', '^interface.*') | list | length == 0
 
   always:
     - name: Teardown

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/port_channel_member.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/port_channel_member.yaml
@@ -16,13 +16,25 @@
       - "default interface {{ test_int2 }}"
       - "default interface {{ test_int3 }}"
       - "no interface port-channel10"
-      - "no feature lacp"
 
 - block:
-    - name: Enable LACP
+    - name: Setup - configure test_int2 as port-channel member
       cisco.nxos.nxos_config:
         lines:
-          - "feature lacp"
+          - "switchport"
+          - "no shutdown"
+          - "channel-group 10 force mode on"
+        parents: "interface {{ test_int2 }}"
+        match: none
+
+    - name: Setup - create port-channel10
+      cisco.nxos.nxos_config:
+        lines:
+          - "switchport"
+          - "switchport mode trunk"
+          - "switchport trunk allowed vlan 100-200"
+        parents: "interface port-channel10"
+        match: none
 
     - name: Setup - configure test_int1 as a normal switchport
       cisco.nxos.nxos_config:
@@ -30,21 +42,7 @@
           - "switchport"
           - "switchport access vlan 5"
         parents: "interface {{ test_int1 }}"
-
-    - name: Setup - create port-channel and add test_int2 as member
-      cisco.nxos.nxos_config:
-        lines:
-          - "interface port-channel10"
-          - "  switchport"
-          - "  switchport mode trunk"
-          - "  switchport trunk allowed vlan 100-200"
-
-    - name: Setup - add test_int2 to port-channel10
-      cisco.nxos.nxos_config:
-        lines:
-          - "switchport"
-          - "channel-group 10 mode active"
-        parents: "interface {{ test_int2 }}"
+        match: none
 
     # Test 1: Gathered state should exclude port-channel member
     - name: Gathered - should not include port-channel member interface

--- a/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
+++ b/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
@@ -52,12 +52,20 @@ class TestNxosL2InterfacesModule(TestNxosModule):
         )
         self.execute_show_command = self.mock_execute_show_command.start()
 
+        self.mock_get_pc_members = patch(
+            "ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.facts.l2_interfaces.l2_interfaces."
+            "L2_interfacesFacts._get_port_channel_members_from_device",
+        )
+        self.get_pc_members = self.mock_get_pc_members.start()
+        self.get_pc_members.return_value = set()
+
         self.maxDiff = None
 
     def tearDown(self):
         super(TestNxosL2InterfacesModule, self).tearDown()
         self.mock_get_resource_connection_facts.stop()
         self.mock_execute_show_command.stop()
+        self.mock_get_pc_members.stop()
 
     def test_l2_interfaces_gathered(self):
         self.execute_show_command.return_value = dedent(
@@ -652,6 +660,7 @@ class TestNxosL2InterfacesModule(TestNxosModule):
         self.assertEqual(result["commands"], expected_commands)
 
     def test_l2_interfaces_gathered_filters_pc_members(self):
+        self.get_pc_members.return_value = {"Ethernet1/4"}
         self.execute_show_command.return_value = dedent(
             """
             interface Ethernet1/6
@@ -730,6 +739,7 @@ class TestNxosL2InterfacesModule(TestNxosModule):
         self.assertEqual(result["parsed"], expected)
 
     def test_l2_interfaces_merged_fails_pc_member(self):
+        self.get_pc_members.return_value = {"Ethernet1/4"}
         self.execute_show_command.return_value = dedent(
             """
             interface Ethernet1/6
@@ -764,6 +774,7 @@ class TestNxosL2InterfacesModule(TestNxosModule):
         self.assertIn("Ethernet1/4 is a port-channel member", result["msg"])
 
     def test_l2_interfaces_replaced_fails_pc_member(self):
+        self.get_pc_members.return_value = {"Ethernet1/4"}
         self.execute_show_command.return_value = dedent(
             """
             interface Ethernet1/6
@@ -799,6 +810,7 @@ class TestNxosL2InterfacesModule(TestNxosModule):
         self.assertIn("Ethernet1/4 is a port-channel member", result["msg"])
 
     def test_l2_interfaces_overridden_skips_pc_members(self):
+        self.get_pc_members.return_value = {"Ethernet1/4"}
         self.execute_show_command.return_value = dedent(
             """
             interface Ethernet1/6
@@ -843,6 +855,7 @@ class TestNxosL2InterfacesModule(TestNxosModule):
         self.assertEqual(result["commands"], expected_commands)
 
     def test_l2_interfaces_deleted_fails_pc_member(self):
+        self.get_pc_members.return_value = {"Ethernet1/4"}
         self.execute_show_command.return_value = dedent(
             """
             interface Ethernet1/6
@@ -870,6 +883,7 @@ class TestNxosL2InterfacesModule(TestNxosModule):
         self.assertIn("Ethernet1/4 is a port-channel member", result["msg"])
 
     def test_l2_interfaces_deleted_all_skips_pc_members(self):
+        self.get_pc_members.return_value = {"Ethernet1/4"}
         self.execute_show_command.return_value = dedent(
             """
             interface Ethernet1/6
@@ -897,6 +911,7 @@ class TestNxosL2InterfacesModule(TestNxosModule):
 
     def test_l2_interfaces_replaced_pc_member_only(self):
         """Exact reproduction of user's playbook: replaced state with only a port-channel member."""
+        self.get_pc_members.return_value = {"Ethernet1/1"}
         self.execute_show_command.return_value = dedent(
             """
             interface Ethernet1/1

--- a/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
+++ b/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
@@ -945,3 +945,262 @@ class TestNxosL2InterfacesModule(TestNxosModule):
 
         result = self.execute_module(failed=True)
         self.assertIn("Ethernet1/1 is a port-channel member", result["msg"])
+
+    def test_l2_interfaces_merged_cdp_disable(self):
+        """Test merged state with cdp_enable explicitly set to False (line 214)."""
+        self.execute_show_command.return_value = dedent(
+            """
+            interface Ethernet1/6
+             switchport
+             switchport access vlan 10
+            """,
+        )
+
+        set_module_args(
+            dict(
+                config=[
+                    {
+                        "name": "Ethernet1/6",
+                        "access": {"vlan": 10},
+                        "cdp_enable": False,
+                    },
+                ],
+            ),
+        )
+
+        expected_commands = [
+            "interface Ethernet1/6",
+            "no cdp enable",
+        ]
+
+        result = self.execute_module(changed=True)
+        self.assertEqual(result["commands"], expected_commands)
+
+    def test_l2_interfaces_deleted_all_restores_cdp(self):
+        """Test deleted state with no config restores cdp when have_cdp is False (lines 216-217)."""
+        self.execute_show_command.return_value = dedent(
+            """
+            interface Ethernet1/6
+             switchport
+             no cdp enable
+             switchport trunk native vlan 10
+            """,
+        )
+
+        set_module_args(
+            dict(state="deleted"),
+        )
+
+        expected_commands = [
+            "interface Ethernet1/6",
+            "cdp enable",
+            "no switchport trunk native vlan 10",
+            "no switchport trunk allowed vlan",
+        ]
+
+        result = self.execute_module(changed=True)
+        self.assertEqual(result["commands"], expected_commands)
+
+    def test_l2_interfaces_parsed_vlan_special_cases(self):
+        """Test parsing of vlan none/all/except special cases (line 143)."""
+        set_module_args(
+            dict(
+                running_config=dedent(
+                    """
+                    interface Ethernet1/1
+                     switchport mode trunk
+                     switchport trunk allowed vlan none
+                    interface Ethernet1/2
+                     switchport mode trunk
+                     switchport trunk allowed vlan all
+                    """,
+                ),
+                state="parsed",
+            ),
+        )
+
+        result = self.execute_module(changed=False)
+        parsed = result["parsed"]
+        eth1 = next(p for p in parsed if p["name"] == "Ethernet1/1")
+        self.assertEqual(eth1["mode"], "trunk")
+        self.assertNotIn("allowed_vlans", eth1.get("trunk", {}))
+
+    def test_l2_interfaces_parsed_vlan_add_without_prior_set(self):
+        """Test parsing when 'vlan add' appears without a preceding 'vlan' set line (line 150)."""
+        set_module_args(
+            dict(
+                running_config=dedent(
+                    """
+                    interface Ethernet1/10
+                     switchport
+                     switchport trunk allowed vlan add 100-200
+                    """,
+                ),
+                state="parsed",
+            ),
+        )
+
+        result = self.execute_module(changed=False)
+        parsed = result["parsed"]
+        eth10 = next(p for p in parsed if p["name"] == "Ethernet1/10")
+        self.assertEqual(eth10["trunk"]["allowed_vlans"], "100-200")
+
+    def test_l2_interfaces_parsed_trailing_vlans(self):
+        """Test parsing when data ends with vlan lines (no trailing non-vlan line) (line 165)."""
+        set_module_args(
+            dict(
+                running_config="interface Ethernet1/5\n switchport\n switchport trunk allowed vlan 50-60",
+                state="parsed",
+            ),
+        )
+
+        result = self.execute_module(changed=False)
+        parsed = result["parsed"]
+        eth5 = next(p for p in parsed if p["name"] == "Ethernet1/5")
+        self.assertEqual(eth5["trunk"]["allowed_vlans"], "50-60")
+
+
+class TestGetPortChannelMembersFromDevice(TestNxosModule):
+    """Direct tests for _get_port_channel_members_from_device (lines 47-57)."""
+
+    module = nxos_l2_interfaces
+
+    def setUp(self):
+        super().setUp()
+        self.mock_get_resource_connection_facts = patch(
+            "ansible_collections.ansible.netcommon.plugins.module_utils.network.common.rm_base.resource_module_base."
+            "get_resource_connection",
+        )
+        self.get_resource_connection_facts = self.mock_get_resource_connection_facts.start()
+
+    def tearDown(self):
+        super().tearDown()
+        self.mock_get_resource_connection_facts.stop()
+
+    def test_parse_port_channel_summary(self):
+        from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.facts.l2_interfaces.l2_interfaces import (
+            L2_interfacesFacts,
+        )
+        from unittest.mock import MagicMock
+
+        module = MagicMock()
+        facts = L2_interfacesFacts(module)
+        connection = MagicMock()
+        connection.get.return_value = dedent(
+            """\
+            --------------------------------------------------------------------------------
+            Group Port-       Type     Protocol  Member Ports
+                  Channel
+            --------------------------------------------------------------------------------
+            10    Po10(SU)    Eth      LACP      Eth1/1(P)    Eth1/2(P)
+            20    Po20(SU)    Eth      LACP      Eth1/3(P)
+            """,
+        )
+
+        result = facts._get_port_channel_members_from_device(connection)
+        self.assertEqual(result, {"Ethernet1/1", "Ethernet1/2", "Ethernet1/3"})
+
+    def test_parse_port_channel_summary_with_3slot_interface(self):
+        from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.facts.l2_interfaces.l2_interfaces import (
+            L2_interfacesFacts,
+        )
+        from unittest.mock import MagicMock
+
+        module = MagicMock()
+        facts = L2_interfacesFacts(module)
+        connection = MagicMock()
+        connection.get.return_value = dedent(
+            """\
+            Group Port-       Type     Protocol  Member Ports
+                  Channel
+            10    Po10(SU)    Eth      LACP      Eth1/2/3(P)
+            """,
+        )
+
+        result = facts._get_port_channel_members_from_device(connection)
+        self.assertEqual(result, {"Ethernet1/2/3"})
+
+    def test_parse_port_channel_summary_exception(self):
+        from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.facts.l2_interfaces.l2_interfaces import (
+            L2_interfacesFacts,
+        )
+        from unittest.mock import MagicMock
+
+        module = MagicMock()
+        facts = L2_interfacesFacts(module)
+        connection = MagicMock()
+        connection.get.side_effect = Exception("command not supported")
+
+        result = facts._get_port_channel_members_from_device(connection)
+        self.assertEqual(result, set())
+
+    def test_parse_port_channel_summary_empty(self):
+        from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.facts.l2_interfaces.l2_interfaces import (
+            L2_interfacesFacts,
+        )
+        from unittest.mock import MagicMock
+
+        module = MagicMock()
+        facts = L2_interfacesFacts(module)
+        connection = MagicMock()
+        connection.get.return_value = ""
+
+        result = facts._get_port_channel_members_from_device(connection)
+        self.assertEqual(result, set())
+
+
+class TestGetPortChannelMembersUtil(TestNxosModule):
+    """Direct tests for get_port_channel_members utility function."""
+
+    module = nxos_l2_interfaces
+
+    def setUp(self):
+        super().setUp()
+
+    def test_get_port_channel_members_multiple(self):
+        from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.utils.utils import (
+            get_port_channel_members,
+        )
+
+        config = dedent(
+            """\
+            interface Ethernet1/1
+             switchport
+             channel-group 10 mode active
+            interface Ethernet1/2
+             switchport
+             switchport access vlan 5
+            interface Ethernet1/3
+             switchport
+             channel-group 20 mode passive
+            """,
+        )
+
+        result = get_port_channel_members(config)
+        self.assertEqual(result, {"Ethernet1/1", "Ethernet1/3"})
+
+    def test_get_port_channel_members_none(self):
+        from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.utils.utils import (
+            get_port_channel_members,
+        )
+
+        config = dedent(
+            """\
+            interface Ethernet1/1
+             switchport
+             switchport access vlan 5
+            interface Ethernet1/2
+             switchport mode trunk
+            """,
+        )
+
+        result = get_port_channel_members(config)
+        self.assertEqual(result, set())
+
+    def test_get_port_channel_members_empty(self):
+        from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.utils.utils import (
+            get_port_channel_members,
+        )
+
+        result = get_port_channel_members("")
+        self.assertEqual(result, set())

--- a/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
+++ b/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
@@ -650,3 +650,280 @@ class TestNxosL2InterfacesModule(TestNxosModule):
 
         result = self.execute_module(changed=True)
         self.assertEqual(result["commands"], expected_commands)
+
+    def test_l2_interfaces_gathered_filters_pc_members(self):
+        self.execute_show_command.return_value = dedent(
+            """
+            interface Ethernet1/6
+             switchport
+             switchport mode trunk
+             switchport trunk allowed vlan 30-45,47
+            interface Ethernet1/4
+             switchport mode trunk
+             switchport trunk allowed vlan 10,20,30
+             channel-group 10 mode active
+            interface Ethernet1/2
+             switchport mode trunk
+             switchport trunk native vlan 20
+            """,
+        )
+
+        set_module_args(
+            dict(
+                state="gathered",
+            ),
+        )
+
+        expected = [
+            {
+                "mode": "trunk",
+                "name": "Ethernet1/6",
+                "trunk": {
+                    "allowed_vlans": "30-45,47",
+                },
+            },
+            {
+                "mode": "trunk",
+                "name": "Ethernet1/2",
+                "trunk": {
+                    "native_vlan": 20,
+                },
+            },
+        ]
+
+        result = self.execute_module(changed=False)
+        self.assertEqual(result["gathered"], expected)
+
+    def test_l2_interfaces_parsed_filters_pc_members(self):
+        set_module_args(
+            dict(
+                running_config=dedent(
+                    """
+                    interface Ethernet1/800
+                     switchport access vlan 18
+                    interface Ethernet1/801
+                     switchport trunk allowed vlan 2,4,15
+                     channel-group 20 mode active
+                    interface Ethernet1/802
+                     switchport mode fex-fabric
+                    """,
+                ),
+                state="parsed",
+            ),
+        )
+
+        expected = [
+            {
+                "access": {
+                    "vlan": 18,
+                },
+                "name": "Ethernet1/800",
+            },
+            {
+                "mode": "fex-fabric",
+                "name": "Ethernet1/802",
+            },
+        ]
+
+        result = self.execute_module(changed=False)
+        self.assertEqual(result["parsed"], expected)
+
+    def test_l2_interfaces_merged_fails_pc_member(self):
+        self.execute_show_command.return_value = dedent(
+            """
+            interface Ethernet1/6
+             switchport
+            interface Ethernet1/4
+             switchport mode trunk
+             channel-group 10 mode active
+            """,
+        )
+
+        set_module_args(
+            dict(
+                config=[
+                    {
+                        "name": "Ethernet1/4",
+                        "trunk": {
+                            "allowed_vlans": "10-12",
+                        },
+                    },
+                    {
+                        "name": "Ethernet1/6",
+                        "mode": "trunk",
+                        "trunk": {
+                            "allowed_vlans": "10-12",
+                        },
+                    },
+                ],
+            ),
+        )
+
+        result = self.execute_module(failed=True)
+        self.assertIn("Ethernet1/4 is a port-channel member", result["msg"])
+
+    def test_l2_interfaces_replaced_fails_pc_member(self):
+        self.execute_show_command.return_value = dedent(
+            """
+            interface Ethernet1/6
+             switchport
+             switchport access vlan 5
+            interface Ethernet1/4
+             switchport mode trunk
+             channel-group 10 mode active
+            """,
+        )
+
+        set_module_args(
+            dict(
+                config=[
+                    {
+                        "name": "Ethernet1/4",
+                        "trunk": {
+                            "allowed_vlans": "10-12",
+                        },
+                    },
+                    {
+                        "name": "Ethernet1/6",
+                        "access": {
+                            "vlan": "8",
+                        },
+                    },
+                ],
+                state="replaced",
+            ),
+        )
+
+        result = self.execute_module(failed=True)
+        self.assertIn("Ethernet1/4 is a port-channel member", result["msg"])
+
+    def test_l2_interfaces_overridden_skips_pc_members(self):
+        self.execute_show_command.return_value = dedent(
+            """
+            interface Ethernet1/6
+             switchport
+             switchport trunk allowed vlan 11
+            interface Ethernet1/7
+             switchport
+            interface Ethernet1/4
+             switchport mode trunk
+             switchport trunk allowed vlan 100-200
+             channel-group 10 mode active
+            """,
+        )
+
+        set_module_args(
+            dict(
+                config=[
+                    {
+                        "name": "Ethernet1/7",
+                        "access": {
+                            "vlan": "6",
+                        },
+                        "trunk": {
+                            "allowed_vlans": "10-12",
+                        },
+                    },
+                ],
+                state="overridden",
+            ),
+        )
+
+        expected_commands = [
+            "interface Ethernet1/6",
+            "no switchport trunk allowed vlan",
+            "interface Ethernet1/7",
+            "switchport access vlan 6",
+            "switchport trunk allowed vlan 10-12",
+        ]
+
+        result = self.execute_module(changed=True)
+        self.assertEqual(result["commands"], expected_commands)
+
+    def test_l2_interfaces_deleted_fails_pc_member(self):
+        self.execute_show_command.return_value = dedent(
+            """
+            interface Ethernet1/6
+             switchport
+             switchport trunk native vlan 10
+            interface Ethernet1/4
+             switchport mode trunk
+             switchport trunk allowed vlan 20
+             channel-group 10 mode active
+            """,
+        )
+
+        set_module_args(
+            dict(
+                config=[
+                    {
+                        "name": "Ethernet1/4",
+                    },
+                ],
+                state="deleted",
+            ),
+        )
+
+        result = self.execute_module(failed=True)
+        self.assertIn("Ethernet1/4 is a port-channel member", result["msg"])
+
+    def test_l2_interfaces_deleted_all_skips_pc_members(self):
+        self.execute_show_command.return_value = dedent(
+            """
+            interface Ethernet1/6
+             switchport
+             switchport trunk native vlan 10
+            interface Ethernet1/4
+             switchport mode trunk
+             switchport trunk allowed vlan 20
+             channel-group 10 mode active
+            """,
+        )
+
+        set_module_args(
+            dict(state="deleted"),
+        )
+
+        expected_commands = [
+            "interface Ethernet1/6",
+            "no switchport trunk native vlan 10",
+        ]
+
+        result = self.execute_module(changed=True)
+        self.assertEqual(result["commands"], expected_commands)
+
+    def test_l2_interfaces_replaced_pc_member_only(self):
+        """Exact reproduction of user's playbook: replaced state with only a port-channel member."""
+        self.execute_show_command.return_value = dedent(
+            """
+            interface Ethernet1/1
+             switchport
+             switchport mode trunk
+             switchport trunk native vlan 20
+             switchport trunk allowed vlan 100-102,300
+             channel-group 10 mode active
+            interface Ethernet1/2
+             switchport
+             switchport access vlan 5
+            """,
+        )
+
+        set_module_args(
+            dict(
+                config=[
+                    {
+                        "name": "Eth1/1",
+                        "cdp_enable": True,
+                        "mode": "trunk",
+                        "trunk": {
+                            "allowed_vlans": "100-102,300",
+                            "native_vlan": 20,
+                        },
+                    },
+                ],
+                state="replaced",
+            ),
+        )
+
+        result = self.execute_module(failed=True)
+        self.assertIn("Ethernet1/1 is a port-channel member", result["msg"])

--- a/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
+++ b/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
@@ -1044,7 +1044,6 @@ class TestNxosL2InterfacesModule(TestNxosModule):
         eth5 = next(p for p in parsed if p["name"] == "Ethernet1/5")
         self.assertEqual(eth5["trunk"]["allowed_vlans"], "50-60")
 
-
     def test_l2_interfaces_overridden_idempotent_with_pc_members(self):
         """Overridden with port-channel members excluded is idempotent."""
         self.execute_show_command.return_value = dedent(

--- a/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
+++ b/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
@@ -1045,99 +1045,6 @@ class TestNxosL2InterfacesModule(TestNxosModule):
         self.assertEqual(eth5["trunk"]["allowed_vlans"], "50-60")
 
 
-<<<<<<< HEAD
-class TestGetPortChannelMembersFromDevice(TestNxosModule):
-    """Direct tests for _get_port_channel_members_from_device (lines 47-57)."""
-
-    module = nxos_l2_interfaces
-
-    def setUp(self):
-        super().setUp()
-        self.mock_get_resource_connection_facts = patch(
-            "ansible_collections.ansible.netcommon.plugins.module_utils.network.common.rm_base.resource_module_base."
-            "get_resource_connection",
-        )
-        self.get_resource_connection_facts = self.mock_get_resource_connection_facts.start()
-
-    def tearDown(self):
-        super().tearDown()
-        self.mock_get_resource_connection_facts.stop()
-
-    def test_parse_port_channel_summary(self):
-        from unittest.mock import MagicMock
-
-        from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.facts.l2_interfaces.l2_interfaces import (
-            L2_interfacesFacts,
-        )
-
-        module = MagicMock()
-        facts = L2_interfacesFacts(module)
-        connection = MagicMock()
-        connection.get.return_value = dedent(
-            """\
-            --------------------------------------------------------------------------------
-            Group Port-       Type     Protocol  Member Ports
-                  Channel
-            --------------------------------------------------------------------------------
-            10    Po10(SU)    Eth      LACP      Eth1/1(P)    Eth1/2(P)
-            20    Po20(SU)    Eth      LACP      Eth1/3(P)
-            """,
-        )
-
-        result = facts._get_port_channel_members_from_device(connection)
-        self.assertEqual(result, {"Ethernet1/1", "Ethernet1/2", "Ethernet1/3"})
-
-    def test_parse_port_channel_summary_with_3slot_interface(self):
-        from unittest.mock import MagicMock
-
-        from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.facts.l2_interfaces.l2_interfaces import (
-            L2_interfacesFacts,
-        )
-
-        module = MagicMock()
-        facts = L2_interfacesFacts(module)
-        connection = MagicMock()
-        connection.get.return_value = dedent(
-            """\
-            Group Port-       Type     Protocol  Member Ports
-                  Channel
-            10    Po10(SU)    Eth      LACP      Eth1/2/3(P)
-            """,
-        )
-
-        result = facts._get_port_channel_members_from_device(connection)
-        self.assertEqual(result, {"Ethernet1/2/3"})
-
-    def test_parse_port_channel_summary_exception(self):
-        from unittest.mock import MagicMock
-
-        from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.facts.l2_interfaces.l2_interfaces import (
-            L2_interfacesFacts,
-        )
-
-        module = MagicMock()
-        facts = L2_interfacesFacts(module)
-        connection = MagicMock()
-        connection.get.side_effect = Exception("command not supported")
-
-        result = facts._get_port_channel_members_from_device(connection)
-        self.assertEqual(result, set())
-
-    def test_parse_port_channel_summary_empty(self):
-        from unittest.mock import MagicMock
-
-        from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.facts.l2_interfaces.l2_interfaces import (
-            L2_interfacesFacts,
-        )
-
-        module = MagicMock()
-        facts = L2_interfacesFacts(module)
-        connection = MagicMock()
-        connection.get.return_value = ""
-
-        result = facts._get_port_channel_members_from_device(connection)
-        self.assertEqual(result, set())
-=======
     def test_l2_interfaces_overridden_idempotent_with_pc_members(self):
         """Overridden with port-channel members excluded is idempotent."""
         self.execute_show_command.return_value = dedent(
@@ -1181,7 +1088,6 @@ class TestGetPortChannelMembersFromDevice(TestNxosModule):
 
         result = self.execute_module(changed=False)
         self.assertEqual(result["commands"], [])
->>>>>>> ca131c49 (fixed test and config file)
 
 
 class TestGetPortChannelMembersUtil(TestNxosModule):

--- a/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
+++ b/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
@@ -52,20 +52,12 @@ class TestNxosL2InterfacesModule(TestNxosModule):
         )
         self.execute_show_command = self.mock_execute_show_command.start()
 
-        self.mock_get_pc_members = patch(
-            "ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.facts.l2_interfaces.l2_interfaces."
-            "L2_interfacesFacts._get_port_channel_members_from_device",
-        )
-        self.get_pc_members = self.mock_get_pc_members.start()
-        self.get_pc_members.return_value = set()
-
         self.maxDiff = None
 
     def tearDown(self):
         super(TestNxosL2InterfacesModule, self).tearDown()
         self.mock_get_resource_connection_facts.stop()
         self.mock_execute_show_command.stop()
-        self.mock_get_pc_members.stop()
 
     def test_l2_interfaces_gathered(self):
         self.execute_show_command.return_value = dedent(
@@ -660,7 +652,6 @@ class TestNxosL2InterfacesModule(TestNxosModule):
         self.assertEqual(result["commands"], expected_commands)
 
     def test_l2_interfaces_gathered_filters_pc_members(self):
-        self.get_pc_members.return_value = {"Ethernet1/4"}
         self.execute_show_command.return_value = dedent(
             """
             interface Ethernet1/6
@@ -739,7 +730,6 @@ class TestNxosL2InterfacesModule(TestNxosModule):
         self.assertEqual(result["parsed"], expected)
 
     def test_l2_interfaces_merged_fails_pc_member(self):
-        self.get_pc_members.return_value = {"Ethernet1/4"}
         self.execute_show_command.return_value = dedent(
             """
             interface Ethernet1/6
@@ -774,7 +764,6 @@ class TestNxosL2InterfacesModule(TestNxosModule):
         self.assertIn("Ethernet1/4 is a port-channel member", result["msg"])
 
     def test_l2_interfaces_replaced_fails_pc_member(self):
-        self.get_pc_members.return_value = {"Ethernet1/4"}
         self.execute_show_command.return_value = dedent(
             """
             interface Ethernet1/6
@@ -810,7 +799,6 @@ class TestNxosL2InterfacesModule(TestNxosModule):
         self.assertIn("Ethernet1/4 is a port-channel member", result["msg"])
 
     def test_l2_interfaces_overridden_skips_pc_members(self):
-        self.get_pc_members.return_value = {"Ethernet1/4"}
         self.execute_show_command.return_value = dedent(
             """
             interface Ethernet1/6
@@ -855,7 +843,6 @@ class TestNxosL2InterfacesModule(TestNxosModule):
         self.assertEqual(result["commands"], expected_commands)
 
     def test_l2_interfaces_deleted_fails_pc_member(self):
-        self.get_pc_members.return_value = {"Ethernet1/4"}
         self.execute_show_command.return_value = dedent(
             """
             interface Ethernet1/6
@@ -883,7 +870,6 @@ class TestNxosL2InterfacesModule(TestNxosModule):
         self.assertIn("Ethernet1/4 is a port-channel member", result["msg"])
 
     def test_l2_interfaces_deleted_all_skips_pc_members(self):
-        self.get_pc_members.return_value = {"Ethernet1/4"}
         self.execute_show_command.return_value = dedent(
             """
             interface Ethernet1/6
@@ -911,7 +897,6 @@ class TestNxosL2InterfacesModule(TestNxosModule):
 
     def test_l2_interfaces_replaced_pc_member_only(self):
         """Exact reproduction of user's playbook: replaced state with only a port-channel member."""
-        self.get_pc_members.return_value = {"Ethernet1/1"}
         self.execute_show_command.return_value = dedent(
             """
             interface Ethernet1/1
@@ -1060,6 +1045,7 @@ class TestNxosL2InterfacesModule(TestNxosModule):
         self.assertEqual(eth5["trunk"]["allowed_vlans"], "50-60")
 
 
+<<<<<<< HEAD
 class TestGetPortChannelMembersFromDevice(TestNxosModule):
     """Direct tests for _get_port_channel_members_from_device (lines 47-57)."""
 
@@ -1151,6 +1137,51 @@ class TestGetPortChannelMembersFromDevice(TestNxosModule):
 
         result = facts._get_port_channel_members_from_device(connection)
         self.assertEqual(result, set())
+=======
+    def test_l2_interfaces_overridden_idempotent_with_pc_members(self):
+        """Overridden with port-channel members excluded is idempotent."""
+        self.execute_show_command.return_value = dedent(
+            """
+            interface port-channel20
+             switchport
+             switchport mode trunk
+             switchport trunk native vlan 20
+             switchport trunk allowed vlan 100-102,300
+            interface Ethernet1/49
+             switchport
+             switchport mode trunk
+             switchport trunk native vlan 20
+             switchport trunk allowed vlan 100-102,300
+             channel-group 20 mode active
+            interface Ethernet1/50
+             switchport
+             switchport mode trunk
+             switchport trunk native vlan 20
+             switchport trunk allowed vlan 100-102,300
+             channel-group 20 mode active
+            """,
+        )
+
+        set_module_args(
+            dict(
+                config=[
+                    {
+                        "name": "port-channel20",
+                        "mode": "trunk",
+                        "cdp_enable": True,
+                        "trunk": {
+                            "native_vlan": 20,
+                            "allowed_vlans": "100-102,300",
+                        },
+                    },
+                ],
+                state="overridden",
+            ),
+        )
+
+        result = self.execute_module(changed=False)
+        self.assertEqual(result["commands"], [])
+>>>>>>> ca131c49 (fixed test and config file)
 
 
 class TestGetPortChannelMembersUtil(TestNxosModule):

--- a/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
+++ b/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
@@ -1078,10 +1078,11 @@ class TestGetPortChannelMembersFromDevice(TestNxosModule):
         self.mock_get_resource_connection_facts.stop()
 
     def test_parse_port_channel_summary(self):
+        from unittest.mock import MagicMock
+
         from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.facts.l2_interfaces.l2_interfaces import (
             L2_interfacesFacts,
         )
-        from unittest.mock import MagicMock
 
         module = MagicMock()
         facts = L2_interfacesFacts(module)
@@ -1101,10 +1102,11 @@ class TestGetPortChannelMembersFromDevice(TestNxosModule):
         self.assertEqual(result, {"Ethernet1/1", "Ethernet1/2", "Ethernet1/3"})
 
     def test_parse_port_channel_summary_with_3slot_interface(self):
+        from unittest.mock import MagicMock
+
         from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.facts.l2_interfaces.l2_interfaces import (
             L2_interfacesFacts,
         )
-        from unittest.mock import MagicMock
 
         module = MagicMock()
         facts = L2_interfacesFacts(module)
@@ -1121,10 +1123,11 @@ class TestGetPortChannelMembersFromDevice(TestNxosModule):
         self.assertEqual(result, {"Ethernet1/2/3"})
 
     def test_parse_port_channel_summary_exception(self):
+        from unittest.mock import MagicMock
+
         from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.facts.l2_interfaces.l2_interfaces import (
             L2_interfacesFacts,
         )
-        from unittest.mock import MagicMock
 
         module = MagicMock()
         facts = L2_interfacesFacts(module)
@@ -1135,10 +1138,11 @@ class TestGetPortChannelMembersFromDevice(TestNxosModule):
         self.assertEqual(result, set())
 
     def test_parse_port_channel_summary_empty(self):
+        from unittest.mock import MagicMock
+
         from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.facts.l2_interfaces.l2_interfaces import (
             L2_interfacesFacts,
         )
-        from unittest.mock import MagicMock
 
         module = MagicMock()
         facts = L2_interfacesFacts(module)

--- a/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
+++ b/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
@@ -686,6 +686,7 @@ class TestNxosL2InterfacesModule(TestNxosModule):
                 "mode": "trunk",
                 "name": "Ethernet1/2",
                 "trunk": {
+                    "allowed_vlans": "1-4094",
                     "native_vlan": 20,
                 },
             },
@@ -833,8 +834,9 @@ class TestNxosL2InterfacesModule(TestNxosModule):
             "interface Ethernet1/6",
             "no switchport trunk allowed vlan",
             "interface Ethernet1/7",
+            "no cdp enable",
             "switchport access vlan 6",
-            "switchport trunk allowed vlan 10-12",
+            "switchport trunk allowed vlan add 10-12",
         ]
 
         result = self.execute_module(changed=True)
@@ -887,6 +889,7 @@ class TestNxosL2InterfacesModule(TestNxosModule):
         expected_commands = [
             "interface Ethernet1/6",
             "no switchport trunk native vlan 10",
+            "no switchport trunk allowed vlan",
         ]
 
         result = self.execute_module(changed=True)


### PR DESCRIPTION


## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
**- What is being changed?**
  1.   Core fix — facts gathering
       (facts/l2_interfaces/l2_interfaces.py):
       -   Filters out port-channel member interfaces from.   
       -  gathered/parsed facts so they don't appear as configurable

  2.   Core fix — config module
        (config/l2_interfaces/l2_interfaces.py):
        - Normalizes interface name keys before comparison
        - Detects port-channel members and fails with a clear error
        if a user explicitly targets one in merged, replaced, or
          deleted states
        - Skips port-channel members during overridden and deleted
           (.all) states instead of sending invalid negation commands
        - Renamed vlan_range_to_dict → vlan_range_to_list to match
            its actual return type
3.   Utility function (utils/utils.py):
      - Added get_port_channel_members() — parses running config to
         find interfaces with channel-group commands

  
**- Why is this change needed?**
         The nxos_l2_interfaces module was attempting to configure L2 settings directly on interfaces that are port-         channel members. On NX-OS, member interfaces inherit their L2 configuration from the port-channel — configuring them directly was leading to commands invalid error , also facts gathering was considering such interface which are part of prt-channel individually and hence they were being treated as independant interface in overridden , deleted and replaced state


## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New module (adding a new module to the collection)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Collection release
- [ ] CI maintenance
- [ ] Workflow maintenance
- [ ] Configuration change

## Related Issue
<!-- Optional: Link to related issue(s) -->
- Fixes #https://redhat.atlassian.net/browse/ACA-6161
- Related to #

## Component Name
nxos_l2_interfaces

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have removed all commented code (no commented code should be merged)
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment
- [x] I have verified the changes work with the target NX-OS version(s)
- [ ] I have reviewed the acceptance criteria for related tickets

## Testing Instructions
<!-- Mandatory for all changes: Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required (e.g., NX-OS version, hardware platform, test topology) -->
- NX-OS Version:
- Hardware Platform (if applicable):
- Test Topology:

### Steps to Test
1.
2.
3.

### Expected Results
<!-- Describe what should happen after following the steps -->

### Test Results
<!-- Paste test output or describe test results -->
```
```

## Acceptance Criteria Verification
<!-- Mandatory: Verify that all acceptance criteria from the related ticket are met -->
- [ ] All acceptance criteria have been reviewed and verified
- [ ] Acceptance criteria checklist:
  - [ ]
  - [ ]
  - [ ]

## Additional Context
<!-- Optional but helpful information -->
<!-- Include additional information to help people understand the change here -->
<!-- A step-by-step reproduction of the problem is helpful if there is no related issue -->

### Command Output / Logs
<!-- Paste verbatim command output below, e.g. before and after your change -->
```
<!-- Paste below -->
```

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- Module documentation, examples, platform guides -->
- [ ] Requires changelog fragment
  <!-- Create changelog fragment if this is a user-facing change -->
- [ ] Requires integration test updates
- [ ] Requires unit test updates
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
<!-- Include device output, error messages, or test results -->

### Breaking Changes
<!-- If this is a breaking change, describe the impact and migration path -->
<!-- Remove section if not applicable -->
