### PR TITLE
Remove pycrypto from requirements.txt for unit tests

### DIFF
--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,6 +1,5 @@
 boto3
 placebo
-pycrypto
 passlib
 pypsrp
 python-memcached


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- Why is this change needed?
Unit Test CI Jobs were failing today because of pycrypto being built.
  ```

  × Building wheel for pycrypto (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [73 lines of output]
      /tmp/pip-build-env-w34qkedt/overlay/lib/python3.14/site-packages/setuptools/dist.py:765: SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!
      
              ********************************************************************************
              Please consider removing the following classifiers in favor of a SPDX license expression:

```

Job Link: https://github.com/ansible-collections/cisco.nxos/actions/runs/29916683986/job/88912171317

There is not any pycrypto dependency present

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New module (adding a new module to the collection)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Collection release
- [x] CI maintenance
- [ ] Workflow maintenance
- [ ] Configuration change
