### PR TITLE
Update integration-libssh CI to ansible-core stable-2.21

### DIFF
--- a/.github/workflows/integration-libssh.yml
+++ b/.github/workflows/integration-libssh.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ansible_version: ["stable-2.17"]
+        ansible_version: ["stable-2.21"]
     uses: ansible/ansible-content-actions/.github/workflows/cml_network_integration.yaml@main
     with:
       ansible_version: ${{ matrix.ansible_version }}

--- a/changelogs/fragments/update_integration_ansible_2_21.yaml
+++ b/changelogs/fragments/update_integration_ansible_2_21.yaml
@@ -1,0 +1,5 @@
+---
+trivial:
+  - >-
+    Update integration-libssh CI workflow and CML lab topology to use
+    ansible-core stable-2.21 instead of stable-2.17.

--- a/tests/integration/labs/multi.yaml
+++ b/tests/integration/labs/multi.yaml
@@ -259,7 +259,7 @@ nodes:
     hide_links: false
     id: n4
     image_definition: null
-    label: stable-2.17
+    label: stable-2.21
     node_definition: nxosv9000
     parameters: {}
     ram: null
@@ -368,7 +368,7 @@ links:
     i1: i5
     i2: i1
     conditioning: {}
-    label: slave-switch-port5<->stable-2.17-mgmt0
+    label: slave-switch-port5<->stable-2.21-mgmt0
 lab:
   description: "Upstream test lab for cisco.nxos"
   notes: "Upstream test lab for cisco.nxos"


### PR DESCRIPTION
## Summary
- Bump the `integration-libssh` workflow matrix from `stable-2.17` to `stable-2.21`.
- Update the CML lab topology node label and switch link to match `stable-2.21`.

## Test plan
- [ ] Merge PR so `main` picks up the workflow and topology changes.
- [ ] Run integration tests against `main` via `workflow_dispatch`.
- [ ] Confirm the lab provisions the `stable-2.21` node and the integration job passes.