### PR TITLE
nxos_facts - document the features gather_subset value

### DIFF
--- a/changelogs/fragments/nxos_facts_document_features_subset.yml
+++ b/changelogs/fragments/nxos_facts_document_features_subset.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - nxos_facts - document the ``features`` value for the ``gather_subset``
+    option. The value was already supported by the module but was missing from
+    the list of possible values in the documentation.

--- a/docs/cisco.nxos.nxos_facts_module.rst
+++ b/docs/cisco.nxos.nxos_facts_module.rst
@@ -83,7 +83,7 @@ Parameters
                         <b>Default:</b><br/><div style="color: blue">"min"</div>
                 </td>
                 <td>
-                        <div>When supplied, this argument will gather operational facts only for the given subset. Possible values for this argument include <code>all</code>, <code>hardware</code>, <code>config</code>, <code>legacy</code>, <code>interfaces</code>, and <code>min</code>.  Can specify a list of values to include a larger subset.  Values can also be used with an initial <code>!</code> to specify that a specific subset should not be collected.</div>
+                        <div>When supplied, this argument will gather operational facts only for the given subset. Possible values for this argument include <code>all</code>, <code>hardware</code>, <code>config</code>, <code>legacy</code>, <code>interfaces</code>, <code>features</code>, and <code>min</code>.  Can specify a list of values to include a larger subset.  Values can also be used with an initial <code>!</code> to specify that a specific subset should not be collected.</div>
                 </td>
             </tr>
     </table>

--- a/plugins/modules/nxos_facts.py
+++ b/plugins/modules/nxos_facts.py
@@ -43,7 +43,7 @@ options:
   gather_subset:
     description:
     - When supplied, this argument will gather operational facts only for the given subset. Possible
-      values for this argument include C(all), C(hardware), C(config), C(legacy), C(interfaces), and C(min).  Can
+      values for this argument include C(all), C(hardware), C(config), C(legacy), C(interfaces), C(features), and C(min).  Can
       specify a list of values to include a larger subset.  Values can also be used
       with an initial C(!) to specify that a specific subset should not be collected.
     required: false


### PR DESCRIPTION
## Description

- Adds `features` to the list of possible values documented for the `gather_subset`
  option of `nxos_facts`.
- The `features` subset is already registered in `FACT_LEGACY_SUBSETS` and is fully
  supported by the module, but it was missing from the documented list
  (`all`, `hardware`, `config`, `legacy`, `interfaces`, `min`), so users had no way
  to know it was a valid value.
- Documentation-only change. A changelog fragment is included.

## Type of Change

- [x] Documentation update

## Component Name

nxos_facts