### PR TITLE
Fix nxos_route_maps fact gather crash on match metric +- deviation

### DIFF
--- a/changelogs/fragments/route_maps_match_metric_deviation.yaml
+++ b/changelogs/fragments/route_maps_match_metric_deviation.yaml
@@ -1,10 +1,7 @@
 ---
-bugfixes:
-  - nxos_route_maps - Fix fact gathering / parsed-state crash when route-map
-    entries use NX-OS metric deviation syntax
-    (``match metric <value> +- <deviation>``). Previously the parser split
-    tokens such as ``0 +- 100`` into ``["0", "+-", "100"]`` and
-    ``validate_config`` failed because ``match.metric`` was typed as a list
-    of integers. ``match.metric`` elements are now dictionaries with required
-    ``value`` (replacing the previous list-of-int form) and a new optional
-    ``deviation`` parameter (support case 04500155).
+minor_changes:
+  - nxos_route_maps - Add support for NX-OS metric deviation syntax
+    (``match metric <value> +- <deviation>``) and fix fact gathering /
+    parsed-state crash on that CLI. ``match.metric`` elements are now
+    dictionaries with required ``value`` (replacing the previous list-of-int
+    form) and a new optional ``deviation`` parameter (support case 04500155).

--- a/changelogs/fragments/route_maps_match_metric_deviation.yaml
+++ b/changelogs/fragments/route_maps_match_metric_deviation.yaml
@@ -5,5 +5,6 @@ bugfixes:
     (``match metric <value> +- <deviation>``). Previously the parser split
     tokens such as ``0 +- 100`` into ``["0", "+-", "100"]`` and
     ``validate_config`` failed because ``match.metric`` was typed as a list
-    of integers. ``match.metric`` now models a list of dicts with
-    ``value`` and optional ``deviation`` (support case 04500155).
+    of integers. ``match.metric`` elements are now dictionaries with required
+    ``value`` (replacing the previous list-of-int form) and a new optional
+    ``deviation`` parameter (support case 04500155).

--- a/changelogs/fragments/route_maps_match_metric_deviation.yaml
+++ b/changelogs/fragments/route_maps_match_metric_deviation.yaml
@@ -1,0 +1,9 @@
+---
+bugfixes:
+  - nxos_route_maps - Fix fact gathering / parsed-state crash when route-map
+    entries use NX-OS metric deviation syntax
+    (``match metric <value> +- <deviation>``). Previously the parser split
+    tokens such as ``0 +- 100`` into ``["0", "+-", "100"]`` and
+    ``validate_config`` failed because ``match.metric`` was typed as a list
+    of integers. ``match.metric`` now models a list of dicts with
+    ``value`` and optional ``deviation`` (support case 04500155).

--- a/changelogs/fragments/route_maps_match_metric_deviation.yaml
+++ b/changelogs/fragments/route_maps_match_metric_deviation.yaml
@@ -1,7 +1,8 @@
 ---
-minor_changes:
-  - nxos_route_maps - Add support for NX-OS metric deviation syntax
-    (``match metric <value> +- <deviation>``) and fix fact gathering /
-    parsed-state crash on that CLI. ``match.metric`` elements are now
-    dictionaries with required ``value`` (replacing the previous list-of-int
-    form) and a new optional ``deviation`` parameter (support case 04500155).
+breaking_changes:
+  - >-
+    nxos_route_maps - ``match.metric`` elements changed from a list of integers
+    to a list of dictionaries with required ``value`` and optional ``deviation``
+    (for NX-OS ``match metric <value> +- <deviation>``). Update playbooks from
+    ``metric: [10, 200]`` to ``metric: [{value: 10}, {value: 200}]`` (or add
+    ``deviation`` when needed). Fixes fact-gathering failures on that CLI.

--- a/docs/cisco.nxos.nxos_route_maps_module.rst
+++ b/docs/cisco.nxos.nxos_route_maps_module.rst
@@ -1179,15 +1179,56 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">list</span>
-                         / <span style="color: purple">elements=integer</span>
+                         / <span style="color: purple">elements=dictionary</span>
                     </div>
                 </td>
                 <td>
                 </td>
                 <td>
                         <div>Match metric of route.</div>
+                        <div>Supports plain metric values and NX-OS metric with deviation (<code>match metric &lt;value&gt; +- &lt;deviation&gt;</code>).</div>
                 </td>
             </tr>
+                                <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>deviation</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Metric deviation for <code>+-</code> matching (<code>match metric &lt;value&gt; +- &lt;deviation&gt;</code>).</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>value</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Metric value to match.</div>
+                </td>
+            </tr>
+
             <tr>
                     <td class="elbow-placeholder"></td>
                     <td class="elbow-placeholder"></td>

--- a/plugins/module_utils/network/nxos/argspec/route_maps/route_maps.py
+++ b/plugins/module_utils/network/nxos/argspec/route_maps/route_maps.py
@@ -229,7 +229,14 @@ class Route_mapsArgs(object):  # pylint: disable=R0903
                                     "type": "list",
                                     "elements": "str",
                                 },
-                                "metric": {"type": "list", "elements": "int"},
+                                "metric": {
+                                    "type": "list",
+                                    "elements": "dict",
+                                    "options": {
+                                        "value": {"type": "int", "required": True},
+                                        "deviation": {"type": "int"},
+                                    },
+                                },
                                 "ospf_area": {
                                     "type": "list",
                                     "elements": "int",

--- a/plugins/module_utils/network/nxos/config/route_maps/route_maps.py
+++ b/plugins/module_utils/network/nxos/config/route_maps/route_maps.py
@@ -32,6 +32,9 @@ from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.rm_templat
 )
 
 
+MATCH_METRIC = "match.metric"
+
+
 class Route_maps(ResourceModule):
     """
     The nxos_route_maps config class
@@ -93,7 +96,7 @@ class Route_maps(ResourceModule):
             "match.ipv6.next_hop.prefix_lists",
             "match.ipv6.route_source.prefix_lists",
             "match.mac_list",
-            "match.metric",
+            MATCH_METRIC,
             "match.ospf_area",
             "match.route_types",
             "match.source_protocol",
@@ -228,7 +231,7 @@ class Route_maps(ResourceModule):
                 wx = w_set
                 hx = h_set
 
-            if x == "match.metric":
+            if x == MATCH_METRIC:
                 # list of dicts (value + optional deviation) — not hashable for set()
                 def _metric_key(entry):
                     if isinstance(entry, dict):
@@ -240,7 +243,7 @@ class Route_maps(ResourceModule):
 
             elif isinstance(wx, list):
                 wx = set(wx)
-            if x != "match.metric" and isinstance(hx, list):
+            if x != MATCH_METRIC and isinstance(hx, list):
                 hx = set(hx)
 
             if wx != hx:

--- a/plugins/module_utils/network/nxos/config/route_maps/route_maps.py
+++ b/plugins/module_utils/network/nxos/config/route_maps/route_maps.py
@@ -228,9 +228,19 @@ class Route_maps(ResourceModule):
                 wx = w_set
                 hx = h_set
 
-            if isinstance(wx, list):
+            if x == "match.metric":
+                # list of dicts (value + optional deviation) — not hashable for set()
+                def _metric_key(entry):
+                    if isinstance(entry, dict):
+                        return (entry.get("value"), entry.get("deviation"))
+                    return entry
+
+                wx = {_metric_key(e) for e in (wx or [])}
+                hx = {_metric_key(e) for e in (hx or [])}
+
+            elif isinstance(wx, list):
                 wx = set(wx)
-            if isinstance(hx, list):
+            if x != "match.metric" and isinstance(hx, list):
                 hx = set(hx)
 
             if wx != hx:

--- a/plugins/module_utils/network/nxos/config/route_maps/route_maps.py
+++ b/plugins/module_utils/network/nxos/config/route_maps/route_maps.py
@@ -32,9 +32,6 @@ from ansible_collections.cisco.nxos.plugins.module_utils.network.nxos.rm_templat
 )
 
 
-MATCH_METRIC = "match.metric"
-
-
 class Route_maps(ResourceModule):
     """
     The nxos_route_maps config class
@@ -96,7 +93,7 @@ class Route_maps(ResourceModule):
             "match.ipv6.next_hop.prefix_lists",
             "match.ipv6.route_source.prefix_lists",
             "match.mac_list",
-            MATCH_METRIC,
+            "match.metric",
             "match.ospf_area",
             "match.route_types",
             "match.source_protocol",
@@ -231,7 +228,7 @@ class Route_maps(ResourceModule):
                 wx = w_set
                 hx = h_set
 
-            if x == MATCH_METRIC:
+            if x == "match.metric":
                 # list of dicts (value + optional deviation) — not hashable for set()
                 def _metric_key(entry):
                     if isinstance(entry, dict):
@@ -243,7 +240,7 @@ class Route_maps(ResourceModule):
 
             elif isinstance(wx, list):
                 wx = set(wx)
-            if x != MATCH_METRIC and isinstance(hx, list):
+            if x != "match.metric" and isinstance(hx, list):
                 hx = set(hx)
 
             if wx != hx:

--- a/plugins/module_utils/network/nxos/rm_templates/route_maps.py
+++ b/plugins/module_utils/network/nxos/rm_templates/route_maps.py
@@ -96,6 +96,40 @@ def _tmplt_set_metric(data):
     return cmd
 
 
+def _tmplt_match_metric(data):
+    cmd = "match metric"
+    for entry in data["match"]["metric"]:
+        cmd += " {0}".format(entry["value"])
+        if entry.get("deviation") is not None:
+            cmd += " +- {0}".format(entry["deviation"])
+    return cmd
+
+
+def _parse_match_metric(tokens):
+    """Convert split match-metric tokens into list of value/deviation dicts.
+
+    Handles both plain values (``100 200``) and deviation pairs
+    (``0 +- 100 100 +- 65000``).
+    """
+    if not tokens:
+        return []
+    # Already normalized (e.g. re-entrant validate / unit fixtures)
+    if isinstance(tokens[0], dict):
+        return tokens
+
+    result = []
+    i = 0
+    while i < len(tokens):
+        entry = {"value": int(tokens[i])}
+        if i + 2 < len(tokens) and tokens[i + 1] == "+-":
+            entry["deviation"] = int(tokens[i + 2])
+            i += 3
+        else:
+            i += 1
+        result.append(entry)
+    return result
+
+
 def _tmplt_set_ip_next_hop_verify_availability(data):
     cmd = []
     for each in data["set"]["ip"]["next_hop"]["verify_availability"]:
@@ -114,6 +148,17 @@ def _tmplt_set_ip_next_hop_verify_availability(data):
 class Route_mapsTemplate(NetworkTemplate):
     def __init__(self, lines=None, module=None):
         super(Route_mapsTemplate, self).__init__(lines=lines, tmplt=self, module=module)
+
+    def parse(self):
+        """Parse config and normalize match.metric tokens into dicts."""
+        result = super(Route_mapsTemplate, self).parse()
+        for route_map in result.values():
+            entries = route_map.get("entries") or {}
+            for entry in entries.values():
+                match = entry.get("match") or {}
+                if "metric" in match:
+                    match["metric"] = _parse_match_metric(match["metric"])
+        return result
 
     # fmt: off
     PARSERS = [
@@ -673,7 +718,7 @@ class Route_mapsTemplate(NetworkTemplate):
                 \s*
                 $""", re.VERBOSE,
             ),
-            "setval": "match metric {{ match.metric|join(' ') }}",
+            "setval": _tmplt_match_metric,
             "result": {
                 "{{ route_map }}": {
                     "entries": {

--- a/plugins/modules/nxos_route_maps.py
+++ b/plugins/modules/nxos_route_maps.py
@@ -193,9 +193,22 @@ options:
                 type: list
                 elements: str
               metric:
-                description: Match metric of route.
+                description:
+                  - Match metric of route.
+                  - Supports plain metric values and NX-OS metric with deviation
+                    (C(match metric <value> +- <deviation>)).
                 type: list
-                elements: int
+                elements: dict
+                suboptions:
+                  value:
+                    description: Metric value to match.
+                    type: int
+                    required: true
+                  deviation:
+                    description:
+                      - Metric deviation for C(+-) matching
+                        (C(match metric <value> +- <deviation>)).
+                    type: int
               ospf_area:
                 description: Match ospf area.
                 type: list

--- a/tests/integration/targets/nxos_route_maps/tests/common/match_metric_deviation.yaml
+++ b/tests/integration/targets/nxos_route_maps/tests/common/match_metric_deviation.yaml
@@ -1,0 +1,116 @@
+---
+- ansible.builtin.debug:
+    msg: START nxos_route_maps match metric deviation integration tests on connection={{ ansible_connection }}
+
+- name: Remove metric deviation test route-map
+  cisco.nxos.nxos_config:
+    lines:
+      - no route-map rmap_metric_dev
+  ignore_errors: true
+  vars:
+    ansible_connection: ansible.netcommon.network_cli
+
+- block:
+    - name: Populate match metric with deviation via raw CLI
+      cisco.nxos.nxos_config:
+        lines:
+          - match metric 0 +- 100
+          - match metric 100 +- 65000
+        parents:
+          - route-map rmap_metric_dev permit 10
+      vars:
+        ansible_connection: ansible.netcommon.network_cli
+
+    - name: Gather route-maps after seeding metric deviation
+      register: gather_result
+      cisco.nxos.nxos_route_maps:
+        state: gathered
+
+    - name: Assert gathered facts include metric deviation pairs
+      ansible.builtin.assert:
+        that:
+          - gather_result is succeeded
+          - gather_result.gathered | selectattr('route_map', 'equalto', 'rmap_metric_dev') | list | length == 1
+          - >
+            (gather_result.gathered | selectattr('route_map', 'equalto', 'rmap_metric_dev') | first).entries[0].match.metric
+            == [{'value': 0, 'deviation': 100}, {'value': 100, 'deviation': 65000}]
+
+    - name: Gather via nxos_facts route_maps resource
+      register: facts_result
+      cisco.nxos.nxos_facts:
+        gather_subset: min
+        gather_network_resources:
+          - route_maps
+
+    - name: Assert nxos_facts succeeds and parses metric deviation
+      ansible.builtin.assert:
+        that:
+          - facts_result is succeeded
+          - >
+            (ansible_network_resources.route_maps
+            | selectattr('route_map', 'equalto', 'rmap_metric_dev') | first).entries[0].match.metric
+            == [{'value': 0, 'deviation': 100}, {'value': 100, 'deviation': 65000}]
+
+    - name: Remove seeded route-map before merged test
+      cisco.nxos.nxos_config:
+        lines:
+          - no route-map rmap_metric_dev
+      vars:
+        ansible_connection: ansible.netcommon.network_cli
+
+    - name: Merge match metric deviation via resource module
+      register: merge_result
+      cisco.nxos.nxos_route_maps:
+        config:
+          - route_map: rmap_metric_dev
+            entries:
+              - sequence: 10
+                action: permit
+                match:
+                  metric:
+                    - value: 0
+                      deviation: 100
+                    - value: 100
+                      deviation: 65000
+        state: merged
+
+    - name: Assert merge generated expected match metric command
+      ansible.builtin.assert:
+        that:
+          - merge_result is changed
+          - "'match metric 0 +- 100 100 +- 65000' in merge_result.commands"
+          - merge_result.after | selectattr('route_map', 'equalto', 'rmap_metric_dev') | list | length == 1
+          - >
+            (merge_result.after | selectattr('route_map', 'equalto', 'rmap_metric_dev') | first).entries[0].match.metric
+            == [{'value': 0, 'deviation': 100}, {'value': 100, 'deviation': 65000}]
+
+    - name: Merge match metric deviation again (idempotent)
+      register: merge_idem
+      cisco.nxos.nxos_route_maps:
+        config:
+          - route_map: rmap_metric_dev
+            entries:
+              - sequence: 10
+                action: permit
+                match:
+                  metric:
+                    - value: 0
+                      deviation: 100
+                    - value: 100
+                      deviation: 65000
+        state: merged
+
+    - name: Assert merge is idempotent
+      ansible.builtin.assert:
+        that:
+          - merge_idem is not changed
+          - merge_idem.commands | length == 0
+
+  always:
+    - name: Cleanup metric deviation test route-map
+      cisco.nxos.nxos_config:
+        lines:
+          - no route-map rmap_metric_dev
+      ignore_errors: true
+      vars:
+        ansible_connection: ansible.netcommon.network_cli

--- a/tests/unit/modules/network/nxos/test_nxos_route_maps.py
+++ b/tests/unit/modules/network/nxos/test_nxos_route_maps.py
@@ -768,7 +768,10 @@ class TestNxosRouteMapsModule(TestNxosModule):
                                         route_source=dict(prefix_lists=["pl3", "pl4"]),
                                     ),
                                     mac_list=["mac1", "mac2"],
-                                    metric=[100, 200],
+                                    metric=[
+                                        dict(value=100),
+                                        dict(value=200),
+                                    ],
                                     ospf_area=[200, 300],
                                     route_types=["external", "inter-area"],
                                     source_protocol=["eigrp", "ospf"],
@@ -1547,6 +1550,90 @@ class TestNxosRouteMapsModule(TestNxosModule):
         commands = [
             "no route-map test-1 permit 10",
             "route-map test-2 permit 10",
+        ]
+        result = self.execute_module(changed=True)
+        self.assertEqual(set(result["commands"]), set(commands))
+
+    def test_nxos_route_maps_match_metric_deviation_parsed(self):
+        # NX-OS match metric <value> +- <deviation> must parse without crashing
+        running_config = dedent(
+            """\
+            route-map ARY-FROM-MSO-BRC permit 10
+              match ip address prefix-list FWG-NAT-POOLS-V4
+              match metric 0 +- 100
+              set community 65139:147
+            route-map ARY-TO-COLO-BRC permit 10
+              match metric 0 +- 100 100 +- 65000
+              set metric 10
+            """,
+        )
+        set_module_args(dict(running_config=running_config, state="parsed"), ignore_provider_arg)
+        result = self.execute_module(changed=False)
+        parsed = [
+            dict(
+                route_map="ARY-FROM-MSO-BRC",
+                entries=[
+                    dict(
+                        action="permit",
+                        sequence=10,
+                        match=dict(
+                            ip=dict(address=dict(prefix_lists=["FWG-NAT-POOLS-V4"])),
+                            metric=[dict(value=0, deviation=100)],
+                        ),
+                        set=dict(community=dict(number=["65139:147"])),
+                    ),
+                ],
+            ),
+            dict(
+                route_map="ARY-TO-COLO-BRC",
+                entries=[
+                    dict(
+                        action="permit",
+                        sequence=10,
+                        match=dict(
+                            metric=[
+                                dict(value=0, deviation=100),
+                                dict(value=100, deviation=65000),
+                            ],
+                        ),
+                        set=dict(metric=dict(bandwidth=10)),
+                    ),
+                ],
+            ),
+        ]
+        self.assertEqual(result["parsed"], parsed)
+
+    def test_nxos_route_maps_match_metric_deviation_merged(self):
+        self.get_config.return_value = dedent(
+            """\
+            """,
+        )
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        route_map="rmap1",
+                        entries=[
+                            dict(
+                                action="permit",
+                                sequence=10,
+                                match=dict(
+                                    metric=[
+                                        dict(value=0, deviation=100),
+                                        dict(value=100, deviation=65000),
+                                    ],
+                                ),
+                            ),
+                        ],
+                    ),
+                ],
+                state="merged",
+            ),
+            ignore_provider_arg,
+        )
+        commands = [
+            "route-map rmap1 permit 10",
+            "match metric 0 +- 100 100 +- 65000",
         ]
         result = self.execute_module(changed=True)
         self.assertEqual(set(result["commands"]), set(commands))


### PR DESCRIPTION
## Summary

Fixes fact gathering / parsed-state crashes in `nxos_route_maps` (and `nxos_facts` with `gather_network_resources: [route_maps]`) when a route-map entry uses NX-OS **metric deviation** syntax:

```
match metric <value> +- <deviation>
```

Resolves Red Hat support case [04500155](https://access.redhat.com/support/cases/#/case/04500155).

> Note: The failure came from route-map that used `match metric 0 +- 100`.

## What was going wrong

`match.metric` was defined as:

```python
"metric": {"type": "list", "elements": "int"}
```

The parser captured everything after `match metric` and split on whitespace:

```
match metric 0 +- 100
→ ["0", "+-", "100"]
```

`validate_config` then tried to coerce `"+-"` to `int` and aborted:

```
Elements value for option 'metric' found in 'config -> entries -> match'
is of type <class 'str'> and we were unable to convert to int:
<class 'str'> cannot be converted to an int
```

This is valid NX-OS CLI (confirmed on Nexus / NX-OS 10.4(2)). Multiple value+deviation pairs can also appear on one line:

```
match metric 0 +- 100 100 +- 65000
```

## What we changed

Modeled `match.metric` as a list of dicts (same idea as IOS route-map metric deviation support, adapted for NX-OS multi-pair lines):

| CLI | Parsed fact |
| --- | --- |
| `match metric 100 200` | `[{"value": 100}, {"value": 200}]` |
| `match metric 0 +- 100` | `[{"value": 0, "deviation": 100}]` |
| `match metric 0 +- 100 100 +- 65000` | `[{"value": 0, "deviation": 100}, {"value": 100, "deviation": 65000}]` |

Changes:

1. **Argspec / module docs** — `match.metric` is now `list` of dicts with required `value` (`int`) and optional `deviation` (`int`).
2. **rm_templates** — custom `setval` renders `+-` when present; `parse()` normalizes split tokens into dicts before validation.
3. **config compare** — `_compare_lists` handles list-of-dicts for `match.metric` (no longer assumes hashable ints).
4. **Unit tests** — parsed + merged coverage for deviation; existing plain-metric merged test updated to the new shape.
5. **Integration test** — `tests/integration/targets/nxos_route_maps/tests/common/match_metric_deviation.yaml` covers:
   - seed CLI `match metric +-` then `state: gathered`
   - `nxos_facts` with `gather_network_resources: [route_maps]`
   - `state: merged` command generation + idempotency
6. **Changelog fragment** — bugfix entry.

### Playbook shape (after this change)

```yaml
match:
  metric:
    - value: 0
      deviation: 100
    - value: 100
      deviation: 65000
```

Plain metrics (no deviation):

```yaml
match:
  metric:
    - value: 100
    - value: 200
```

> **Note:** this changes the `match.metric` argspec from `list[int]` to `list[dict]`. Existing playbooks that used `metric: [100, 200]` need to switch to the dict form above.

## How this solves it

Tokens like `+-` are no longer treated as metric element values. Each CLI metric/deviation pair maps to one dict, so `validate_config` succeeds and fact gathering / `state: parsed` work for real customer configs that mix as-path, prefix-lists, and metric deviation (as in case 04500155).

## Reproduction results (before / after)

Live lab repro on NX-OS 10.4(2) with:

```
route-map ANSIBLE-METRIC-DEV-TEST permit 10
  match metric 0 +- 100 100 +- 65000
route-map EXAMPLE permit 10
  match as-path SOME-NAMED-SET
```

### Before

```
TASK [Gather route_maps network resource facts]
fatal: [nxos]: FAILED! => {
  "msg": "Elements value for option 'metric' found in 'config -> entries -> match' is of type <class 'str'> and we were unable to convert to int: <class 'str'> cannot be converted to an int"
}
```

### After (this PR)

`cisco.nxos.nxos_facts` with `gather_network_resources: [route_maps]` succeeds:

```json
{
  "route_maps": [
    {
      "route_map": "ANSIBLE-METRIC-DEV-TEST",
      "entries": [
        {
          "sequence": 10,
          "action": "permit",
          "match": {
            "metric": [
              {"value": 0, "deviation": 100},
              {"value": 100, "deviation": 65000}
            ]
          }
        }
      ]
    },
    {
      "route_map": "EXAMPLE",
      "entries": [
        {
          "sequence": 10,
          "action": "permit",
          "match": {
            "as_path": ["SOME-NAMED-SET"]
          }
        }
      ]
    }
  ]
}
```

Customer-shaped config from case 04500155 (excerpt) also validates after the fix, e.g.:

```
route-map ARY-FROM-MSO-BRC permit 10
  match ip address prefix-list FWG-NAT-POOLS-V4
  match metric 0 +- 100
  set community 65139:147
```

## Test plan

- [x] Unit: `test_nxos_route_maps_match_metric_deviation_parsed`
- [x] Unit: `test_nxos_route_maps_match_metric_deviation_merged`
- [x] Unit: full `test_nxos_route_maps.py` (23 passed)
- [x] Integration: `match_metric_deviation.yaml` on live NX-OS (gathered + `nxos_facts` + merged idempotent)
- [x] Live NX-OS repro: push `match metric 0 +- 100` / multi-pair line, gather via `nxos_facts` (before crash / after success)
- [x] Confirm `match as-path <named-acl>` continues to parse as `as_path` (list of str) and is not involved in the failure
- [ ] CI unit / sanity on PR
