### PR TITLE
Fix intermittent httpapi "connection refused" in integration tests

### DIFF
--- a/changelogs/fragments/httpapi_test_retry.yml
+++ b/changelogs/fragments/httpapi_test_retry.yml
@@ -1,0 +1,7 @@
+---
+trivial:
+  - integration tests - Wrap each httpapi test case so that a mid-run NX-API
+    httpd bounce (which poisons netcommon's persistent connection and causes
+    intermittent "connection refused" failures on the virtual NX9000v used in
+    CI) resets the connection, waits for the httpd to return, and retries the
+    case once. A genuine test failure on retry still propagates.

--- a/tests/integration/targets/nxos_aaa_server/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_aaa_server/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_aaa_server/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_aaa_server/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_aaa_server_host/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_aaa_server_host/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_aaa_server_host/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_aaa_server_host/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_acl_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_acl_interfaces/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_acl_interfaces/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_acl_interfaces/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_acls/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_acls/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_acls/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_acls/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_banner/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_banner/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_banner/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_banner/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_bfd_global/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bfd_global/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_bfd_global/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_bfd_global/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_bfd_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tasks/nxapi.yaml
@@ -24,7 +24,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_bfd_interfaces/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_bfd_interfaces/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_bgp_address_family/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bgp_address_family/tasks/nxapi.yaml
@@ -24,7 +24,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_bgp_address_family/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_bgp_address_family/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_bgp_global/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bgp_global/tasks/nxapi.yaml
@@ -24,7 +24,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_bgp_global/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_bgp_global/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_bgp_neighbor_address_family/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bgp_neighbor_address_family/tasks/nxapi.yaml
@@ -24,7 +24,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_bgp_neighbor_address_family/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_bgp_neighbor_address_family/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_bgp_templates/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_bgp_templates/tasks/nxapi.yaml
@@ -24,7 +24,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_bgp_templates/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_bgp_templates/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_command/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_command/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_command/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_command/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_config/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_config/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_config/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_config/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_evpn_global/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_evpn_global/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_evpn_global/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_evpn_global/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_evpn_vni/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_evpn_vni/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_evpn_vni/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_evpn_vni/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_facts/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_facts/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_facts/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_facts/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_feature/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_feature/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_feature/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_feature/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_file_copy/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_file_copy/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_file_copy/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_file_copy/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_gir/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_gir/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_gir/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_gir/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_gir_profile_management/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_gir_profile_management/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_gir_profile_management/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_gir_profile_management/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_hostname/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_hostname/tasks/nxapi.yaml
@@ -24,7 +24,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_hostname/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_hostname/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_hsrp_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_hsrp_interfaces/tasks/nxapi.yaml
@@ -24,7 +24,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_hsrp_interfaces/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_hsrp_interfaces/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_igmp/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_igmp/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_igmp/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_igmp/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_igmp_interface/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_igmp_interface/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_igmp_interface/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_igmp_interface/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_igmp_snooping/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_igmp_snooping/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_igmp_snooping/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_igmp_snooping/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_install_os/tasks/httpapi.yaml
+++ b/tests/integration/targets/nxos_install_os/tasks/httpapi.yaml
@@ -11,7 +11,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_install_os/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_install_os/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_interfaces/tasks/nxapi.yaml
@@ -24,7 +24,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_interfaces/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_interfaces/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_l2_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_l2_interfaces/tasks/nxapi.yaml
@@ -24,7 +24,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_l2_interfaces/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_l2_interfaces/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_l3_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_l3_interfaces/tasks/nxapi.yaml
@@ -24,7 +24,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_l3_interfaces/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_l3_interfaces/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_lacp/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_lacp/tasks/nxapi.yaml
@@ -24,7 +24,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_lacp/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_lacp/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_lacp_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_lacp_interfaces/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_lacp_interfaces/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_lacp_interfaces/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_lag_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_lag_interfaces/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_lag_interfaces/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_lag_interfaces/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_lldp_global/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_lldp_global/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_lldp_global/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_lldp_global/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_lldp_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_lldp_interfaces/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_lldp_interfaces/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_lldp_interfaces/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_logging_global/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_logging_global/tasks/nxapi.yaml
@@ -24,7 +24,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_logging_global/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_logging_global/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_ntp_global/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_ntp_global/tasks/nxapi.yaml
@@ -24,7 +24,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_ntp_global/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_ntp_global/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_nxapi/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_nxapi/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_nxapi/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_nxapi/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_ospf_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_ospf_interfaces/tasks/nxapi.yaml
@@ -24,7 +24,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_ospf_interfaces/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_ospf_interfaces/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_ospfv2/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_ospfv2/tasks/nxapi.yaml
@@ -24,7 +24,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_ospfv2/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_ospfv2/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_ospfv3/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_ospfv3/tasks/nxapi.yaml
@@ -24,7 +24,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_ospfv3/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_ospfv3/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_overlay_global/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_overlay_global/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_overlay_global/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_overlay_global/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_pim/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_pim/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_pim/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_pim/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_pim_interface/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_pim_interface/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_pim_interface/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_pim_interface/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_pim_rp_address/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_pim_rp_address/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_pim_rp_address/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_pim_rp_address/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_prefix_lists/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_prefix_lists/tasks/nxapi.yaml
@@ -24,7 +24,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_prefix_lists/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_prefix_lists/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_reboot/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_reboot/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_reboot/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_reboot/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_rollback/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_rollback/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection network_cli
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_rollback/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_rollback/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_route_maps/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_route_maps/tasks/nxapi.yaml
@@ -24,7 +24,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_route_maps/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_route_maps/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_rpm/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_rpm/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection network_cli
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_rpm/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_rpm/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_smoke/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_smoke/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_smoke/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_smoke/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_snapshot/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_snapshot/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_snapshot/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_snapshot/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_snmp_server/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_snmp_server/tasks/nxapi.yaml
@@ -24,7 +24,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_snmp_server/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_snmp_server/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_system/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_system/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_system/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_system/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_telemetry/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_telemetry/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_telemetry/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_telemetry/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_udld/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_udld/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_udld/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_udld/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_udld_interface/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_udld_interface/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_udld_interface/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_udld_interface/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_user/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_user/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_user/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_user/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_vlans/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vlans/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_vlans/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_vlans/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_vpc/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vpc/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_vpc/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_vpc/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_vpc_interface/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vpc_interface/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_vpc_interface/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_vpc_interface/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_vrf/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vrf/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_vrf/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_vrf/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_vrf_af/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vrf_af/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_vrf_af/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_vrf_af/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_vrf_interfaces/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vrf_interfaces/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_vrf_interfaces/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_vrf_interfaces/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_vrrp/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vrrp/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_vrrp/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_vrrp/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_vtp_domain/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vtp_domain/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection network_cli
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_vtp_domain/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_vtp_domain/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_vtp_password/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vtp_password/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_vtp_password/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_vtp_password/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_vtp_version/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vtp_version/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection network_cli
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_vtp_version/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_vtp_version/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_vxlan_vtep/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases with connection network_cli
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_vxlan_vtep/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_vxlan_vtep/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"

--- a/tests/integration/targets/nxos_vxlan_vtep_vni/tasks/nxapi.yaml
+++ b/tests/integration/targets/nxos_vxlan_vtep_vni/tasks/nxapi.yaml
@@ -23,7 +23,7 @@
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test cases  with connection httpapi
-  ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  ansible.builtin.include_tasks: run_httpapi_case.yml
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/nxos_vxlan_vtep_vni/tasks/run_httpapi_case.yml
+++ b/tests/integration/targets/nxos_vxlan_vtep_vni/tasks/run_httpapi_case.yml
@@ -1,0 +1,24 @@
+---
+# Runs a single httpapi test case with resilience against the NX-API httpd
+# bouncing mid-run (common on the virtual NX9000v used in CI). When the httpd
+# restarts after a config commit, netcommon's persistent httpapi socket caches
+# the dead connection, so every later task in the role gets "connection
+# refused". On failure we drop that poisoned socket (reset_connection), wait for
+# the httpd to come back, and retry the case once. A genuine failure on retry
+# still propagates, since a failing task inside a rescue is not caught.
+- name: "Run httpapi test case: {{ test_case_to_run }}"
+  block:
+    - name: "httpapi case (attempt 1): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+  rescue:
+    - name: Drop the poisoned persistent httpapi connection
+      ansible.builtin.meta: reset_connection
+    - name: Wait for NX-API httpd to come back after a config-triggered bounce
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ ansible_httpapi_port | default(80) }}"
+        timeout: 120
+        delay: 2
+      delegate_to: localhost
+    - name: "httpapi case (retry): {{ test_case_to_run }}"
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"


### PR DESCRIPTION
## Problem

Integration tests intermittently fail with httpapi `connection refused`. The failure is **mid-run on a random task**, not at role start.

Root cause: the NX-API httpd on the virtual NX9000v used in CI restarts whenever config is committed. When it bounces mid-run, `ansible.netcommon`'s **persistent** httpapi connection caches the dead socket, so every subsequent task in that role fails with `connection refused`. A one-time readiness gate (`wait_for` on the port / a `show version` probe at role start) cannot fix this, because the httpd dies *after* the gate passes.

## Fix

Wrap each httpapi test case in a `block`/`rescue` that, on failure:
1. drops the poisoned persistent connection (`meta: reset_connection`),
2. waits for the httpd to come back (`wait_for` on the NX-API port),
3. retries the case once.

A genuine test failure on the retry still propagates, since a failing task inside a `rescue` is not caught.

This is applied via a shared `run_httpapi_case.yml` wrapper referenced by every httpapi test runner (69 roles). Only the httpapi loops are changed — `cli.yaml` / `network_cli` / `local` loops are untouched.

## Notes / caveats

- The rescue re-runs the case **from the top**, so a case that isn't idempotent-from-start could show a spurious diff on retry. Almost all nxos cases begin with a `_remove_config`/setup block, so this is generally safe; the first CI run is the real validation.
- Belt-and-suspenders follow-up (separate repo): expose `--retry-on-error` in `ansible/ansible-content-actions`'s `cml_network_integration` workflow so a flaky target is retried wholesale. The shared action currently hardcodes the `ansible-test` invocation with no retry lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)