### PR TITLE
fix(bgp_global): generate `no bfd` when bfd.set is false for BGP neighbors

### DIFF
--- a/changelogs/fragments/fix_bgp_global_bfd_negation.yaml
+++ b/changelogs/fragments/fix_bgp_global_bfd_negation.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - nxos_bgp_global - Generate ``no bfd``, ``no bfd singlehop``, and ``no bfd multihop``
+    when ``bfd.set``, ``bfd.singlehop``, or ``bfd.multihop.set`` is false for BGP
+    neighbors (https://github.com/ansible-collections/cisco.nxos/pull/1073).

--- a/plugins/module_utils/network/nxos/rm_templates/bgp_global.py
+++ b/plugins/module_utils/network/nxos/rm_templates/bgp_global.py
@@ -45,6 +45,13 @@ def _tmplt_bfd(proc):
     bfd = proc.get("bfd", {})
     cmd = None
 
+    if bfd.get("set") is False:
+        return "no bfd"
+    if bfd.get("singlehop") is False:
+        return "no bfd singlehop"
+    if bfd.get("multihop", {}).get("set") is False:
+        return "no bfd multihop"
+
     if bfd.get("set"):
         cmd = "bfd"
     if bfd.get("singlehop"):

--- a/tests/integration/targets/nxos_bgp_global/tests/common/bfd_negation.yaml
+++ b/tests/integration/targets/nxos_bgp_global/tests/common/bfd_negation.yaml
@@ -1,0 +1,113 @@
+---
+- ansible.builtin.debug:
+    msg: Start nxos_bgp_global bfd negation integration tests connection={{ ansible_connection }}
+
+- ansible.builtin.include_tasks: _remove_config.yaml
+
+- block:
+    - name: Enable BFD feature
+      cisco.nxos.nxos_config:
+        lines:
+          - feature bfd
+      vars:
+        ansible_connection: ansible.netcommon.network_cli
+
+    - name: Setup BGP neighbors with BFD enabled
+      cisco.nxos.nxos_config:
+        lines:
+          - neighbor 198.51.100.30
+          - remote-as 65537
+          - bfd
+        parents:
+          - router bgp 65536
+      vars:
+        ansible_connection: ansible.netcommon.network_cli
+
+    - name: Setup BGP neighbor with BFD singlehop enabled
+      cisco.nxos.nxos_config:
+        lines:
+          - neighbor 198.51.100.31
+          - remote-as 65537
+          - bfd singlehop
+        parents:
+          - router bgp 65536
+      vars:
+        ansible_connection: ansible.netcommon.network_cli
+
+    - name: Setup BGP neighbor with BFD multihop enabled
+      cisco.nxos.nxos_config:
+        lines:
+          - neighbor 198.51.100.32
+          - remote-as 65537
+          - bfd multihop
+        parents:
+          - router bgp 65536
+      vars:
+        ansible_connection: ansible.netcommon.network_cli
+
+    - name: Remove BFD from BGP neighbors with bfd.set false
+      cisco.nxos.nxos_bgp_global:
+        config:
+          as_number: "65536"
+          neighbors:
+            - neighbor_address: 198.51.100.30
+              remote_as: "65537"
+              bfd:
+                set: false
+            - neighbor_address: 198.51.100.31
+              remote_as: "65537"
+              bfd:
+                singlehop: false
+            - neighbor_address: 198.51.100.32
+              remote_as: "65537"
+              bfd:
+                multihop:
+                  set: false
+        state: merged
+      register: result
+
+    - name: Assert BFD negation commands were generated
+      ansible.builtin.assert:
+        that:
+          - result.changed == true
+          - "'no bfd' in result.commands"
+          - "'no bfd singlehop' in result.commands"
+          - "'no bfd multihop' in result.commands"
+        msg: "Assert failed. 'result.commands': {{ result.commands }}"
+
+    - name: Verify BFD removed from running config
+      cisco.nxos.nxos_command:
+        commands:
+          - show running-config | section "router bgp"
+      register: bgp_cfg
+
+    - name: Assert running config no longer contains BFD on neighbors
+      ansible.builtin.assert:
+        that:
+          - bgp_cfg.stdout[0] is search('neighbor 198.51.100.30')
+          - bgp_cfg.stdout[0] is search('neighbor 198.51.100.31')
+          - bgp_cfg.stdout[0] is search('neighbor 198.51.100.32')
+          - "'bfd' not in bgp_cfg.stdout[0]"
+
+    - name: Idempotence - desired state without BFD keys
+      cisco.nxos.nxos_bgp_global:
+        config:
+          as_number: "65536"
+          neighbors:
+            - neighbor_address: 198.51.100.30
+              remote_as: "65537"
+            - neighbor_address: 198.51.100.31
+              remote_as: "65537"
+            - neighbor_address: 198.51.100.32
+              remote_as: "65537"
+        state: merged
+      register: result
+
+    - name: Assert that the previous task was idempotent
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+          - result.commands | length == 0
+
+  always:
+    - ansible.builtin.include_tasks: _remove_config.yaml

--- a/tests/unit/modules/network/nxos/test_nxos_bgp_global.py
+++ b/tests/unit/modules/network/nxos/test_nxos_bgp_global.py
@@ -307,6 +307,59 @@ class TestNxosBgpGlobalModule(TestNxosModule):
         result = self.execute_module(changed=False)
         self.assertEqual(result["commands"], [])
 
+    def test_nxos_bgp_global_bfd_negation(self):
+        run_cfg = dedent(
+            """\
+            router bgp 65536
+              neighbor 198.51.100.20
+                bfd
+                remote-as 65537
+              neighbor 198.51.100.21
+                bfd singlehop
+                remote-as 65537
+              neighbor 198.51.100.22
+                bfd multihop
+                remote-as 65537
+            """,
+        )
+        self.get_config.return_value = run_cfg
+        self.cfg_get_config.return_value = run_cfg
+
+        set_module_args(
+            dict(
+                config=dict(
+                    as_number="65536",
+                    neighbors=[
+                        dict(
+                            neighbor_address="198.51.100.20",
+                            bfd=dict(set=False),
+                        ),
+                        dict(
+                            neighbor_address="198.51.100.21",
+                            bfd=dict(singlehop=False),
+                        ),
+                        dict(
+                            neighbor_address="198.51.100.22",
+                            bfd=dict(multihop=dict(set=False)),
+                        ),
+                    ],
+                ),
+                state="merged",
+            ),
+            ignore_provider_arg,
+        )
+        commands = [
+            "router bgp 65536",
+            "neighbor 198.51.100.20",
+            "no bfd",
+            "neighbor 198.51.100.21",
+            "no bfd singlehop",
+            "neighbor 198.51.100.22",
+            "no bfd multihop",
+        ]
+        result = self.execute_module(changed=True)
+        self.assertEqual(set(result["commands"]), set(commands))
+
     def test_nxos_bgp_global_merged_idempotent(self):
         run_cfg = dedent(
             """\


### PR DESCRIPTION
## Summary

`nxos_bgp_global` silently ignored explicit BFD disablement for BGP neighbors. When a playbook set `bfd.set: false` (or `singlehop: false`, or `multihop.set: false`), the module generated no CLI — BFD remained active on the device even though automation reported success. This created a silent misconfiguration risk on production NX-OS switches.

## Root cause

The bug is in `_tmplt_bfd` in `plugins/module_utils/network/nxos/rm_templates/bgp_global.py`. Before this change, the function only handled **truthy** BFD values:

```python
if bfd.get("set"):
    cmd = "bfd"
# ...
if cmd:
    return cmd   # returns None when set: false
```

When `bfd.set` was `False`, every branch was skipped and `cmd` stayed `None`, so no command was emitted.

That alone is not sufficient context — the resource module `compare()` path for **dict** values also matters. For a nested dict like `bfd: {set: false}` when BFD is already configured on the neighbor, `compare()` calls `addcmd(want, "bfd", negate=False)`. Unlike plain boolean fields, dict values are **not** auto-negated by the framework; the `setval` function (`_tmplt_bfd`) must return the full command string, including `no bfd`, itself.

The same gap applied to `singlehop: false` and `multihop.set: false`.

## Fix

Add early-return branches in `_tmplt_bfd` for explicit `False` checks, following the established `_tmplt_dampening` pattern in `bgp_address_family.py`:

```python
if bfd.get("set") is False:
    return "no bfd"
if bfd.get("singlehop") is False:
    return "no bfd singlehop"
if bfd.get("multihop", {}).get("set") is False:
    return "no bfd multihop"
```

Uses `is False` (not truthiness) so omitted/`None` keys do not accidentally trigger negation.

**Files changed:**
- `plugins/module_utils/network/nxos/rm_templates/bgp_global.py` — fix `_tmplt_bfd`
- `changelogs/fragments/fix_bgp_global_bfd_negation.yaml` — changelog entry

## Unit test

Added `test_nxos_bgp_global_bfd_negation` in `tests/unit/modules/network/nxos/test_nxos_bgp_global.py`.

The test mocks running config with three neighbors having `bfd`, `bfd singlehop`, and `bfd multihop` respectively, then asserts that `state: merged` with explicit false values generates:

- `no bfd`
- `no bfd singlehop`
- `no bfd multihop`

All 21 existing `bgp_global` unit tests continue to pass.

## Integration test

Added `tests/integration/targets/nxos_bgp_global/tests/common/bfd_negation.yaml`.

The test runs on a live NX-OS device and:

1. Enables `feature bfd` and configures three BGP neighbors with BFD, BFD singlehop, and BFD multihop
2. Runs `nxos_bgp_global` with `bfd.set: false`, `singlehop: false`, and `multihop.set: false`
3. Asserts the generated commands include `no bfd`, `no bfd singlehop`, and `no bfd multihop`
4. Verifies BFD is absent from `show running-config | section "router bgp"`
5. Confirms idempotency when the desired state omits BFD keys

### Verified on a live NX-OS device

| | Before fix | After fix |
|---|---|---|
| `result.commands` | `[]` (empty) | `["router bgp 65137", "neighbor 65.38.208.2", "no bfd"]` |
| `changed` | `False` | `True` |
| Device config after | `bfd` still present | `bfd` removed |

### Reproduction playbook

```yaml
# 1. Device has BFD enabled:
#    router bgp 65137
#      neighbor 65.38.208.2
#        bfd
#        remote-as 65111

# 2. Run with bfd.set: false
- cisco.nxos.nxos_bgp_global:
    config:
      as_number: "65137"
      neighbors:
        - neighbor_address: 65.38.208.2
          remote_as: "65111"
          bfd:
            set: false
    state: merged
```

**Before fix:** No BFD-related command generated; BFD remains active.
**After fix:** `no bfd` correctly generated and applied to the device.

## Test plan

- [x] Fix `_tmplt_bfd` negation for `set`, `singlehop`, and `multihop.set`
- [x] Changelog fragment added
- [x] Unit test `test_nxos_bgp_global_bfd_negation` — all three negation variants
- [x] Integration test `bfd_negation.yaml` — live NX-OS CLI verification
- [x] All 21 existing `bgp_global` unit tests pass (zero regressions)
- [x] Verified end-to-end on a live NX-OS device (CML)