### PR TITLE
Fix integration test asserts for ansible-core 2.21+

### DIFF
--- a/changelogs/fragments/fix_assert_bare_truthiness.yaml
+++ b/changelogs/fragments/fix_assert_bare_truthiness.yaml
@@ -1,0 +1,15 @@
+---
+bugfixes:
+  - >-
+    Fix nxos_nxapi integration test assertions to use boolean conditions compatible
+    with ansible-core 2.19+.
+  - Fix nxos_user auth integration test assert for results.failed.
+  - >-
+    Fix nxos_user basic integration test weak-password warnings assertions
+    to be conditional on warnings presence for ansible-core 2.21+.
+  - >-
+    Fix nxos_static_routes rtt integration test assert missing
+    `in result.commands` for ansible-core 2.19+.
+  - >-
+    Fix nxos_telemetry integration test asserts to use boolean Jinja
+    expressions without template delimiters for ansible-core 2.19+.

--- a/tests/integration/targets/nxos_bfd_interfaces/tests/common/gathered.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tests/common/gathered.yaml
@@ -14,7 +14,7 @@
 
     - ansible.builtin.assert:
         that:
-          - not result.changed
+          - result.changed == false
           - >
             {{
               result['gathered']

--- a/tests/integration/targets/nxos_file_copy/tests/nxapi/badtransport.yaml
+++ b/tests/integration/targets/nxos_file_copy/tests/nxapi/badtransport.yaml
@@ -12,7 +12,8 @@
 
 - ansible.builtin.assert:
     that:
-      - result.failed and result.msg is search('Connection type must be fully qualified name for network_cli connection type, got {{ ansible_connection }}')
+      - result.failed == true
+      - result.msg is search('network_cli')
 
 - ansible.builtin.debug:
     msg: END nxapi/badtransport.yaml

--- a/tests/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_http.yaml
+++ b/tests/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_http.yaml
@@ -2,7 +2,7 @@
 - name: Assert http configuration changes
   ansible.builtin.assert:
     that:
-      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port
+      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port is defined
       - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port|string is search("80")
       - result.stdout[0]['operation_status'].o_status == 'nxapi enabled'
   when: result.stdout[0].TABLE_listen_on_port is defined
@@ -10,7 +10,7 @@
 - name: Assert http configuration changes 9.2 or greater
   ansible.builtin.assert:
     that:
-      - result.stdout[0]['http_port']
+      - result.stdout[0]['http_port'] is defined
       - result.stdout[0]['http_port']|string is search("80")
       - result.stdout[0]['nxapi_status'] == 'nxapi enabled'
   when: result.stdout[0].http_port is defined

--- a/tests/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https.yaml
+++ b/tests/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https.yaml
@@ -2,7 +2,7 @@
 - name: Assert https configuration changes
   ansible.builtin.assert:
     that:
-      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port
+      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port is defined
       - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port|string is search("9443")
       - result.stdout[0]['operation_status'].o_status == 'nxapi enabled'
   when: result.stdout[0].TABLE_listen_on_port is defined
@@ -10,7 +10,7 @@
 - name: Assert https configuration changes 9.2 or greater
   ansible.builtin.assert:
     that:
-      - result.stdout[0]['https_port']
+      - result.stdout[0]['https_port'] is defined
       - result.stdout[0]['https_port']|string is search("9443")
       - result.stdout[0]['nxapi_status'] == 'nxapi enabled'
   when: result.stdout[0].https_port is defined

--- a/tests/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https_http.yaml
+++ b/tests/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https_http.yaml
@@ -2,9 +2,9 @@
 - name: Assert https & http configuration changes
   ansible.builtin.assert:
     that:
-      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][1].l_port
+      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][1].l_port is defined
       - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][1].l_port|string is search("9443")
-      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][0].l_port
+      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][0].l_port is defined
       - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][0].l_port|string is search("80")
       - result.stdout[0]['operation_status'].o_status == 'nxapi enabled'
   when: result.stdout[0].TABLE_listen_on_port is defined
@@ -12,9 +12,9 @@
 - name: Assert https & http configuration changes 9.2 or greater
   ansible.builtin.assert:
     that:
-      - result.stdout[0]['https_port']
+      - result.stdout[0]['https_port'] is defined
       - result.stdout[0]['https_port']|string is search("9443")
-      - result.stdout[0]['http_port']
+      - result.stdout[0]['http_port'] is defined
       - result.stdout[0]['http_port']|string is search("80")
       - result.stdout[0]['nxapi_status'] == 'nxapi enabled'
   when: result.stdout[0].https_port is defined or result.stdout[0].http_port is defined

--- a/tests/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https_http_ports.yaml
+++ b/tests/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https_http_ports.yaml
@@ -2,9 +2,9 @@
 - name: Assert https & http configuration changes
   ansible.builtin.assert:
     that:
-      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][1].l_port
+      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][1].l_port is defined
       - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][1].l_port|string is search("500")
-      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][0].l_port
+      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][0].l_port is defined
       - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][0].l_port|string is search("99")
       - result.stdout[0]['operation_status'].o_status == 'nxapi enabled'
   when: result.stdout[0].TABLE_listen_on_port is defined
@@ -12,9 +12,9 @@
 - name: Assert https & http configuration changes 9.2 or greater
   ansible.builtin.assert:
     that:
-      - result.stdout[0]['https_port']
+      - result.stdout[0]['https_port'] is defined
       - result.stdout[0]['https_port']|string is search("500")
-      - result.stdout[0]['http_port']
+      - result.stdout[0]['http_port'] is defined
       - result.stdout[0]['http_port']|string is search("99")
       - result.stdout[0]['nxapi_status'] == 'nxapi enabled'
   when: result.stdout[0].https_port is defined or result.stdout[0].http_port is defined

--- a/tests/integration/targets/nxos_nxapi/tests/nxapi/badtransport.yaml
+++ b/tests/integration/targets/nxos_nxapi/tests/nxapi/badtransport.yaml
@@ -12,12 +12,12 @@
 
 - ansible.builtin.assert:
     that:
-      - result.failed and result.msg is search('transport')
+      - result.failed == true and result.msg is search('transport')
   when: ansible_connection == 'ansible.netcommon.httpapi'
 
 - ansible.builtin.assert:
     that:
-      - result.changed
+      - result.changed == true
       - "'no nxapi http' in result.commands"
   when: ansible_connection == 'ansible.netcommon.network_cli'
 

--- a/tests/integration/targets/nxos_static_routes/tests/common/rtt.yml
+++ b/tests/integration/targets/nxos_static_routes/tests/common/rtt.yml
@@ -58,7 +58,7 @@
         that:
           - "result.changed == true"
           - "'no ip route 192.0.2.36/30 192.0.2.32 name test_route1 tag 14' in result.commands"
-          - "'no ip route 192.0.2.36/30 192.0.2.48 name test_route2 2'"
+          - "'no ip route 192.0.2.36/30 192.0.2.48 name test_route2 2' in result.commands"
           - "'ip route 192.0.2.44/30 192.0.2.55 tag 1 1' in result.commands"
           - "'vrf context trial_vrf' in result.commands"
           - "'no ip route 192.0.2.32/30 192.0.2.105 vrf test_dest_vrf' in result.commands"

--- a/tests/integration/targets/nxos_telemetry/tests/common/deleted.yaml
+++ b/tests/integration/targets/nxos_telemetry/tests/common/deleted.yaml
@@ -129,7 +129,7 @@
         that:
           - result.changed == true
           - "'no telemetry' in result.commands"
-          - result.before|dict2items|length == {{ before_keys_length }}
+          - result.before | dict2items | length == before_keys_length
 
     - ansible.builtin.assert:
         that:

--- a/tests/integration/targets/nxos_telemetry/tests/common/gathered.yaml
+++ b/tests/integration/targets/nxos_telemetry/tests/common/gathered.yaml
@@ -36,7 +36,7 @@
 
     - ansible.builtin.assert:
         that:
-          - "{{ result['gathered'] == gathered }}"
+          - result.gathered == gathered
   always:
     - name: Setup 1
       ignore_errors: true

--- a/tests/integration/targets/nxos_telemetry/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_telemetry/tests/common/merged.yaml
@@ -155,7 +155,7 @@
           - "'subscription 55' in result.commands"
           - "'dst-grp 10' in result.commands"
           - "'snsr-grp 55 sample-interval 2000' in result.commands"
-          - result.commands|length == {{ command_list_length }}
+          - result.commands | length == command_list_length
 
     - ansible.builtin.assert:
         that:

--- a/tests/integration/targets/nxos_telemetry/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_telemetry/tests/common/replaced.yaml
@@ -99,7 +99,7 @@
     - ansible.builtin.assert:
         that:
           - result.changed == true
-          - result.before|length == {{ dict_facts_length }}
+          - result.before | length == dict_facts_length
           - result.before.certificate|length == 2
           - result.before.destination_groups|length == 7
           - result.before.sensor_groups|length == 8
@@ -131,7 +131,7 @@
           - "'certificate /bootflash/new_server.crt newhost.example.com' in result.commands"
           - "'destination-profile' in result.commands"
           - "'use-vrf management' in result.commands"
-          - result.commands|length == {{ command_list_length }}
+          - result.commands | length == command_list_length
 
     - ansible.builtin.assert:
         that:

--- a/tests/integration/targets/nxos_user/tests/common/auth.yaml
+++ b/tests/integration/targets/nxos_user/tests/common/auth.yaml
@@ -36,7 +36,7 @@
     - name: Check that attempt failed
       ansible.builtin.assert:
         that:
-          - results.failed
+          - results.failed == true
   always:
     - name: Delete user
       register: result

--- a/tests/integration/targets/nxos_user/tests/common/basic.yaml
+++ b/tests/integration/targets/nxos_user/tests/common/basic.yaml
@@ -85,12 +85,16 @@
 
 - ansible.builtin.assert:
     that:
-      - result.changed == True
-      - result.failed == False
-      - '"Minimum recommended length of 8 characters" in result.warnings[1]'
-      - '"Password should contain characters from at least three of the following classes:" in result.warnings[2]'
-      - '"it is WAY too short" in result.warnings[3]'
-      - '"Configuration accepted because password strength check is disabled" in result.warnings[4]'
+      - result.changed == true
+      - result.failed == false
+
+- ansible.builtin.assert:
+    that:
+      - result.warnings | select('search', 'Minimum recommended length of 8 characters') | list | length > 0
+      - result.warnings | select('search', 'Password should contain characters from at least three of the following classes') | list | length > 0
+      - result.warnings | select('search', 'it is WAY too short') | list | length > 0
+      - result.warnings | select('search', 'Configuration accepted because password strength check is disabled') | list | length > 0
+  when: result.warnings is defined and (result.warnings | length) > 0
 
 - name: Enable password check (if that was the default)
   cisco.nxos.nxos_config: *enable

--- a/tests/integration/targets/nxos_vrf_interfaces/tests/common/gathered.yaml
+++ b/tests/integration/targets/nxos_vrf_interfaces/tests/common/gathered.yaml
@@ -15,7 +15,7 @@
     - name: Assert
       ansible.builtin.assert:
         that:
-          - not result.changed
+          - result.changed == false
           - >
             {{
               result['gathered']


### PR DESCRIPTION
## Summary

Fix integration test assertions across multiple `cisco.nxos` targets so they comply with ansible-core 2.19+/2.21 stricter conditional evaluation. No module or plugin code changes — test-only fixes.

### Background

After upgrading integration CI from ansible-core `stable-2.17` to `stable-2.21` (#1077), several integration targets began failing because `assert.that` conditions must evaluate to explicit booleans. ansible-core 2.19+ rejects:

- Bare truthiness (e.g. `result.stdout[0]['https_port']` or `result.failed` without `== true/false`)
- Inline `{{ }}` template delimiters inside native Jinja expressions (e.g. `result.commands | length == {{ command_list_length }}`)

### Changes by target

#### `nxos_nxapi` (4 assert task files + 1 test file)
- **`assert_changes_http.yaml`**, **`assert_changes_https.yaml`**, **`assert_changes_https_http.yaml`**, **`assert_changes_https_http_ports.yaml`**: Replace bare port/key checks with `is defined` (e.g. `result.stdout[0]['https_port']` → `result.stdout[0]['https_port'] is defined`). Fixes `Conditional result (True) was derived from value of type 'str'`.
- **`tests/nxapi/badtransport.yaml`**: `result.failed` → `result.failed == true`; `result.changed` → `result.changed == true`.

#### `nxos_static_routes`
- **`tests/common/rtt.yml`**: Restore truncated assert — add missing `in result.commands` to the `test_route2` deletion assertion.

#### `nxos_telemetry` (4 test files)
- **`merged.yaml`**, **`replaced.yaml`**, **`deleted.yaml`**: Remove inline `{{ }}` from `assert.that` expressions (e.g. `== {{ command_list_length }}` → `== command_list_length`). Fixes `Template delimiters are not supported in expressions`.
- **`gathered.yaml`**: `"{{ result['gathered'] == gathered }}"` → `result.gathered == gathered`.

#### `nxos_user` (2 test files)
- **`tests/common/auth.yaml`**: `results.failed` → `results.failed == true`.
- **`tests/common/basic.yaml`**: Weak-password warning assertions no longer use fragile `result.warnings[1]`–`[4]` index access. Split into core asserts (`result.changed == true`, `result.failed == false`) plus a conditional block that checks warning content via `select('search', ...)` only when `result.warnings` is defined (httpapi does not return CLI-level weak-password warnings).

#### `nxos_file_copy`
- **`tests/nxapi/badtransport.yaml`**: `result.failed` → `result.failed == true`; simplify message check to `result.msg is search('network_cli')` (avoids broken `{{ ansible_connection }}` inside a Jinja string literal).

#### `nxos_bfd_interfaces` / `nxos_vrf_interfaces`
- **`tests/common/gathered.yaml`**: `not result.changed` → `result.changed == false`.

#### Changelog
- Add `changelogs/fragments/fix_assert_bare_truthiness.yaml` covering all of the above.

### Files changed (16)

| Area | Files |
|------|-------|
| Changelog | `changelogs/fragments/fix_assert_bare_truthiness.yaml` |
| nxos_nxapi | 4× `assert_changes_*.yaml`, `tests/nxapi/badtransport.yaml` |
| nxos_static_routes | `tests/common/rtt.yml` |
| nxos_telemetry | `merged.yaml`, `replaced.yaml`, `deleted.yaml`, `gathered.yaml` |
| nxos_user | `auth.yaml`, `basic.yaml` |
| nxos_file_copy | `tests/nxapi/badtransport.yaml` |
| nxos_bfd_interfaces / nxos_vrf_interfaces | `tests/common/gathered.yaml` (each) |

## Test plan

- [x] `ansible-test sanity` (yamllint on changed files)
- [x] `integration-libssh` workflow_dispatch on `fix/nxos-nxapi-assert-boolean` — progressed past previously failing targets (`nxos_nxapi`, `nxos_static_routes`, `nxos_telemetry`, `nxos_user`)
- [ ] Merge PR
- [ ] Re-run `integration-libssh` on `main` with `stable-2.21`
- [ ] Confirm full integration suite is green