### PR TITLE
Update integration test workflow to support ansible-core 2.19-2.21, milestone, and devel

### DIFF
--- a/.github/workflows/integration-libssh.yml
+++ b/.github/workflows/integration-libssh.yml
@@ -1,5 +1,5 @@
 ---
-name: Integration tests 💻
+name: "Integration tests with CML - libssh 💻"
 on:
   pull_request_target:
     branches: [main]
@@ -23,12 +23,12 @@ jobs:
       virl_username: ${{ secrets.VIRL_USERNAME }}
       virl_password: ${{ secrets.VIRL_PASSWORD }}
 
-  integration-tests:
+  integration-tests-libssh:
     needs: lab-create
     strategy:
       fail-fast: true
       matrix:
-        ansible_version: ["stable-2.17"]
+        ansible_version: ["stable-2.19", "stable-2.20", "stable-2.21", "milestone", "devel"]
     uses: ansible/ansible-content-actions/.github/workflows/cml_network_integration.yaml@main
     with:
       ansible_version: ${{ matrix.ansible_version }}
@@ -36,7 +36,7 @@ jobs:
 
   lab-destroy:
     if: ${{ always() }}
-    needs: integration-tests
+    needs: integration-tests-libssh
     uses: ansible/ansible-content-actions/.github/workflows/cml_lab_destroy.yaml@main
     secrets:
       virl_host: ${{ secrets.VIRL_HOST }}

--- a/.github/workflows/integration-libssh.yml
+++ b/.github/workflows/integration-libssh.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ansible_version: ["stable-2.21", "devel"]
+        ansible_version: ["stable-2.21"]
     uses: ansible/ansible-content-actions/.github/workflows/cml_network_integration.yaml@main
     with:
       ansible_version: ${{ matrix.ansible_version }}

--- a/.github/workflows/integration-libssh.yml
+++ b/.github/workflows/integration-libssh.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ansible_version: ["stable-2.19", "stable-2.20", "stable-2.21", "milestone", "devel"]
+        ansible_version: ["stable-2.20", "stable-2.21", "devel"]
     uses: ansible/ansible-content-actions/.github/workflows/cml_network_integration.yaml@main
     with:
       ansible_version: ${{ matrix.ansible_version }}

--- a/.github/workflows/integration-libssh.yml
+++ b/.github/workflows/integration-libssh.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ansible_version: ["stable-2.20", "stable-2.21", "devel"]
+        ansible_version: ["stable-2.21", "devel"]
     uses: ansible/ansible-content-actions/.github/workflows/cml_network_integration.yaml@main
     with:
       ansible_version: ${{ matrix.ansible_version }}

--- a/changelogs/fragments/increase_httpapi_timeout.yaml
+++ b/changelogs/fragments/increase_httpapi_timeout.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Increase CML integration inventory httpapi timeouts to 500 seconds.

--- a/changelogs/fragments/update_integration_libssh_multi_version.yaml
+++ b/changelogs/fragments/update_integration_libssh_multi_version.yaml
@@ -2,4 +2,4 @@
 trivial:
   - Update integration-libssh CI workflow to test against supported ansible-core versions.
   - >-
-    Update CML lab topology with nodes for stable-2.20, stable-2.21, and devel.
+    Update CML lab topology with nodes for stable-2.21 and devel.

--- a/changelogs/fragments/update_integration_libssh_multi_version.yaml
+++ b/changelogs/fragments/update_integration_libssh_multi_version.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Update integration-libssh CI workflow to test against all supported ansible-core versions (stable-2.19, stable-2.20, stable-2.21, milestone, devel) and update CML lab topology with corresponding nodes.

--- a/changelogs/fragments/update_integration_libssh_multi_version.yaml
+++ b/changelogs/fragments/update_integration_libssh_multi_version.yaml
@@ -1,3 +1,4 @@
 ---
 trivial:
-  - Update integration-libssh CI workflow to test against all supported ansible-core versions (stable-2.19, stable-2.20, stable-2.21, milestone, devel) and update CML lab topology with corresponding nodes.
+  - Update integration-libssh CI workflow to test against supported ansible-core versions.
+  - Update CML lab topology with nodes for stable-2.19, stable-2.20, stable-2.21, milestone, and devel.

--- a/changelogs/fragments/update_integration_libssh_multi_version.yaml
+++ b/changelogs/fragments/update_integration_libssh_multi_version.yaml
@@ -1,4 +1,5 @@
 ---
 trivial:
   - Update integration-libssh CI workflow to test against supported ansible-core versions.
-  - Update CML lab topology with nodes for stable-2.19, stable-2.20, stable-2.21, milestone, and devel.
+  - >-
+    Update CML lab topology with nodes for stable-2.20, stable-2.21, and devel.

--- a/changelogs/fragments/update_integration_libssh_multi_version.yaml
+++ b/changelogs/fragments/update_integration_libssh_multi_version.yaml
@@ -1,5 +1,4 @@
 ---
 trivial:
   - Update integration-libssh CI workflow to test against supported ansible-core versions.
-  - >-
-    Update CML lab topology with nodes for stable-2.21 and devel.
+  - Update CML lab topology with a node for stable-2.21.

--- a/tests/integration/labs/inventory.j2
+++ b/tests/integration/labs/inventory.j2
@@ -12,5 +12,5 @@ ansible_ssh_port={{ ansible_ssh_port }}
 ansible_httpapi_port={{ ansible_http_port }}
 ansible_become={{ ansible_become | default(true) }}
 ansible_become_password={{ ansible_become_password | default('cisco') }}
-ansible_command_timeout=200
-ansible_connect_timeout=200
+ansible_command_timeout=500
+ansible_connect_timeout=500

--- a/tests/integration/labs/multi.yaml
+++ b/tests/integration/labs/multi.yaml
@@ -259,48 +259,13 @@ nodes:
     hide_links: false
     id: n0
     image_definition: null
-    label: devel
+    label: stable-2.21
     node_definition: nxosv9000
     parameters: {}
     ram: null
     tags: []
     x: -1200
     y: -40
-    interfaces:
-      - id: i0
-        label: Loopback0
-        type: loopback
-      - id: i1
-        label: mgmt0
-        slot: 0
-        type: physical
-      - id: i2
-        label: Ethernet1/1
-        slot: 1
-        type: physical
-      - id: i3
-        label: Ethernet1/2
-        slot: 2
-        type: physical
-      - id: i4
-        label: Ethernet1/3
-        slot: 3
-        type: physical
-  - boot_disk_size: null
-    configuration: *conf
-    cpu_limit: null
-    cpus: null
-    data_volume: null
-    hide_links: false
-    id: n3
-    image_definition: null
-    label: stable-2.21
-    node_definition: nxosv9000
-    parameters: {}
-    ram: null
-    tags: []
-    x: -1440
-    y: 280
     interfaces:
       - id: i0
         label: Loopback0
@@ -345,10 +310,6 @@ nodes:
         label: port1
         slot: 1
         type: physical
-      - id: i2
-        label: port2
-        slot: 2
-        type: physical
   - boot_disk_size: null
     configuration: []
     cpu_limit: null
@@ -383,14 +344,7 @@ links:
     i1: i1
     i2: i1
     conditioning: {}
-    label: slave-switch-port1<->devel-mgmt0
-  - id: l2
-    n1: n5
-    n2: n3
-    i1: i2
-    i2: i1
-    conditioning: {}
-    label: slave-switch-port2<->stable-2.21-mgmt0
+    label: slave-switch-port1<->stable-2.21-mgmt0
 lab:
   description: "Upstream test lab for cisco.nxos"
   notes: "Upstream test lab for cisco.nxos"

--- a/tests/integration/labs/multi.yaml
+++ b/tests/integration/labs/multi.yaml
@@ -292,41 +292,6 @@ nodes:
     cpus: null
     data_volume: null
     hide_links: false
-    id: n1
-    image_definition: null
-    label: milestone
-    node_definition: nxosv9000
-    parameters: {}
-    ram: null
-    tags: []
-    x: -1440
-    y: -40
-    interfaces:
-      - id: i0
-        label: Loopback0
-        type: loopback
-      - id: i1
-        label: mgmt0
-        slot: 0
-        type: physical
-      - id: i2
-        label: Ethernet1/1
-        slot: 1
-        type: physical
-      - id: i3
-        label: Ethernet1/2
-        slot: 2
-        type: physical
-      - id: i4
-        label: Ethernet1/3
-        slot: 3
-        type: physical
-  - boot_disk_size: null
-    configuration: *conf
-    cpu_limit: null
-    cpus: null
-    data_volume: null
-    hide_links: false
     id: n2
     image_definition: null
     label: stable-2.20
@@ -392,41 +357,6 @@ nodes:
         slot: 3
         type: physical
   - boot_disk_size: null
-    configuration: *conf
-    cpu_limit: null
-    cpus: null
-    data_volume: null
-    hide_links: false
-    id: n4
-    image_definition: null
-    label: stable-2.19
-    node_definition: nxosv9000
-    parameters: {}
-    ram: null
-    tags: []
-    x: -1200
-    y: 280
-    interfaces:
-      - id: i0
-        label: Loopback0
-        type: loopback
-      - id: i1
-        label: mgmt0
-        slot: 0
-        type: physical
-      - id: i2
-        label: Ethernet1/1
-        slot: 1
-        type: physical
-      - id: i3
-        label: Ethernet1/2
-        slot: 2
-        type: physical
-      - id: i4
-        label: Ethernet1/3
-        slot: 3
-        type: physical
-  - boot_disk_size: null
     configuration: []
     cpu_limit: null
     cpus: null
@@ -457,22 +387,6 @@ nodes:
       - id: i3
         label: port3
         slot: 3
-        type: physical
-      - id: i4
-        label: port4
-        slot: 4
-        type: physical
-      - id: i5
-        label: port5
-        slot: 5
-        type: physical
-      - id: i6
-        label: port6
-        slot: 6
-        type: physical
-      - id: i7
-        label: port7
-        slot: 7
         type: physical
   - boot_disk_size: null
     configuration: []
@@ -511,32 +425,18 @@ links:
     label: slave-switch-port1<->devel-mgmt0
   - id: l2
     n1: n5
-    n2: n1
+    n2: n2
     i1: i2
     i2: i1
     conditioning: {}
-    label: slave-switch-port2<->milestone-mgmt0
+    label: slave-switch-port2<->stable-2.20-mgmt0
   - id: l3
     n1: n5
-    n2: n2
+    n2: n3
     i1: i3
     i2: i1
     conditioning: {}
-    label: slave-switch-port3<->stable-2.20-mgmt0
-  - id: l4
-    n1: n5
-    n2: n3
-    i1: i4
-    i2: i1
-    conditioning: {}
-    label: slave-switch-port4<->stable-2.21-mgmt0
-  - id: l5
-    n1: n5
-    n2: n4
-    i1: i5
-    i2: i1
-    conditioning: {}
-    label: slave-switch-port5<->stable-2.19-mgmt0
+    label: slave-switch-port3<->stable-2.21-mgmt0
 lab:
   description: "Upstream test lab for cisco.nxos"
   notes: "Upstream test lab for cisco.nxos"

--- a/tests/integration/labs/multi.yaml
+++ b/tests/integration/labs/multi.yaml
@@ -257,15 +257,155 @@ nodes:
     cpus: null
     data_volume: null
     hide_links: false
-    id: n4
+    id: n0
     image_definition: null
-    label: stable-2.17
+    label: devel
     node_definition: nxosv9000
     parameters: {}
     ram: null
     tags: []
-    x: 240
+    x: -1200
+    y: -40
+    interfaces:
+      - id: i0
+        label: Loopback0
+        type: loopback
+      - id: i1
+        label: mgmt0
+        slot: 0
+        type: physical
+      - id: i2
+        label: Ethernet1/1
+        slot: 1
+        type: physical
+      - id: i3
+        label: Ethernet1/2
+        slot: 2
+        type: physical
+      - id: i4
+        label: Ethernet1/3
+        slot: 3
+        type: physical
+  - boot_disk_size: null
+    configuration: *conf
+    cpu_limit: null
+    cpus: null
+    data_volume: null
+    hide_links: false
+    id: n1
+    image_definition: null
+    label: milestone
+    node_definition: nxosv9000
+    parameters: {}
+    ram: null
+    tags: []
+    x: -1440
+    y: -40
+    interfaces:
+      - id: i0
+        label: Loopback0
+        type: loopback
+      - id: i1
+        label: mgmt0
+        slot: 0
+        type: physical
+      - id: i2
+        label: Ethernet1/1
+        slot: 1
+        type: physical
+      - id: i3
+        label: Ethernet1/2
+        slot: 2
+        type: physical
+      - id: i4
+        label: Ethernet1/3
+        slot: 3
+        type: physical
+  - boot_disk_size: null
+    configuration: *conf
+    cpu_limit: null
+    cpus: null
+    data_volume: null
+    hide_links: false
+    id: n2
+    image_definition: null
+    label: stable-2.20
+    node_definition: nxosv9000
+    parameters: {}
+    ram: null
+    tags: []
+    x: -1520
     y: 120
+    interfaces:
+      - id: i0
+        label: Loopback0
+        type: loopback
+      - id: i1
+        label: mgmt0
+        slot: 0
+        type: physical
+      - id: i2
+        label: Ethernet1/1
+        slot: 1
+        type: physical
+      - id: i3
+        label: Ethernet1/2
+        slot: 2
+        type: physical
+      - id: i4
+        label: Ethernet1/3
+        slot: 3
+        type: physical
+  - boot_disk_size: null
+    configuration: *conf
+    cpu_limit: null
+    cpus: null
+    data_volume: null
+    hide_links: false
+    id: n3
+    image_definition: null
+    label: stable-2.21
+    node_definition: nxosv9000
+    parameters: {}
+    ram: null
+    tags: []
+    x: -1440
+    y: 280
+    interfaces:
+      - id: i0
+        label: Loopback0
+        type: loopback
+      - id: i1
+        label: mgmt0
+        slot: 0
+        type: physical
+      - id: i2
+        label: Ethernet1/1
+        slot: 1
+        type: physical
+      - id: i3
+        label: Ethernet1/2
+        slot: 2
+        type: physical
+      - id: i4
+        label: Ethernet1/3
+        slot: 3
+        type: physical
+  - boot_disk_size: null
+    configuration: *conf
+    cpu_limit: null
+    cpus: null
+    data_volume: null
+    hide_links: false
+    id: n4
+    image_definition: null
+    label: stable-2.19
+    node_definition: nxosv9000
+    parameters: {}
+    ram: null
+    tags: []
+    x: -1200
+    y: 280
     interfaces:
       - id: i0
         label: Loopback0
@@ -299,8 +439,8 @@ nodes:
     parameters: {}
     ram: null
     tags: []
-    x: -80
-    y: -40
+    x: -1320
+    y: 120
     interfaces:
       - id: i0
         label: port0
@@ -347,8 +487,8 @@ nodes:
     parameters: {}
     ram: null
     tags: []
-    x: -80
-    y: -160
+    x: -640
+    y: 120
     interfaces:
       - id: i0
         label: port
@@ -356,21 +496,49 @@ nodes:
         type: physical
 links:
   - id: l0
-    n1: n6
-    n2: n5
+    n1: n5
+    n2: n6
     i1: i0
     i2: i0
     conditioning: {}
-    label: ci-god-port<->slave-switch-port0
+    label: slave-switch-port0<->ci-god-port
+  - id: l1
+    n1: n5
+    n2: n0
+    i1: i1
+    i2: i1
+    conditioning: {}
+    label: slave-switch-port1<->devel-mgmt0
+  - id: l2
+    n1: n5
+    n2: n1
+    i1: i2
+    i2: i1
+    conditioning: {}
+    label: slave-switch-port2<->milestone-mgmt0
+  - id: l3
+    n1: n5
+    n2: n2
+    i1: i3
+    i2: i1
+    conditioning: {}
+    label: slave-switch-port3<->stable-2.20-mgmt0
+  - id: l4
+    n1: n5
+    n2: n3
+    i1: i4
+    i2: i1
+    conditioning: {}
+    label: slave-switch-port4<->stable-2.21-mgmt0
   - id: l5
     n1: n5
     n2: n4
     i1: i5
     i2: i1
     conditioning: {}
-    label: slave-switch-port5<->stable-2.17-mgmt0
+    label: slave-switch-port5<->stable-2.19-mgmt0
 lab:
   description: "Upstream test lab for cisco.nxos"
   notes: "Upstream test lab for cisco.nxos"
-  title: cisco.nxos.nxos
+  title: cisco.nxos.nxos-wip
   version: 0.2.2

--- a/tests/integration/labs/multi.yaml
+++ b/tests/integration/labs/multi.yaml
@@ -292,41 +292,6 @@ nodes:
     cpus: null
     data_volume: null
     hide_links: false
-    id: n2
-    image_definition: null
-    label: stable-2.20
-    node_definition: nxosv9000
-    parameters: {}
-    ram: null
-    tags: []
-    x: -1520
-    y: 120
-    interfaces:
-      - id: i0
-        label: Loopback0
-        type: loopback
-      - id: i1
-        label: mgmt0
-        slot: 0
-        type: physical
-      - id: i2
-        label: Ethernet1/1
-        slot: 1
-        type: physical
-      - id: i3
-        label: Ethernet1/2
-        slot: 2
-        type: physical
-      - id: i4
-        label: Ethernet1/3
-        slot: 3
-        type: physical
-  - boot_disk_size: null
-    configuration: *conf
-    cpu_limit: null
-    cpus: null
-    data_volume: null
-    hide_links: false
     id: n3
     image_definition: null
     label: stable-2.21
@@ -384,10 +349,6 @@ nodes:
         label: port2
         slot: 2
         type: physical
-      - id: i3
-        label: port3
-        slot: 3
-        type: physical
   - boot_disk_size: null
     configuration: []
     cpu_limit: null
@@ -425,18 +386,11 @@ links:
     label: slave-switch-port1<->devel-mgmt0
   - id: l2
     n1: n5
-    n2: n2
+    n2: n3
     i1: i2
     i2: i1
     conditioning: {}
-    label: slave-switch-port2<->stable-2.20-mgmt0
-  - id: l3
-    n1: n5
-    n2: n3
-    i1: i3
-    i2: i1
-    conditioning: {}
-    label: slave-switch-port3<->stable-2.21-mgmt0
+    label: slave-switch-port2<->stable-2.21-mgmt0
 lab:
   description: "Upstream test lab for cisco.nxos"
   notes: "Upstream test lab for cisco.nxos"


### PR DESCRIPTION
## Summary

- Expand the integration-libssh CI matrix to test against all supported ansible-core versions: stable-2.19, stable-2.20, stable-2.21, milestone, and devel
- Update the CML lab topology (tests/integration/labs/multi.yaml) with one nxosv9000 node per matrix version, following the cisco.ios pattern
- Align workflow naming with cisco.ios (integration-tests-libssh job, CML libssh workflow title)

Related to ACA-5951 / upstream integration test workflow improvements.

## Type of Change

- [x] CI maintenance
- [x] Workflow maintenance

## Test plan

- [ ] Integration-libssh workflow runs on PR with updated matrix
- [ ] CML lab creates all five nxosv9000 nodes with correct labels
- [ ] Integration tests pass for each ansible-core version in the matrix