### PR TITLE
fixed nxos_l2_interface for trunk port functionality

### DIFF
--- a/changelogs/fragments/fix_l2_interfaces_replaced_overridden_trunk_vlans.yaml
+++ b/changelogs/fragments/fix_l2_interfaces_replaced_overridden_trunk_vlans.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nxos_l2_interfaces - Fix replaced and overridden states for trunk allowed VLANs to set the full desired VLAN list instead of using incremental add/remove, which could leave stale VLANs on the interface.

--- a/changelogs/fragments/fix_l2_interfaces_replaced_overridden_trunk_vlans.yaml
+++ b/changelogs/fragments/fix_l2_interfaces_replaced_overridden_trunk_vlans.yaml
@@ -1,2 +1,3 @@
 bugfixes:
-  - nxos_l2_interfaces - Fix replaced and overridden states for trunk allowed VLANs to set the full desired VLAN list instead of using incremental add/remove, which could leave stale VLANs on the interface.
+  - nxos_l2_interfaces - Fix replaced and overridden states for trunk allowed VLANs
+    to set the full desired VLAN list instead of incremental add/remove.

--- a/plugins/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
@@ -168,28 +168,14 @@ class L2_interfaces(ResourceModule):
             return
 
         if self.state in ("replaced", "overridden"):
-            # Replaced/overridden: make device match want_set exactly
-            # Remove vlans that are in have but not in want
-            vlans_to_remove = have_set - want_set
-            # Add vlans that are in want but not in have
-            vlans_to_add = want_set - have_set
-
             if not want_set and have_set:
-                # Want is empty but have has vlans - remove all
                 self.commands.append("no switchport trunk allowed vlan")
-            elif vlans_to_remove:
-                # Remove excess vlans first
-                self.commands.append(
-                    f"switchport trunk allowed vlan remove {vlan_list_to_range(sorted(vlans_to_remove, key=int))}",
-                )
-
-            if vlans_to_add:
-                # Add missing vlans
+            elif want_set and want_set != have_set:
                 self.commands.extend(
                     generate_switchport_trunk(
                         "allowed",
-                        True,
-                        vlan_list_to_range(sorted(vlans_to_add, key=int)),
+                        False,
+                        vlan_list_to_range(sorted(want_set, key=int)),
                     ),
                 )
 

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/action_states.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/action_states.yaml
@@ -28,7 +28,7 @@
           - "'interface Ethernet1/8' in result_replaced.commands"
           - "'switchport access vlan 6' in result_replaced.commands"
           - "'no switchport trunk native vlan 10' in result_replaced.commands"
-          - "'switchport trunk allowed vlan remove 1-199,201-559,1001-4094' in result_replaced.commands | join(' ')"
+          - "'switchport trunk allowed vlan 200,560-1000' in result_replaced.commands"
 
     - name: Replaced - idempotent
       register: result_replaced_idempotent

--- a/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
+++ b/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
@@ -367,13 +367,12 @@ class TestNxosL2InterfacesModule(TestNxosModule):
             "interface Ethernet1/6",
             "no cdp enable",
             "switchport access vlan 8",
-            "switchport trunk allowed vlan add 10-12",
+            "switchport trunk allowed vlan 10-12",
             "interface Ethernet1/7",
             "no cdp enable",
             "switchport trunk native vlan 25",
             "interface Ethernet1/8",
-            "switchport trunk allowed vlan remove 100-200,250",
-            "switchport trunk allowed vlan add 33",
+            "switchport trunk allowed vlan 33",
         ]
 
         result = self.execute_module(changed=True)
@@ -438,7 +437,7 @@ class TestNxosL2InterfacesModule(TestNxosModule):
         expected_commands = [
             "interface Ethernet1/10",
             "no cdp enable",
-            "switchport trunk allowed vlan remove 30-40,50-60",
+            "switchport trunk allowed vlan 10-20",
         ]
 
         result = self.execute_module(changed=True)
@@ -482,7 +481,7 @@ class TestNxosL2InterfacesModule(TestNxosModule):
             "interface Ethernet1/7",
             "no cdp enable",
             "switchport access vlan 6",
-            "switchport trunk allowed vlan remove 5,13-500",
+            "switchport trunk allowed vlan 10-12",
         ]
 
         result = self.execute_module(changed=True)
@@ -532,8 +531,7 @@ class TestNxosL2InterfacesModule(TestNxosModule):
 
         expected_commands = [
             "interface Ethernet1/6",
-            "switchport trunk allowed vlan remove 10-19,251-349,351-500",
-            "switchport trunk allowed vlan add 3999",
+            "switchport trunk allowed vlan 20-250,350,3999",
         ]
 
         result = self.execute_module(changed=True)
@@ -613,7 +611,7 @@ class TestNxosL2InterfacesModule(TestNxosModule):
             "no switchport trunk allowed vlan",
             "interface Ethernet1/10",
             "no cdp enable",
-            "switchport trunk allowed vlan remove 20,30",
+            "switchport trunk allowed vlan 10",
         ]
 
         result = self.execute_module(changed=True)
@@ -836,7 +834,7 @@ class TestNxosL2InterfacesModule(TestNxosModule):
             "interface Ethernet1/7",
             "no cdp enable",
             "switchport access vlan 6",
-            "switchport trunk allowed vlan add 10-12",
+            "switchport trunk allowed vlan 10-12",
         ]
 
         result = self.execute_module(changed=True)


### PR DESCRIPTION
## Description


 The _compare_lists method in l2_interfaces.py for replaced and overridden states. The old code
  used a two-step incremental approach:
  1. Calculate the diff between desired and existing VLANs
  2. Issue switchport trunk allowed vlan remove <unwanted> to remove extras
  3. Issue switchport trunk allowed vlan add <missing> to add missing ones

  The new code uses a single declarative command:
  1. Issue switchport trunk allowed vlan <full-desired-list> — which replaces the entire VLAN
  list in one shot

  The key change in the generate_switchport_trunk call is the second argument flipping from True
  to False — when True, the generated command includes the add keyword; when False, it omits it,
  producing a command that overwrites the VLAN list rather than appending to it.


- Why is this change needed?
 The incremental add/remove approach had a fundamental problem: it could leave stale VLANs on 
  the interface. For example:

  - Device has: allowed vlans 10-500
  - Playbook wants: allowed vlans 20-250,350,3999

  Old behavior generated:
  switchport trunk allowed vlan remove 10-19,251-349,351-500
  switchport trunk allowed vlan add 3999

  This is fragile because:
  - The remove and add are two separate operations — if one fails or the device processes them
  out of order, the interface ends up in an inconsistent state.
  - The replaced/overridden states promise the interface will match the playbook exactly, but
  incremental diffs don't guarantee that.

- How does this change address the issue?
The fix replaces the two-step diff logic with a single command:

  switchport trunk allowed vlan 20-250,350,3999

  This works because on NX-OS, switchport trunk allowed vlan <list> (without add) replaces the 
  entire allowed VLAN list atomically. The device handles the removal of unlisted VLANs and
  addition of new ones internally in a single operation.

  This is both simpler and more correct — it matches the semantics of replaced/overridden
  (declare the full desired state) with the device command that does exactly that (set the full
  VLAN list).

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New module (adding a new module to the collection)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Collection release
- [ ] CI maintenance
- [ ] Workflow maintenance
- [ ] Configuration change

## Related Issue
<!-- Optional: Link to related issue(s) -->
- Fixes #
- Related to #

## Component Name
<!-- Mandatory: Specify the module, plugin, or component being changed -->
<!-- Examples: nxos_config, nxos_bgp_global, cliconf plugin, httpapi plugin, terminal plugin, etc. -->
nxos_l2_interfaces

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [ ] I have removed all commented code (no commented code should be merged)
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment
- [x] I have verified the changes work with the target NX-OS version(s)
- [ ] I have reviewed the acceptance criteria for related tickets

## Testing Instructions
<!-- Mandatory for all changes: Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required (e.g., NX-OS version, hardware platform, test topology) -->
- NX-OS Version:
- Hardware Platform (if applicable):
- Test Topology:

### Steps to Test
1.
2.
3.

### Expected Results
<!-- Describe what should happen after following the steps -->

### Test Results
<!-- Paste test output or describe test results -->
```
```

## Acceptance Criteria Verification
<!-- Mandatory: Verify that all acceptance criteria from the related ticket are met -->
- [ ] All acceptance criteria have been reviewed and verified
- [ ] Acceptance criteria checklist:
  - [ ]
  - [ ]
  - [ ]

## Additional Context
<!-- Optional but helpful information -->
<!-- Include additional information to help people understand the change here -->
<!-- A step-by-step reproduction of the problem is helpful if there is no related issue -->

### Command Output / Logs
<!-- Paste verbatim command output below, e.g. before and after your change -->
```
<!-- Paste below -->
```

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- Module documentation, examples, platform guides -->
- [ ] Requires changelog fragment
  <!-- Create changelog fragment if this is a user-facing change -->
- [ ] Requires integration test updates
- [ ] Requires unit test updates
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
<!-- Include device output, error messages, or test results -->

### Breaking Changes
<!-- If this is a breaking change, describe the impact and migration path -->
<!-- Remove section if not applicable -->
