### PR TITLE
nxos_l2_interfaces: merged state uses SET for implicit default trunk VLAN

### DIFF
--- a/changelogs/fragments/l2_interfaces_merged_implicit_vlans.yaml
+++ b/changelogs/fragments/l2_interfaces_merged_implicit_vlans.yaml
@@ -1,0 +1,9 @@
+bugfixes:
+  - nxos_l2_interfaces - Fix ``state=merged`` to use SET instead of ADD when
+    restricting trunk VLANs on interfaces with implicit default allowed VLANs
+    (1-4094). Previously, merged was a no-op on default trunks because ADD
+    against the synthesized full range added nothing. Adds
+    ``allowed_vlans_implicit`` marker in facts to distinguish synthesized
+    defaults from explicit configuration. ``replaced``/``overridden``
+    semantics are unchanged
+    (https://github.com/ansible-collections/cisco.nxos/issues/AAP-85469).

--- a/docs/cisco.nxos.nxos_l2_interfaces_module.rst
+++ b/docs/cisco.nxos.nxos_l2_interfaces_module.rst
@@ -276,6 +276,29 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>allowed_vlans_implicit</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li>yes</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Read-only flag set by the module in gathered/parsed facts when a trunk interface has no explicit <code>switchport trunk allowed vlan</code> line and the module synthesizes the default <code>1-4094</code> range.</div>
+                        <div>When this flag is present in the current device state and <code>state=merged</code> is used, the module generates a SET command instead of ADD, allowing users to restrict default trunks to specific VLANs without switching to <code>state=replaced</code>.</div>
+                        <div>This option should not be set in playbook config; it is informational only.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>allowed_vlans_none</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -434,6 +457,61 @@ Examples
     # interface mgmt0
     #   ip address dhcp
     #   ipv6 address auto-config
+
+    # Using merged to restrict default trunk VLANs
+
+    # Before state:
+    # -------------
+    #
+    # switch# show running-config | section interface
+    # interface Ethernet1/4
+    #   switchport mode trunk
+    #   switchport trunk native vlan 99
+    #
+    # Note: No explicit "switchport trunk allowed vlan" line means the
+    # interface allows all VLANs (1-4094) by default. The module detects
+    # this as implicit and sets allowed_vlans_implicit: true in facts.
+
+    - name: Restrict default trunk to specific VLANs using merged state
+      cisco.nxos.nxos_l2_interfaces:
+        config:
+          - name: Ethernet1/4
+            trunk:
+              allowed_vlans: "100,200"
+        state: merged
+
+    # Task Output
+    # -----------
+    #
+    # before:
+    # - name: Ethernet1/4
+    #   mode: trunk
+    #   trunk:
+    #     allowed_vlans: "1-4094"
+    #     allowed_vlans_implicit: true
+    #     native_vlan: 99
+    # commands:
+    # - interface Ethernet1/4
+    # - switchport trunk allowed vlan 100,200
+    # after:
+    # - name: Ethernet1/4
+    #   mode: trunk
+    #   trunk:
+    #     allowed_vlans: "100,200"
+    #     native_vlan: 99
+
+    # After state:
+    # ------------
+    #
+    # switch# show running-config | section interface
+    # interface Ethernet1/4
+    #   switchport mode trunk
+    #   switchport trunk native vlan 99
+    #   switchport trunk allowed vlan 100,200
+    #
+    # Note: Because the have VLANs were implicit (default), merged used a
+    # SET command to restrict the trunk. If the trunk already had explicit
+    # VLANs, merged would use ADD to append only new VLANs.
 
     # Using replaced
 

--- a/plugins/module_utils/network/nxos/argspec/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/argspec/l2_interfaces/l2_interfaces.py
@@ -45,6 +45,7 @@ class L2_interfacesArgs(object):  # pylint: disable=R0903
                         "native_vlan": {"type": "int"},
                         "allowed_vlans": {"type": "str"},
                         "allowed_vlans_none": {"type": "bool"},
+                        "allowed_vlans_implicit": {"type": "bool"},
                     },
                 },
                 "mode": {

--- a/plugins/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
@@ -104,6 +104,10 @@ class L2_interfaces(ResourceModule):
 
         # if state is merged, merge want onto have and then compare
         if self.state == "merged":
+            for k, have in haved.items():
+                if have.get("trunk", {}).get("allowed_vlans_implicit"):
+                    if k in wantd and wantd[k].get("trunk", {}).get("allowed_vlans"):
+                        have.get("trunk", {}).pop("allowed_vlans", None)
             wantd = dict_merge(haved, wantd)
 
         # if state is deleted, empty out wantd and set haved to wantd
@@ -154,17 +158,25 @@ class L2_interfaces(ResourceModule):
             return
 
         if self.state in ("merged", "rendered"):
-            # Merged/rendered: only ADD vlans, never remove
-            # Add vlans that are in want but not in have
-            vlans_to_add = want_set - have_set
-            if vlans_to_add:
+            have_implicit = have.get("trunk", {}).get("allowed_vlans_implicit", False)
+            if have_implicit and want_set:
                 self.commands.extend(
                     generate_switchport_trunk(
                         "allowed",
-                        True,
-                        vlan_list_to_range(sorted(vlans_to_add, key=int)),
+                        False,
+                        vlan_list_to_range(sorted(want_set, key=int)),
                     ),
                 )
+            else:
+                vlans_to_add = want_set - have_set
+                if vlans_to_add:
+                    self.commands.extend(
+                        generate_switchport_trunk(
+                            "allowed",
+                            True,
+                            vlan_list_to_range(sorted(vlans_to_add, key=int)),
+                        ),
+                    )
             return
 
         if self.state in ("replaced", "overridden"):

--- a/plugins/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
@@ -104,6 +104,8 @@ class L2_interfaces(ResourceModule):
 
         # if state is merged, merge want onto have and then compare
         if self.state == "merged":
+            # Strip synthesized allowed_vlans before merge so implicit
+            # 1-4094 is not treated as an explicit configured set.
             for k, have in haved.items():
                 if have.get("trunk", {}).get("allowed_vlans_implicit"):
                     if k in wantd and wantd[k].get("trunk", {}).get("allowed_vlans"):

--- a/plugins/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
@@ -160,8 +160,7 @@ class L2_interfaces(ResourceModule):
             return
 
         if self.state in ("merged", "rendered"):
-            have_implicit = have.get("trunk", {}).get("allowed_vlans_implicit", False)
-            if have_implicit and want_set:
+            if not have_set and want_set:
                 self.commands.extend(
                     generate_switchport_trunk(
                         "allowed",

--- a/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/nxos/facts/l2_interfaces/l2_interfaces.py
@@ -56,6 +56,7 @@ class L2_interfacesFacts(object):
                     {},
                 ).get("allowed_vlans_none"):
                     interface["trunk"]["allowed_vlans"] = "1-4094"
+                    interface["trunk"]["allowed_vlans_implicit"] = True
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """Populate the facts for L2_interfaces network resource

--- a/plugins/modules/nxos_l2_interfaces.py
+++ b/plugins/modules/nxos_l2_interfaces.py
@@ -67,6 +67,17 @@ options:
             - negation of this command would consider 1-4093 as the default.
             - This attribute does not ensure idempotency.
             type: bool
+          allowed_vlans_implicit:
+            description:
+            - Read-only flag set by the module in gathered/parsed facts when a trunk
+              interface has no explicit C(switchport trunk allowed vlan) line and the
+              module synthesizes the default C(1-4094) range.
+            - When this flag is present in the current device state and C(state=merged)
+              is used, the module generates a SET command instead of ADD, allowing users
+              to restrict default trunks to specific VLANs without switching to
+              C(state=replaced).
+            - This option should not be set in playbook config; it is informational only.
+            type: bool
       mode:
         description:
         - Mode in which interface needs to be configured.
@@ -193,6 +204,61 @@ EXAMPLES = """
 # interface mgmt0
 #   ip address dhcp
 #   ipv6 address auto-config
+
+# Using merged to restrict default trunk VLANs
+
+# Before state:
+# -------------
+#
+# switch# show running-config | section interface
+# interface Ethernet1/4
+#   switchport mode trunk
+#   switchport trunk native vlan 99
+#
+# Note: No explicit "switchport trunk allowed vlan" line means the
+# interface allows all VLANs (1-4094) by default. The module detects
+# this as implicit and sets allowed_vlans_implicit: true in facts.
+
+- name: Restrict default trunk to specific VLANs using merged state
+  cisco.nxos.nxos_l2_interfaces:
+    config:
+      - name: Ethernet1/4
+        trunk:
+          allowed_vlans: "100,200"
+    state: merged
+
+# Task Output
+# -----------
+#
+# before:
+# - name: Ethernet1/4
+#   mode: trunk
+#   trunk:
+#     allowed_vlans: "1-4094"
+#     allowed_vlans_implicit: true
+#     native_vlan: 99
+# commands:
+# - interface Ethernet1/4
+# - switchport trunk allowed vlan 100,200
+# after:
+# - name: Ethernet1/4
+#   mode: trunk
+#   trunk:
+#     allowed_vlans: "100,200"
+#     native_vlan: 99
+
+# After state:
+# ------------
+#
+# switch# show running-config | section interface
+# interface Ethernet1/4
+#   switchport mode trunk
+#   switchport trunk native vlan 99
+#   switchport trunk allowed vlan 100,200
+#
+# Note: Because the have VLANs were implicit (default), merged used a
+# SET command to restrict the trunk. If the trunk already had explicit
+# VLANs, merged would use ADD to append only new VLANs.
 
 # Using replaced
 

--- a/tests/integration/targets/nxos_l2_interfaces/tests/common/merged_implicit_vlans.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tests/common/merged_implicit_vlans.yaml
@@ -1,0 +1,98 @@
+---
+- name: Debug - Start merged implicit VLANs tests
+  ansible.builtin.debug:
+    msg: Start nxos_l2_interfaces merged implicit VLANs integration tests connection={{ ansible_connection }}
+
+- block:
+    - name: Setup - configure trunk with native vlan only (no explicit allowed vlans)
+      cisco.nxos.nxos_config:
+        lines:
+          - switchport
+          - switchport mode trunk
+          - switchport trunk native vlan 99
+          - no switchport trunk allowed vlan
+        parents: interface Ethernet1/9
+      vars:
+        ansible_connection: ansible.netcommon.network_cli
+
+    - name: Gather facts - verify implicit flag is present
+      register: result_gathered
+      cisco.nxos.nxos_l2_interfaces:
+        state: gathered
+
+    - name: Assert - Ethernet1/9 has allowed_vlans_implicit flag
+      ansible.builtin.assert:
+        that:
+          - eth9_facts.trunk.allowed_vlans == "1-4094"
+          - eth9_facts.trunk.allowed_vlans_implicit == true
+          - eth9_facts.trunk.native_vlan == 99
+      vars:
+        eth9_facts: "{{ result_gathered.gathered | selectattr('name', 'equalto', 'Ethernet1/9') | first }}"
+
+    - name: Merged - restrict default trunk to specific VLANs
+      register: result_merged
+      cisco.nxos.nxos_l2_interfaces:
+        config:
+          - name: Ethernet1/9
+            trunk:
+              allowed_vlans: "100,200"
+        state: merged
+
+    - name: Assert Merged - SET command generated (not ADD)
+      ansible.builtin.assert:
+        that:
+          - result_merged.changed == true
+          - "'interface Ethernet1/9' in result_merged.commands"
+          - "'switchport trunk allowed vlan 100,200' in result_merged.commands"
+          - "'switchport trunk allowed vlan add' not in (result_merged.commands | join(' '))"
+
+    - name: Merged - idempotent (VLANs now explicit)
+      register: result_idempotent
+      cisco.nxos.nxos_l2_interfaces:
+        config:
+          - name: Ethernet1/9
+            trunk:
+              allowed_vlans: "100,200"
+        state: merged
+
+    - name: Assert Merged idempotent - no changes
+      ansible.builtin.assert:
+        that:
+          - result_idempotent.changed == false
+          - result_idempotent.commands | length == 0
+
+    - name: Merged - ADD new VLANs to explicit trunk
+      register: result_add
+      cisco.nxos.nxos_l2_interfaces:
+        config:
+          - name: Ethernet1/9
+            trunk:
+              allowed_vlans: "300,400"
+        state: merged
+
+    - name: Assert Merged - ADD command generated for explicit trunk
+      ansible.builtin.assert:
+        that:
+          - result_add.changed == true
+          - "'switchport trunk allowed vlan add 300,400' in result_add.commands"
+
+    - name: Verify - native_vlan was preserved throughout
+      register: result_verify
+      cisco.nxos.nxos_l2_interfaces:
+        state: gathered
+
+    - name: Assert - native_vlan and mode still intact
+      ansible.builtin.assert:
+        that:
+          - eth9_verify.trunk.native_vlan == 99
+          - eth9_verify.mode == "trunk"
+          - "'allowed_vlans_implicit' not in eth9_verify.trunk"
+      vars:
+        eth9_verify: "{{ result_verify.gathered | selectattr('name', 'equalto', 'Ethernet1/9') | first }}"
+
+  always:
+    - name: Teardown - reset interface
+      ignore_errors: true
+      cisco.nxos.nxos_config:
+        lines:
+          - "default interface Ethernet1/9"

--- a/tests/integration/targets/nxos_l2_interfaces/vars/main.yml
+++ b/tests/integration/targets/nxos_l2_interfaces/vars/main.yml
@@ -14,6 +14,7 @@ gathered:
   - name: Ethernet1/8
     trunk:
       allowed_vlans: "1-4094"
+      allowed_vlans_implicit: true
       native_vlan: 10
   - name: Ethernet1/9
   - name: Ethernet1/10

--- a/tests/integration/targets/nxos_l2_interfaces/vars/main.yml
+++ b/tests/integration/targets/nxos_l2_interfaces/vars/main.yml
@@ -92,13 +92,13 @@ parsed:
 
 rendered:
   - "interface Ethernet1/1"
-  - "switchport trunk allowed vlan add 2,4,15"
   - "switchport trunk native vlan 10"
+  - "switchport trunk allowed vlan 2,4,15"
   - "interface Ethernet1/2"
   - "switchport access vlan 30"
   - "interface Ethernet1/3"
-  - "switchport trunk allowed vlan add 5-10,15"
   - "switchport trunk native vlan 20"
+  - "switchport trunk allowed vlan 5-10,15"
   - "interface Ethernet1/4"
   - "switchport mode fex-fabric"
   - "interface Ethernet1/5"

--- a/tests/integration/targets/nxos_smoke/tests/common/caching.yaml
+++ b/tests/integration/targets/nxos_smoke/tests/common/caching.yaml
@@ -56,7 +56,7 @@
         that:
           - '"interface {{ nxos_int1 }}" in result.commands'
           - '"switchport trunk native vlan 10" in result.commands'
-          - '"switchport trunk allowed vlan add 2,4,15" in result.commands'
+          - '"switchport trunk allowed vlan 2,4,15" in result.commands'
           - result.commands|length == 3
 
     - name: Merge layer 2 interfaces configuration (idempotent)

--- a/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
+++ b/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
@@ -1087,7 +1087,6 @@ class TestNxosL2InterfacesModule(TestNxosModule):
         result = self.execute_module(changed=False)
         self.assertEqual(result["commands"], [])
 
-
     def test_l2_interfaces_merged_implicit_default_trunk_set(self):
         """Merged state uses SET when have is implicit default (1-4094).
 

--- a/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
+++ b/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
@@ -685,6 +685,7 @@ class TestNxosL2InterfacesModule(TestNxosModule):
                 "name": "Ethernet1/2",
                 "trunk": {
                     "allowed_vlans": "1-4094",
+                    "allowed_vlans_implicit": True,
                     "native_vlan": 20,
                 },
             },
@@ -1085,6 +1086,178 @@ class TestNxosL2InterfacesModule(TestNxosModule):
 
         result = self.execute_module(changed=False)
         self.assertEqual(result["commands"], [])
+
+
+    def test_l2_interfaces_merged_implicit_default_trunk_set(self):
+        """Merged state uses SET when have is implicit default (1-4094).
+
+        Customer scenario: trunk port with native_vlan but no explicit
+        allowed_vlans. Using merged to restrict VLANs should generate a
+        plain SET command, not ADD (which would be a no-op).
+        """
+        self.execute_show_command.return_value = dedent(
+            """
+            interface Ethernet1/4
+             switchport mode trunk
+             switchport trunk native vlan 99
+            """,
+        )
+
+        set_module_args(
+            dict(
+                config=[
+                    {
+                        "name": "Ethernet1/4",
+                        "trunk": {
+                            "allowed_vlans": "100,200",
+                        },
+                    },
+                ],
+            ),
+        )
+
+        expected_commands = [
+            "interface Ethernet1/4",
+            "switchport trunk allowed vlan 100,200",
+        ]
+
+        result = self.execute_module(changed=True)
+        self.assertEqual(result["commands"], expected_commands)
+
+    def test_l2_interfaces_merged_implicit_default_trunk_idempotent(self):
+        """Second run after implicit SET is idempotent — have is now explicit."""
+        self.execute_show_command.return_value = dedent(
+            """
+            interface Ethernet1/4
+             switchport mode trunk
+             switchport trunk native vlan 99
+             switchport trunk allowed vlan 100,200
+            """,
+        )
+
+        set_module_args(
+            dict(
+                config=[
+                    {
+                        "name": "Ethernet1/4",
+                        "trunk": {
+                            "allowed_vlans": "100,200",
+                        },
+                    },
+                ],
+            ),
+        )
+
+        result = self.execute_module(changed=False)
+        self.assertEqual(result["commands"], [])
+
+    def test_l2_interfaces_merged_explicit_trunk_still_adds(self):
+        """Merged with explicit have VLANs still uses ADD (not SET)."""
+        self.execute_show_command.return_value = dedent(
+            """
+            interface Ethernet1/4
+             switchport mode trunk
+             switchport trunk native vlan 99
+             switchport trunk allowed vlan 100,200
+            """,
+        )
+
+        set_module_args(
+            dict(
+                config=[
+                    {
+                        "name": "Ethernet1/4",
+                        "trunk": {
+                            "allowed_vlans": "300,400",
+                        },
+                    },
+                ],
+            ),
+        )
+
+        expected_commands = [
+            "interface Ethernet1/4",
+            "switchport trunk allowed vlan add 300,400",
+        ]
+
+        result = self.execute_module(changed=True)
+        self.assertEqual(result["commands"], expected_commands)
+
+    def test_l2_interfaces_replaced_implicit_trunk_unchanged(self):
+        """Replaced state behavior is NOT changed by the implicit marker."""
+        self.execute_show_command.return_value = dedent(
+            """
+            interface Ethernet1/4
+             switchport mode trunk
+             switchport trunk native vlan 99
+            """,
+        )
+
+        set_module_args(
+            dict(
+                config=[
+                    {
+                        "name": "Ethernet1/4",
+                        "trunk": {
+                            "allowed_vlans": "100,200",
+                        },
+                    },
+                ],
+                state="replaced",
+            ),
+        )
+
+        expected_commands = [
+            "interface Ethernet1/4",
+            "no cdp enable",
+            "no switchport mode trunk",
+            "no switchport trunk native vlan 99",
+            "switchport trunk allowed vlan 100,200",
+        ]
+
+        result = self.execute_module(changed=True)
+        self.assertEqual(result["commands"], expected_commands)
+
+    def test_l2_interfaces_gathered_implicit_flag(self):
+        """Gathered facts include allowed_vlans_implicit when VLANs are synthesized."""
+        self.execute_show_command.return_value = dedent(
+            """
+            interface Ethernet1/4
+             switchport mode trunk
+             switchport trunk native vlan 99
+            interface Ethernet1/5
+             switchport mode trunk
+             switchport trunk allowed vlan 100,200
+            """,
+        )
+
+        set_module_args(
+            dict(
+                state="gathered",
+            ),
+        )
+
+        expected = [
+            {
+                "mode": "trunk",
+                "name": "Ethernet1/4",
+                "trunk": {
+                    "allowed_vlans": "1-4094",
+                    "allowed_vlans_implicit": True,
+                    "native_vlan": 99,
+                },
+            },
+            {
+                "mode": "trunk",
+                "name": "Ethernet1/5",
+                "trunk": {
+                    "allowed_vlans": "100,200",
+                },
+            },
+        ]
+
+        result = self.execute_module(changed=False)
+        self.assertEqual(result["gathered"], expected)
 
 
 class TestGetPortChannelMembersUtil(TestNxosModule):

--- a/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
+++ b/tests/unit/modules/network/nxos/test_nxos_l2_interfaces.py
@@ -230,12 +230,12 @@ class TestNxosL2InterfacesModule(TestNxosModule):
             "interface Ethernet1/6",
             "cdp enable",
             "switchport mode trunk",
-            "switchport trunk allowed vlan add 10-12",
+            "switchport trunk allowed vlan 10-12",
             "interface Ethernet1/7",
             "switchport trunk allowed vlan add 21-22,101",
             "interface Ethernet1/8",
             "switchport trunk native vlan 10",
-            "switchport trunk allowed vlan add 1-4000",
+            "switchport trunk allowed vlan 1-4000",
         ]
 
         result = self.execute_module(changed=True)
@@ -299,14 +299,14 @@ class TestNxosL2InterfacesModule(TestNxosModule):
             "interface Ethernet1/6",
             "cdp enable",
             "switchport mode trunk",
-            "switchport trunk allowed vlan add 10-12",
+            "switchport trunk allowed vlan 10-12",
             "interface Ethernet1/8",
             "switchport trunk native vlan 10",
-            "switchport trunk allowed vlan add 1-4094",
+            "switchport trunk allowed vlan 1-4094",
             "interface Ethernet1/9",
             "switchport mode trunk",
             "switchport trunk native vlan 18",
-            "switchport trunk allowed vlan add 222",
+            "switchport trunk allowed vlan 222",
         ]
 
         result = self.execute_module(changed=True)


### PR DESCRIPTION
When a trunk interface has no explicit `switchport trunk allowed vlan` line, merged state now generates a SET command to restrict the trunk instead of ADD (which was a no-op against the synthesized 1-4094 default). This allows users to restrict default trunks without switching to state: replaced, which removes all unspecified L2 attributes.

Adds `allowed_vlans_implicit` marker in facts to distinguish synthesized defaults from explicit configuration. replaced/overridden semantics are unchanged.

Fixes: AAP-85469

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
- Why is this change needed?
- How does this change address the issue?

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New module (adding a new module to the collection)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Collection release
- [ ] CI maintenance
- [ ] Workflow maintenance
- [ ] Configuration change

## Related Issue
<!-- Optional: Link to related issue(s) -->
- Fixes #
- Related to #

## Component Name
<!-- Mandatory: Specify the module, plugin, or component being changed -->
<!-- Examples: nxos_config, nxos_bgp_global, cliconf plugin, httpapi plugin, terminal plugin, etc. -->

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [ ] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have removed all commented code (no commented code should be merged)
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment
- [ ] I have verified the changes work with the target NX-OS version(s)
- [ ] I have reviewed the acceptance criteria for related tickets

## Testing Instructions
<!-- Mandatory for all changes: Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required (e.g., NX-OS version, hardware platform, test topology) -->
- NX-OS Version:
- Hardware Platform (if applicable):
- Test Topology:

### Steps to Test
1.
2.
3.

### Expected Results
<!-- Describe what should happen after following the steps -->

### Test Results
<!-- Paste test output or describe test results -->
```
```

## Acceptance Criteria Verification
<!-- Mandatory: Verify that all acceptance criteria from the related ticket are met -->
- [ ] All acceptance criteria have been reviewed and verified
- [ ] Acceptance criteria checklist:
  - [ ]
  - [ ]
  - [ ]

## Additional Context
<!-- Optional but helpful information -->
<!-- Include additional information to help people understand the change here -->
<!-- A step-by-step reproduction of the problem is helpful if there is no related issue -->

### Command Output / Logs
<!-- Paste verbatim command output below, e.g. before and after your change -->
```
<!-- Paste below -->
```

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- Module documentation, examples, platform guides -->
- [ ] Requires changelog fragment
  <!-- Create changelog fragment if this is a user-facing change -->
- [ ] Requires integration test updates
- [ ] Requires unit test updates
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
<!-- Include device output, error messages, or test results -->

### Breaking Changes
<!-- If this is a breaking change, describe the impact and migration path -->
<!-- Remove section if not applicable -->
