### PR TITLE
Fix nxos_lag_interfaces NoneType when replaced on empty port-channel

### DIFF
--- a/changelogs/fragments/819-lag-interfaces-empty-members.yaml
+++ b/changelogs/fragments/819-lag-interfaces-empty-members.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - nxos_lag_interfaces - fix ``'NoneType' object is not iterable`` when using
+    replaced state on a port-channel with no members
+    (https://github.com/ansible-collections/cisco.nxos/issues/819).

--- a/plugins/module_utils/network/nxos/config/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/nxos/config/lag_interfaces/lag_interfaces.py
@@ -255,6 +255,12 @@ class Lag_interfaces(ConfigBase):
         return diff
 
     def intersect_list_of_dicts(self, w, h):
+        if not w:
+            w = []
+
+        if not h:
+            h = []
+
         intersect = []
         wmem = []
         hmem = []
@@ -302,9 +308,10 @@ class Lag_interfaces(ConfigBase):
         if not obj_in_have:
             commands = self.add_commands(w["members"], w["name"])
         else:
-            if "members" not in obj_in_have:
-                obj_in_have["members"] = None
-            diff = self.diff_list_of_dicts(w["members"], obj_in_have["members"])
+            diff = self.diff_list_of_dicts(
+                w.get("members") or [],
+                obj_in_have.get("members") or [],
+            )
             commands = self.add_commands(diff, w["name"])
         return commands
 
@@ -321,7 +328,10 @@ class Lag_interfaces(ConfigBase):
         commands = []
         obj_in_have = search_obj_in_list(w["name"], have, "name")
         if obj_in_have:
-            lst_to_del = self.intersect_list_of_dicts(w["members"], obj_in_have["members"])
+            lst_to_del = self.intersect_list_of_dicts(
+                w.get("members") or [],
+                obj_in_have.get("members") or [],
+            )
             if lst_to_del:
                 for item in lst_to_del:
                     commands.append("interface" + " " + item["member"])

--- a/tests/integration/targets/nxos_lag_interfaces/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_lag_interfaces/tests/common/replaced.yaml
@@ -73,6 +73,48 @@
     - ansible.builtin.assert:
         that:
           - result.changed == false
+
+    - name: Clear lag config before empty port-channel replaced (issue 819)
+      cisco.nxos.nxos_lag_interfaces: *id003
+
+    - name: Remove prior port-channels
+      ignore_errors: true
+      cisco.nxos.nxos_config:
+        lines:
+          - no interface port-channel 10
+          - no interface port-channel 11
+
+    - name: Create empty port-channel 11
+      ignore_errors: true
+      cisco.nxos.nxos_config:
+        lines:
+          - interface port-channel 11
+
+    - name: Replaced - empty port-channel with no members
+      register: result
+      cisco.nxos.nxos_lag_interfaces: &id004
+        config:
+          - name: port-channel11
+            members:
+              - member: "{{ test_int1 }}"
+                mode: active
+                force: true
+              - member: "{{ test_int2 }}"
+                mode: active
+                force: true
+        state: replaced
+
+    - ansible.builtin.assert:
+        that:
+          - result.changed == true
+
+    - name: Idempotence - replaced - empty port-channel
+      register: result
+      cisco.nxos.nxos_lag_interfaces: *id004
+
+    - ansible.builtin.assert:
+        that:
+          - result.changed == false
   always:
     - name: Teardown1
       ignore_errors: true

--- a/tests/unit/modules/network/nxos/test_nxos_lag_interfaces.py
+++ b/tests/unit/modules/network/nxos/test_nxos_lag_interfaces.py
@@ -1,0 +1,185 @@
+# (c) 2026 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import, division, print_function
+
+
+__metaclass__ = type
+
+from textwrap import dedent
+from unittest.mock import MagicMock, patch
+
+from ansible_collections.cisco.nxos.plugins.modules import nxos_lag_interfaces
+
+from .nxos_module import TestNxosModule, set_module_args
+
+
+ignore_provider_arg = True
+
+
+class TestNxosLagInterfacesModule(TestNxosModule):
+    module = nxos_lag_interfaces
+
+    def setUp(self):
+        super(TestNxosLagInterfacesModule, self).setUp()
+
+        self.mock_FACT_LEGACY_SUBSETS = patch(
+            "ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.facts.facts.FACT_LEGACY_SUBSETS",
+        )
+        self.FACT_LEGACY_SUBSETS = self.mock_FACT_LEGACY_SUBSETS.start()
+
+        self.mock_get_resource_connection_config = patch(
+            "ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base.get_resource_connection",
+        )
+        self.get_resource_connection_config = self.mock_get_resource_connection_config.start()
+
+        self.mock_get_resource_connection_facts = patch(
+            "ansible_collections.ansible.netcommon.plugins.module_utils.network.common.facts.facts.get_resource_connection",
+        )
+        self.get_resource_connection_facts = self.mock_get_resource_connection_facts.start()
+
+    def tearDown(self):
+        super(TestNxosLagInterfacesModule, self).tearDown()
+        self.mock_FACT_LEGACY_SUBSETS.stop()
+        self.mock_get_resource_connection_config.stop()
+        self.mock_get_resource_connection_facts.stop()
+
+    def load_fixtures(self, commands=None, device=""):
+        self.mock_FACT_LEGACY_SUBSETS.return_value = dict()
+        conn = MagicMock()
+        conn.edit_config.return_value = {}
+        self.get_resource_connection_config.return_value = conn
+
+    SHOW_CMD = "show running-config | section ^interface"
+
+    def test_replaced_empty_port_channel_no_members(self):
+        """Regression for #819: replaced on port-channel with no members."""
+        existing = dedent(
+            """\
+          interface port-channel100
+          interface Ethernet1/1
+          interface Ethernet1/2
+        """,
+        )
+        self.get_resource_connection_facts.return_value = {self.SHOW_CMD: existing}
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        name="port-channel100",
+                        members=[
+                            dict(member="Ethernet1/1", mode="active"),
+                        ],
+                    ),
+                ],
+                state="replaced",
+            ),
+            ignore_provider_arg,
+        )
+        commands = [
+            "interface Ethernet1/1",
+            "channel-group 100 mode active",
+        ]
+        self.execute_module(changed=True, commands=commands)
+
+    def test_replaced_with_existing_members(self):
+        existing = dedent(
+            """\
+          interface port-channel10
+          interface Ethernet1/1
+            channel-group 10
+          interface Ethernet1/2
+        """,
+        )
+        self.get_resource_connection_facts.return_value = {self.SHOW_CMD: existing}
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        name="port-channel10",
+                        members=[
+                            dict(member="Ethernet1/2", mode="active"),
+                        ],
+                    ),
+                ],
+                state="replaced",
+            ),
+            ignore_provider_arg,
+        )
+        commands = [
+            "interface Ethernet1/2",
+            "channel-group 10 mode active",
+        ]
+        self.execute_module(changed=True, commands=commands)
+
+    def test_replaced_empty_port_channel_idempotent(self):
+        existing = dedent(
+            """\
+          interface port-channel100
+          interface Ethernet1/1
+            channel-group 100 mode active
+          interface Ethernet1/2
+        """,
+        )
+        self.get_resource_connection_facts.return_value = {self.SHOW_CMD: existing}
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        name="port-channel100",
+                        members=[
+                            dict(member="Ethernet1/1", mode="active"),
+                        ],
+                    ),
+                ],
+                state="replaced",
+            ),
+            ignore_provider_arg,
+        )
+        self.execute_module(changed=False, commands=[])
+
+    def test_merged_empty_port_channel(self):
+        existing = dedent(
+            """\
+          interface port-channel11
+          interface Ethernet1/1
+          interface Ethernet1/2
+        """,
+        )
+        self.get_resource_connection_facts.return_value = {self.SHOW_CMD: existing}
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        name="port-channel11",
+                        members=[
+                            dict(member="Ethernet1/1"),
+                            dict(member="Ethernet1/2", mode="active"),
+                        ],
+                    ),
+                ],
+                state="merged",
+            ),
+            ignore_provider_arg,
+        )
+        commands = [
+            "interface Ethernet1/1",
+            "channel-group 11",
+            "interface Ethernet1/2",
+            "channel-group 11 mode active",
+        ]
+        self.execute_module(changed=True, commands=commands)


### PR DESCRIPTION
## Summary
- Fixes `'NoneType' object is not iterable` when `nxos_lag_interfaces` uses `state: replaced` on a port-channel with no members ([#819](https://github.com/ansible-collections/cisco.nxos/issues/819)).
- Stops mutating missing `members` to `None` in `set_commands()`, and hardens `intersect_list_of_dicts()` / `del_intf_commands()` to treat missing members as an empty list (same pattern as `diff_list_of_dicts()`).
- Adds unit coverage and an integration case for empty port-channel `replaced`.

## Test plan
- [x] Reproduced on inventory NXOS: empty PC + `state: replaced` → `'NoneType' object is not iterable`
- [x] Re-ran same playbook after fix → members added successfully (`failed=0`)
- [x] Unit: `test_nxos_lag_interfaces.py` (4 passed)
- [x] Sanity: changelog / yamllint / compile on changed files
- [x] Integration: `ansible-test network-integration --testcase replaced nxos_lag_interfaces` against `ansible-dev/inventory.ini` (`failed=0`)

Fixes #819