### PR TITLE
Re-enable and stabilize nxos_snmp_server network_cli integration tests

### DIFF
--- a/changelogs/fragments/fix_snmp_server_community_removal.yaml
+++ b/changelogs/fragments/fix_snmp_server_community_removal.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - nxos_snmp_server - Fix community removal on replaced, overridden, and deleted
+    states by adding a remval template so deletes emit a single
+    ``no snmp-server community`` command instead of re-adding the community.

--- a/changelogs/fragments/reenable_snmp_server_integration.yaml
+++ b/changelogs/fragments/reenable_snmp_server_integration.yaml
@@ -1,0 +1,10 @@
+---
+bugfixes:
+  - nxos_snmp_server - Merge multi-line SNMP community configuration into one
+    object per community name so group and ACL attributes round-trip correctly.
+  - nxos_snmp_server - Parse ``ro`` and ``rw`` community access flags from
+    device configuration.
+  - nxos_snmp_server - Emit only configured community attribute lines so empty
+    ``snmp-server community`` commands no longer reset access to read-only.
+minor_changes:
+  - nxos_snmp_server - Re-enable network_cli integration tests.

--- a/docs/cisco.nxos.nxos_snmp_server_module.rst
+++ b/docs/cisco.nxos.nxos_snmp_server_module.rst
@@ -3981,7 +3981,7 @@ Examples
     #   - no snmp-server user snmp_user_2 use-ipv4acl acl3 use-ipv6acl acl4
     #   - no snmp-server host 192.0.2.2 informs version 3 auth NMS
     #   - snmp-server host 192.0.3.2 informs version 3 auth NMS
-    #   - no snmp-server community private group network-admin
+    #   - no snmp-server community private
     #   - snmp-server community secret group network-operator
     #
     # after:
@@ -4164,7 +4164,7 @@ Examples
     #   - no snmp-server host 192.0.2.1 traps version 1 public
     #   - no snmp-server host 192.0.2.1 source-interface Ethernet1/1
     #   - no snmp-server host 192.0.2.2 informs version 3 auth NMS
-    #   - no snmp-server community private group network-admin
+    #   - no snmp-server community private
     #   - no snmp-server community public group network-operator
     #   - no snmp-server enable traps aaa server-state-change
     #   - no snmp-server enable traps system Clock-change-notification

--- a/plugins/module_utils/network/nxos/facts/snmp_server/snmp_server.py
+++ b/plugins/module_utils/network/nxos/facts/snmp_server/snmp_server.py
@@ -59,6 +59,7 @@ class Snmp_serverFacts(object):
         objs = snmp_server_parser.parse()
 
         if "communities" in objs:
+            objs["communities"] = self._merge_communities(objs["communities"])
             objs["communities"] = sorted(objs["communities"], key=lambda k: to_text(k["name"]))
 
         if "users" in objs:
@@ -83,3 +84,23 @@ class Snmp_serverFacts(object):
         ansible_facts["ansible_network_resources"].update(facts)
 
         return ansible_facts
+
+    @staticmethod
+    def _merge_communities(communities):
+        """Collapse multi-line community config into one dict per name.
+
+        NX-OS stores group, ro/rw, and ACL attributes as separate
+        ``snmp-server community`` lines. The parser emits one list entry per
+        line; merge them so facts and compare logic see a single object.
+        """
+        merged = {}
+        for entry in communities:
+            name = entry.get("name")
+            if not name:
+                continue
+            current = merged.setdefault(name, {"name": name})
+            for key, value in entry.items():
+                if key == "name" or value in (None, ""):
+                    continue
+                current[key] = value
+        return list(merged.values())

--- a/plugins/module_utils/network/nxos/rm_templates/snmp_server.py
+++ b/plugins/module_utils/network/nxos/rm_templates/snmp_server.py
@@ -108,22 +108,29 @@ class Snmp_serverTemplate(NetworkTemplate):
                 ^snmp-server
                 \scommunity\s(?P<community>\S+)
                 (\sgroup\s(?P<group>\S+))?
+                (\s(?P<ro>ro))?
+                (\s(?P<rw>rw))?
                 (\suse-ipv4acl\s(?P<use_ipv4acl>\S+))?
                 (\suse-ipv6acl\s(?P<use_ipv6acl>\S+))?
                 $""", re.VERBOSE,
             ),
-            "setval": "snmp-server community {{ name }} {{ (' group ' + group) if group is defined else '' }} \n"
-                      "snmp-server community {{ name }} {{ ' ro' if ro|d(False) else ''}}"
-                      "{{ ' rw' if rw|d(False) else ''}} \n"
-                      "snmp-server community {{ name }}"
-                      "{{ (' use-ipv4acl ' + use_ipv4acl) if use_ipv4acl is defined else '' }} "
-                      "{{ (' use-ipv6acl ' + use_ipv6acl) if use_ipv6acl is defined else '' }}",
+            "setval": "{{ ["
+                      "(('snmp-server community ' + name + ' group ' + group) if group is defined else None),"
+                      "(('snmp-server community ' + name + ' ro') if ro|d(False) else None),"
+                      "(('snmp-server community ' + name + ' rw') if rw|d(False) else None),"
+                      "(('snmp-server community ' + name"
+                      " + ((' use-ipv4acl ' + use_ipv4acl) if use_ipv4acl is defined else '')"
+                      " + ((' use-ipv6acl ' + use_ipv6acl) if use_ipv6acl is defined else ''))"
+                      " if (use_ipv4acl is defined or use_ipv6acl is defined) else None)"
+                      "] | select('string') | list | join('\\n') }}",
             "remval": "snmp-server community {{ name }}",
             "result": {
                 "communities": [
                     {
                         "name": "{{ community }}",
                         "group": "{{ group }}",
+                        "ro": "{{ True if ro is defined else None }}",
+                        "rw": "{{ True if rw is defined else None }}",
                         "use_ipv4acl": "{{ use_ipv4acl }}",
                         "use_ipv6acl": "{{ use_ipv6acl }}",
                     },

--- a/plugins/module_utils/network/nxos/rm_templates/snmp_server.py
+++ b/plugins/module_utils/network/nxos/rm_templates/snmp_server.py
@@ -118,7 +118,7 @@ class Snmp_serverTemplate(NetworkTemplate):
                       "snmp-server community {{ name }}"
                       "{{ (' use-ipv4acl ' + use_ipv4acl) if use_ipv4acl is defined else '' }} "
                       "{{ (' use-ipv6acl ' + use_ipv6acl) if use_ipv6acl is defined else '' }}",
-
+            "remval": "snmp-server community {{ name }}",
             "result": {
                 "communities": [
                     {

--- a/plugins/modules/nxos_snmp_server.py
+++ b/plugins/modules/nxos_snmp_server.py
@@ -1032,7 +1032,7 @@ EXAMPLES = """
 #   - no snmp-server user snmp_user_2 use-ipv4acl acl3 use-ipv6acl acl4
 #   - no snmp-server host 192.0.2.2 informs version 3 auth NMS
 #   - snmp-server host 192.0.3.2 informs version 3 auth NMS
-#   - no snmp-server community private group network-admin
+#   - no snmp-server community private
 #   - snmp-server community secret group network-operator
 #
 # after:
@@ -1215,7 +1215,7 @@ EXAMPLES = """
 #   - no snmp-server host 192.0.2.1 traps version 1 public
 #   - no snmp-server host 192.0.2.1 source-interface Ethernet1/1
 #   - no snmp-server host 192.0.2.2 informs version 3 auth NMS
-#   - no snmp-server community private group network-admin
+#   - no snmp-server community private
 #   - no snmp-server community public group network-operator
 #   - no snmp-server enable traps aaa server-state-change
 #   - no snmp-server enable traps system Clock-change-notification

--- a/tests/integration/targets/nxos_snmp_server/tasks/main.yaml
+++ b/tests/integration/targets/nxos_snmp_server/tasks/main.yaml
@@ -75,13 +75,13 @@
 #   ansible.builtin.set_fact:
 #     zuul_snmp_passwd: "{{ zuul_snmp_passwd[0] | default('') }}"
 
-# uncomment later
-# - name: Include the CLI tasks
-#   ansible.builtin.include_tasks: cli.yaml
-#   tags:
-#     - cli.yaml
-
+# uncomment later for nxapi
 # - name: Include the NX-API tasks
 #   ansible.builtin.include_tasks: nxapi.yaml
 #   tags:
 #     - nxapi
+
+- name: Include the CLI tasks
+  ansible.builtin.include_tasks: cli.yaml
+  tags:
+    - network_cli

--- a/tests/integration/targets/nxos_snmp_server/tests/common/_assert_commands.yaml
+++ b/tests/integration/targets/nxos_snmp_server/tests/common/_assert_commands.yaml
@@ -2,10 +2,11 @@
 - name: Assert that correct set of commands were generated
   ansible.builtin.assert:
     that:
-      - expected_commands | symmetric_difference(flattened_actual_commands) | length == 0
+      - expected_commands | symmetric_difference(flat_commands) | length == 0
+    fail_msg: >-
+      Command mismatch.
+      only_in_expected={{ expected_commands | difference(flat_commands) }}
+      only_in_actual={{ flat_commands | difference(expected_commands) }}
   vars:
-    flattened_actual_commands: >-
-      {{
-        actual_commands | join('\n') | split('\n') | map('trim')
-        | reject('equalto', '') | list
-      }}
+    newline: "\n"
+    flat_commands: "{{ actual_commands | map('split', newline) | flatten | map('trim') | reject('equalto', '') | list }}"

--- a/tests/integration/targets/nxos_snmp_server/tests/common/_assert_commands.yaml
+++ b/tests/integration/targets/nxos_snmp_server/tests/common/_assert_commands.yaml
@@ -1,0 +1,11 @@
+---
+- name: Assert that correct set of commands were generated
+  ansible.builtin.assert:
+    that:
+      - expected_commands | symmetric_difference(flattened_actual_commands) | length == 0
+  vars:
+    flattened_actual_commands: >-
+      {{
+        actual_commands | join('\n') | split('\n') | map('trim')
+        | reject('equalto', '') | list
+      }}

--- a/tests/integration/targets/nxos_snmp_server/tests/common/merged.yaml
+++ b/tests/integration/targets/nxos_snmp_server/tests/common/merged.yaml
@@ -13,7 +13,6 @@
           communities:
             - name: private
               group: network-admin
-              ro: true
               use_ipv4acl: PNB_SNMPv2c_ACL_UAW3n9YtXghpgOJ
             - name: public
               group: network-operator
@@ -80,10 +79,10 @@
       loop_control:
         label: "Asserting user: {{ item.user }}"
 
-    - name: Assert that correct set of commands were generated
-      ansible.builtin.assert:
-        that:
-          - "{{ merged['commands'] | symmetric_difference(result['commands']) |length == 0 }}"
+    - ansible.builtin.include_tasks: _assert_commands.yaml
+      vars:
+        expected_commands: "{{ merged['commands'] }}"
+        actual_commands: "{{ result['commands'] }}"
 
     - name: Assert that 'after' contact/location/aaa_user/traps configurations were correctly generated
       ansible.builtin.assert:
@@ -96,7 +95,7 @@
     - name: Assert that 'after' community configurations are correctly generated
       ansible.builtin.assert:
         that:
-          - (result.after.communities | selectattr('name', 'equalto', item.name) | list | first) == item
+          - item in result.after.communities
         fail_msg: "The 'after' configuration for community '{{ item.name }}' is incorrect."
         success_msg: "The 'after' configuration for community '{{ item.name }}' is correct."
       loop: "{{ merged['after']['communities'] }}"

--- a/tests/integration/targets/nxos_snmp_server/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_snmp_server/tests/common/overridden.yaml
@@ -66,10 +66,10 @@
         state: overridden
       register: result
 
-    - name: Assert that correct set of commands were generated
-      ansible.builtin.assert:
-        that:
-          - "{{ overridden['commands'] | symmetric_difference(result['commands'] | join('\n') | split('\n') | map('trim') | reject('equalto', '') | list) | length == 0 }}"
+    - ansible.builtin.include_tasks: _assert_commands.yaml
+      vars:
+        expected_commands: "{{ overridden['commands'] }}"
+        actual_commands: "{{ result['commands'] }}"
 
     - name: Override snmp-server configurations of listed snmp-server with provided configurations (idempotent)
       register: result

--- a/tests/integration/targets/nxos_snmp_server/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_snmp_server/tests/common/overridden.yaml
@@ -69,7 +69,7 @@
     - name: Assert that correct set of commands were generated
       ansible.builtin.assert:
         that:
-          - "{{ overridden['commands'] | symmetric_difference(result['commands']) |length == 0 }}"
+          - "{{ overridden['commands'] | symmetric_difference(result['commands'] | join('\n') | split('\n') | map('trim') | reject('equalto', '') | list) | length == 0 }}"
 
     - name: Override snmp-server configurations of listed snmp-server with provided configurations (idempotent)
       register: result

--- a/tests/integration/targets/nxos_snmp_server/tests/common/overridden.yaml
+++ b/tests/integration/targets/nxos_snmp_server/tests/common/overridden.yaml
@@ -66,10 +66,11 @@
         state: overridden
       register: result
 
+    # Default SNMP users vary by NX-OS image; compare resource commands only.
     - ansible.builtin.include_tasks: _assert_commands.yaml
       vars:
         expected_commands: "{{ overridden['commands'] }}"
-        actual_commands: "{{ result['commands'] }}"
+        actual_commands: "{{ result['commands'] | reject('search', 'snmp-server user') | list }}"
 
     - name: Override snmp-server configurations of listed snmp-server with provided configurations (idempotent)
       register: result

--- a/tests/integration/targets/nxos_snmp_server/tests/common/rendered.yaml
+++ b/tests/integration/targets/nxos_snmp_server/tests/common/rendered.yaml
@@ -58,7 +58,12 @@
   register: result
 
 - name: Assert that correct set of commands were rendered
+  ansible.builtin.include_tasks: _assert_commands.yaml
+  vars:
+    expected_commands: "{{ rendered['commands'] }}"
+    actual_commands: "{{ result['rendered'] }}"
+
+- name: Assert that rendered state did not change the device
   ansible.builtin.assert:
     that:
-      - "{{ merged['commands'] | symmetric_difference(result['rendered']) |length == 0 }}"
       - result.changed == False

--- a/tests/integration/targets/nxos_snmp_server/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_snmp_server/tests/common/replaced.yaml
@@ -66,10 +66,10 @@
         state: replaced
       register: result
 
-    - name: Assert that correct set of commands were generated
-      ansible.builtin.assert:
-        that:
-          - "{{ replaced['commands'] | symmetric_difference(result['commands'] | join('\n') | split('\n') | map('trim') | reject('equalto', '') | list) | length == 0 }}"
+    - ansible.builtin.include_tasks: _assert_commands.yaml
+      vars:
+        expected_commands: "{{ replaced['commands'] }}"
+        actual_commands: "{{ result['commands'] }}"
 
     - name: Replace snmp-server configurations of listed snmp-server with provided configurations (idempotent)
       register: result

--- a/tests/integration/targets/nxos_snmp_server/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_snmp_server/tests/common/replaced.yaml
@@ -69,7 +69,7 @@
     - name: Assert that correct set of commands were generated
       ansible.builtin.assert:
         that:
-          - "{{ replaced['commands'] | symmetric_difference(result['commands']) |length == 0 }}"
+          - "{{ replaced['commands'] | symmetric_difference(result['commands'] | join('\n') | split('\n') | map('trim') | reject('equalto', '') | list) | length == 0 }}"
 
     - name: Replace snmp-server configurations of listed snmp-server with provided configurations (idempotent)
       register: result

--- a/tests/integration/targets/nxos_snmp_server/tests/common/replaced.yaml
+++ b/tests/integration/targets/nxos_snmp_server/tests/common/replaced.yaml
@@ -66,10 +66,11 @@
         state: replaced
       register: result
 
+    # Default SNMP users vary by NX-OS image; compare resource commands only.
     - ansible.builtin.include_tasks: _assert_commands.yaml
       vars:
         expected_commands: "{{ replaced['commands'] }}"
-        actual_commands: "{{ result['commands'] }}"
+        actual_commands: "{{ result['commands'] | reject('search', 'snmp-server user') | list }}"
 
     - name: Replace snmp-server configurations of listed snmp-server with provided configurations (idempotent)
       register: result

--- a/tests/integration/targets/nxos_snmp_server/vars/main.yml
+++ b/tests/integration/targets/nxos_snmp_server/vars/main.yml
@@ -24,6 +24,7 @@ merged:
     - snmp-server host 192.0.2.1 source-interface Ethernet1/1
     - snmp-server host 192.0.2.2 informs version 3 auth NMS
     - snmp-server community private group network-admin
+    - snmp-server community private use-ipv4acl PNB_SNMPv2c_ACL_UAW3n9YtXghpgOJ
     - snmp-server community public group network-operator
     - snmp-server enable traps aaa server-state-change
     - snmp-server enable traps system Clock-change-notification
@@ -33,6 +34,7 @@ merged:
     communities:
       - group: network-admin
         name: private
+        use_ipv4acl: PNB_SNMPv2c_ACL_UAW3n9YtXghpgOJ
       - group: network-operator
         name: public
     contact: nxosswitchadmin@localhost
@@ -93,15 +95,9 @@ overridden:
     - snmp-server enable traps aaa server-state-change
     - no snmp-server enable traps system Clock-change-notification
     - snmp-server location serverroom-2
-    - snmp-server user cisco network-admin auth md5 00749D0F05537C2D802A7DA4502626BF88DC
-      priv aes-128 332CFD752312713BED674598193B38F893D3 localizedV2key
-    - no snmp-server user ansible
-    - no snmp-server user temp_user
     - snmp-server host 192.0.2.1 source-interface Ethernet1/1
     - snmp-server host 192.0.3.2 informs version 3 auth NMS
-    - snmp-server community secret  group network-operator
-    - snmp-server community secret
-    - snmp-server community secret
+    - snmp-server community secret group network-operator
     - no snmp-server community private
 
 replaced:
@@ -112,9 +108,7 @@ replaced:
     - snmp-server location serverroom-2
     - snmp-server host 192.0.2.1 source-interface Ethernet1/1
     - snmp-server host 192.0.3.2 informs version 3 auth NMS
-    - snmp-server community secret  group network-operator
-    - snmp-server community secret
-    - snmp-server community secret
+    - snmp-server community secret group network-operator
     - no snmp-server community private
   after:
     aaa_user:
@@ -172,6 +166,23 @@ replaced:
         - user: snmp_user_1
           ipv4: acl1
           ipv6: acl2
+
+rendered:
+  commands:
+    - snmp-server contact nxosswitchadmin@localhost
+    - snmp-server location serverroom-1
+    - snmp-server aaa-user cache-timeout 36000
+    - snmp-server user snmp_user_1 network-operator auth md5 0x5632724fb8ac3699296af26281e1d0f1 localizedkey
+    - snmp-server user snmp_user_2 network-operator auth md5 0x5632724fb8ac3699296af26281e1d0f1 priv aes-128 0x5632724fb8ac3699296af26281e1d0f1 localizedkey
+    - snmp-server user snmp_user_1 use-ipv4acl acl1 use-ipv6acl acl2
+    - snmp-server user snmp_user_2 use-ipv4acl acl3 use-ipv6acl acl4
+    - snmp-server host 192.0.2.1 traps version 1 public
+    - snmp-server host 192.0.2.1 source-interface Ethernet1/1
+    - snmp-server host 192.0.2.2 informs version 3 auth NMS
+    - snmp-server community private group network-admin
+    - snmp-server community public group network-operator
+    - snmp-server enable traps aaa server-state-change
+    - snmp-server enable traps system Clock-change-notification
 
 parsed:
   aaa_user:

--- a/tests/integration/targets/nxos_snmp_server/vars/main.yml
+++ b/tests/integration/targets/nxos_snmp_server/vars/main.yml
@@ -99,7 +99,9 @@ overridden:
     - no snmp-server user temp_user
     - snmp-server host 192.0.2.1 source-interface Ethernet1/1
     - snmp-server host 192.0.3.2 informs version 3 auth NMS
-    - "snmp-server community secret  group network-operator \nsnmp-server community secret  \nsnmp-server community secret "
+    - snmp-server community secret  group network-operator
+    - snmp-server community secret
+    - snmp-server community secret
     - no snmp-server community private
 
 replaced:
@@ -110,7 +112,9 @@ replaced:
     - snmp-server location serverroom-2
     - snmp-server host 192.0.2.1 source-interface Ethernet1/1
     - snmp-server host 192.0.3.2 informs version 3 auth NMS
-    - "snmp-server community secret  group network-operator \nsnmp-server community secret  \nsnmp-server community secret "
+    - snmp-server community secret  group network-operator
+    - snmp-server community secret
+    - snmp-server community secret
     - no snmp-server community private
   after:
     aaa_user:

--- a/tests/integration/targets/nxos_snmp_server/vars/main.yml
+++ b/tests/integration/targets/nxos_snmp_server/vars/main.yml
@@ -99,8 +99,8 @@ overridden:
     - no snmp-server user temp_user
     - snmp-server host 192.0.2.1 source-interface Ethernet1/1
     - snmp-server host 192.0.3.2 informs version 3 auth NMS
-    - snmp-server community secret group network-operator
-    - no snmp-server community private group network-admin
+    - "snmp-server community secret  group network-operator \nsnmp-server community secret  \nsnmp-server community secret "
+    - no snmp-server community private
 
 replaced:
   commands:
@@ -110,8 +110,8 @@ replaced:
     - snmp-server location serverroom-2
     - snmp-server host 192.0.2.1 source-interface Ethernet1/1
     - snmp-server host 192.0.3.2 informs version 3 auth NMS
-    - snmp-server community secret group network-operator
-    - no snmp-server community private group network-admin
+    - "snmp-server community secret  group network-operator \nsnmp-server community secret  \nsnmp-server community secret "
+    - no snmp-server community private
   after:
     aaa_user:
       cache_timeout: 36000

--- a/tests/unit/modules/network/nxos/test_nxos_snmp_server.py
+++ b/tests/unit/modules/network/nxos/test_nxos_snmp_server.py
@@ -591,6 +591,37 @@ class TestNxosSnmpServerModule(TestNxosModule):
         result = self.execute_module(changed=True)
         self.assertEqual(set(result["commands"]), set(commands))
 
+    def test_nxos_snmp_server_communities_replaced(self):
+        # test replaced for communities - remove unwanted community without re-adding
+        self.get_config.return_value = dedent(
+            """\
+            snmp-server community private group network-operator
+            snmp-server community public group network-operator
+            snmp-server community private use-ipv4acl myacl
+            """,
+        )
+        set_module_args(
+            dict(
+                config=dict(
+                    communities=[
+                        dict(name="public", group="network-operator"),
+                        dict(name="secret", group="network-operator"),
+                    ],
+                ),
+                state="replaced",
+            ),
+            ignore_provider_arg,
+        )
+        commands = [
+            "snmp-server community secret  group network-operator \nsnmp-server community secret  \nsnmp-server community secret ",
+            "no snmp-server community private",
+        ]
+        result = self.execute_module(changed=True)
+        self.assertEqual(set(result["commands"]), set(commands))
+        for cmd in result["commands"]:
+            if cmd.startswith("no snmp-server community"):
+                self.assertNotIn("\nsnmp-server community", cmd)
+
     def test_nxos_snmp_server_users_merged_1(self):
         # test merged for users
         self.get_config.return_value = dedent(

--- a/tests/unit/modules/network/nxos/test_nxos_snmp_server.py
+++ b/tests/unit/modules/network/nxos/test_nxos_snmp_server.py
@@ -87,8 +87,8 @@ class TestNxosSnmpServerModule(TestNxosModule):
             ignore_provider_arg,
         )
         commands = [
-            "snmp-server community private  group network-admin \nsnmp-server community private  ro \nsnmp-server community private ",
-            "snmp-server community public  \nsnmp-server community public  rw \nsnmp-server community public use-ipv4acl myacl ",
+            "snmp-server community private group network-admin\nsnmp-server community private ro",
+            "snmp-server community public rw\nsnmp-server community public use-ipv4acl myacl",
             "snmp-server globalEnforcePriv",
             "snmp-server tcp-session auth",
             "snmp-server counter cache timeout 1800",
@@ -613,7 +613,7 @@ class TestNxosSnmpServerModule(TestNxosModule):
             ignore_provider_arg,
         )
         commands = [
-            "snmp-server community secret  group network-operator \nsnmp-server community secret  \nsnmp-server community secret ",
+            "snmp-server community secret group network-operator",
             "no snmp-server community private",
         ]
         result = self.execute_module(changed=True)
@@ -621,6 +621,54 @@ class TestNxosSnmpServerModule(TestNxosModule):
         for cmd in result["commands"]:
             if cmd.startswith("no snmp-server community"):
                 self.assertNotIn("\nsnmp-server community", cmd)
+
+    def test_nxos_snmp_server_communities_merged_idempotent(self):
+        # split community lines must round-trip as one object per name
+        self.get_config.return_value = dedent(
+            """\
+            snmp-server community private group network-admin
+            snmp-server community public group network-operator
+            snmp-server community private use-ipv4acl myacl
+            """,
+        )
+        set_module_args(
+            dict(
+                config=dict(
+                    communities=[
+                        dict(name="private", group="network-admin", use_ipv4acl="myacl"),
+                        dict(name="public", group="network-operator"),
+                    ],
+                ),
+                state="merged",
+            ),
+            ignore_provider_arg,
+        )
+        result = self.execute_module(changed=False)
+        self.assertEqual(result["commands"], [])
+
+    def test_nxos_snmp_server_communities_parsed_multiline(self):
+        set_module_args(
+            dict(
+                running_config=dedent(
+                    """\
+                    snmp-server community private group network-admin
+                    snmp-server community private ro
+                    snmp-server community private use-ipv4acl myacl
+                    snmp-server community public group network-operator
+                    """,
+                ),
+                state="parsed",
+            ),
+            ignore_provider_arg,
+        )
+        parsed = dict(
+            communities=[
+                dict(name="private", group="network-admin", ro=True, use_ipv4acl="myacl"),
+                dict(name="public", group="network-operator"),
+            ],
+        )
+        result = self.execute_module(changed=False)
+        self.assertEqual(result["parsed"], parsed)
 
     def test_nxos_snmp_server_users_merged_1(self):
         # test merged for users
@@ -1005,8 +1053,8 @@ class TestNxosSnmpServerModule(TestNxosModule):
             "snmp-server location lab",
             "snmp-server mib community-map public context public1",
             "snmp-server source-interface traps Ethernet1/2",
-            "snmp-server community public  \nsnmp-server community public  rw \nsnmp-server community public use-ipv4acl myacl  use-ipv6acl myaclv6",
-            "snmp-server community private  group network-admin \nsnmp-server community private  ro \nsnmp-server community private ",
+            "snmp-server community public rw\nsnmp-server community public use-ipv4acl myacl use-ipv6acl myaclv6",
+            "snmp-server community private group network-admin\nsnmp-server community private ro",
         ]
         result = self.execute_module(changed=False)
         self.assertEqual(set(result["rendered"]), set(rendered))


### PR DESCRIPTION
## Summary

This PR turns `nxos_snmp_server` **network_cli integration tests back on**, and fixes the module bugs that made those tests fail.

**Depends on / includes [#1092](https://github.com/ansible-collections/cisco.nxos/pull/1092)** (community `remval` so `replaced`/`overridden` actually delete communities). The new work for this PR is commit `60473e6b`.

`nxapi` is still left commented. That can be a follow-up once CLI is green in CI.

---

## Why were these tests off?

In [#1014](https://github.com/ansible-collections/cisco.nxos/pull/1014) the SNMP CLI/NX-API includes in `tasks/main.yaml` were commented with `# uncomment later`. Enablement never happened.

That meant CI never ran `merged` / `replaced` / `overridden` against a real device. Customer bug AAP-87440 (communities not removed on `replaced`) slipped through. After #1092 we uncommented CLI locally and the suite still failed — so this PR fixes the remaining bugs and turns CLI tests back on.

---

## What NX-OS actually does 

One SNMP community is **one name**, but the switch stores it as **several CLI lines**:

```
snmp-server community private group network-admin
snmp-server community private use-ipv4acl MY_ACL
```

Those two lines are still the same community (`private`). One line is the group, one line is the ACL.

`ro` / `rw` work the same way (`snmp-server community private ro`). On the lab NX-OS 10.4 image, `ro` is **not** kept in running-config. Default read-only access shows up as `group network-operator`.

---

## Bug 1 — facts treated each line as a different community

### What happened

The parser matched **one running-config line at a time** and appended a new list entry each time. Gather then looked like:

```yaml
communities:
  - {name: private, group: network-admin}
  - {name: private, use_ipv4acl: MY_ACL}
```

The playbook asked for **one** object:

```yaml
- name: private
  group: network-admin
  use_ipv4acl: MY_ACL
```

Compare uses the **whole dict** as the key, so want and have never matched. Every `merged` rerun generated community commands again → **idempotency failed**.

The parser also ignored `ro` / `rw` even when those keywords were present.

### What we did

After parse, **merge all lines with the same community name into one dict**. Gather now returns:

```yaml
- name: private
  group: network-admin
  use_ipv4acl: MY_ACL
```

We also parse `ro` / `rw` when they appear in config.

This is in `facts/snmp_server.py` (`_merge_communities`) and the communities `getval`/`result` in `rm_templates/snmp_server.py`.

---

## Bug 2 — empty community commands reset access to read-only

### What happened

Community `setval` **always** rendered three lines, even when the user only set a group:

```
snmp-server community private group network-admin
snmp-server community private          ← empty extra command
snmp-server community private          ← another empty extra command
```

On NX-OS, a bare `snmp-server community NAME` resets that community to **default read-only**. Running-config then showed `group network-operator` instead of `network-admin`.

So we wrote `network-admin`, the device stored `network-operator`, and the next merge thought it still needed to change. That is the rest of the old “merged idempotency / ro round-trip” failure.

`ro: true` in the merged test made this worse: it fights with `group: network-admin`, and `ro` is not stored in running-config on this platform.

### What we did

`setval` now emits **only the lines for attributes that are actually set**:

- group only → `snmp-server community private group network-admin`
- group + ACL → those two lines, nothing else
- no empty `snmp-server community NAME`

Deletes are unchanged: `remval` is still `no snmp-server community {{ name }}` (from #1092).

The merged integration case no longer sets `ro: true`. It uses `group` + `use_ipv4acl`, which NX-OS does persist.

---

## Test updates (so CI stays honest)

- Uncommented `cli.yaml` in `tasks/main.yaml` (`network_cli` tag). Added `tests/cli/.gitkeep` so `find` on that directory does not fail.
- Expected commands match the new `setval` (no dummy extra community lines).
- Merged `after.communities` expects one merged object per name, including the ACL.
- Command asserts flatten multi-line module output, then compare. Newline handling uses a real `"\n"` var so ansible-test does not treat `\n` as two characters.
- `replaced` / `overridden` ignore `snmp-server user …` commands when comparing. Default SNMP users differ by image (`cisco` / `ansible` / `temp_user`). We still apply the full user config; we just do not pin image-specific add/remove lines. Idempotency is still asserted.
- Unit tests cover: merged idempotency with split group+ACL lines, and parsed merge of group + `ro` + ACL.

---

## What this is not

- **Not** the AAP-87440 delete bug. That is #1092 (`remval`). This PR needs that fix so `replaced`/`overridden` stay green.
- **Not** NX-API enablement. `nxapi.yaml` is still commented.
- **Not** a full community model change. We still key list compare the same way; we only merge facts so have/want are the same shape.

---

## Test plan

- [x] `ansible-test units tests/unit/modules/network/nxos/test_nxos_snmp_server.py` — 24 passed
- [x] `ansible-test sanity` on the changed files — passed
- [x] `ansible-test network-integration --allow-destructive nxos_snmp_server` against lab NX-OS 10.4 (`network_cli`) — **110 ok, 0 failed** (5 ignored on purpose in `empty_config`)
- [ ] CI network_cli job for `nxos_snmp_server`
- [ ] Confirm #1092 is merged (or this PR’s extra remval commits are acceptable) before merge