### PR TITLE
nxos_interfaces: add negotiate_auto attribute for auto-negotiation control

### DIFF
--- a/changelogs/fragments/nxos_interfaces_negotiate_auto.yaml
+++ b/changelogs/fragments/nxos_interfaces_negotiate_auto.yaml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - nxos_interfaces - Add ``negotiate_auto`` boolean attribute to control
+    auto-negotiation on Ethernet interfaces. Set to ``false`` to configure
+    ``no negotiate auto`` and disable auto-negotiation; set to ``true`` to
+    configure ``negotiate auto`` and re-enable it.

--- a/docs/cisco.nxos.nxos_interfaces_module.rst
+++ b/docs/cisco.nxos.nxos_interfaces_module.rst
@@ -278,6 +278,26 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="4">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>negotiate_auto</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li>yes</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Enable or disable auto-negotiation on the interface. Set the value to <code>true</code> to enable auto-negotiation (configures <code>negotiate auto</code>) or <code>false</code> to disable it (configures <code>no negotiate auto</code>). Applicable for Ethernet interfaces only.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>service_policy</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/plugins/module_utils/network/nxos/argspec/interfaces/interfaces.py
+++ b/plugins/module_utils/network/nxos/argspec/interfaces/interfaces.py
@@ -46,6 +46,7 @@ class InterfacesArgs(object):  # pylint: disable=R0903
                 "duplex": {"type": "str", "choices": ["full", "half", "auto"]},
                 "ip_forward": {"type": "bool"},
                 "fabric_forwarding_anycast_gateway": {"type": "bool"},
+                "negotiate_auto": {"type": "bool"},
                 "mac_address": {"type": "str"},
                 "logging": {
                     "type": "dict",

--- a/plugins/module_utils/network/nxos/config/interfaces/interfaces.py
+++ b/plugins/module_utils/network/nxos/config/interfaces/interfaces.py
@@ -182,6 +182,20 @@ class Interfaces(ResourceModule):
                 no_cmd = True if self.defaults.get("default_mode") == "layer3" else False
                 self.addcmd(have, "mode", no_cmd)
 
+        # Handle 'negotiate_auto' separately because its default (enabled) does not
+        # appear in running-config; only 'no negotiate auto' appears when disabled.
+        # The base class compare() skips bool False vs None, so we own the full logic.
+        want_negotiate = want.get("negotiate_auto")
+        have_negotiate = have.get("negotiate_auto")
+        if want_negotiate is not None:
+            if want_negotiate != have_negotiate:
+                # False → emit "no negotiate auto"; True → emit "negotiate auto"
+                self.addcmd(want, "negotiate_auto", not want_negotiate)
+        elif not want and self.state in ["overridden", "deleted"]:
+            if have_negotiate is False:
+                # Restore default: remove "no negotiate auto"
+                self.addcmd(have, "negotiate_auto", False)
+
         if len(self.commands) != begin:
             self.commands.insert(begin, self._tmplt.render(want or have, "name", False))
 

--- a/plugins/module_utils/network/nxos/rm_templates/interfaces.py
+++ b/plugins/module_utils/network/nxos/rm_templates/interfaces.py
@@ -115,6 +115,20 @@ class InterfacesTemplate(NetworkTemplate):
             },
         },
         {
+            "name": "negotiate_auto",
+            "getval": re.compile(
+                r"""
+                \s+no\snegotiate\sauto
+                $""", re.VERBOSE,
+            ),
+            "setval": "negotiate auto",
+            "result": {
+                '{{ name }}': {
+                    'negotiate_auto': "{{ False }}",
+                },
+            },
+        },
+        {
             "name": "ip_forward",
             "getval": re.compile(
                 r"""

--- a/plugins/modules/nxos_interfaces.py
+++ b/plugins/modules/nxos_interfaces.py
@@ -85,6 +85,13 @@ options:
           - Associate SVI with anycast gateway under VLAN configuration mode.
             Applicable for SVI interfaces only.
         type: bool
+      negotiate_auto:
+        description:
+          - Enable or disable auto-negotiation on the interface. Set the value
+            to C(true) to enable auto-negotiation (configures C(negotiate auto))
+            or C(false) to disable it (configures C(no negotiate auto)).
+            Applicable for Ethernet interfaces only.
+        type: bool
       mac_address:
         description: E.E.E  MAC address.
         type: str

--- a/tests/unit/modules/network/nxos/test_nxos_interfaces.py
+++ b/tests/unit/modules/network/nxos/test_nxos_interfaces.py
@@ -800,3 +800,65 @@ class TestNxosInterfacesModule(TestNxosModule):
         set_module_args(playbook)
         result = self.execute_module(changed=True)
         self.assertEqual(sorted(result["commands"]), sorted(replaced))
+
+    def test_nxos_interfaces_negotiate_auto_disable(self):
+        """Setting negotiate_auto: false should emit 'no negotiate auto'."""
+        self.exec_get_defaults.return_value = {
+            "default_mode": "layer3",
+            "L2_enabled": False,
+        }
+        self.execute_show_command.return_value = dedent(
+            """\
+          interface Ethernet1/43
+            speed 1000
+            duplex full
+        """,
+        )
+
+        playbook = dict(
+            config=[
+                dict(
+                    name="Ethernet1/43",
+                    speed="1000",
+                    duplex="full",
+                    negotiate_auto=False,
+                ),
+            ],
+            state="merged",
+        )
+
+        set_module_args(playbook)
+        result = self.execute_module(changed=True)
+        self.assertIn("no negotiate auto", result["commands"])
+        self.assertIn("interface Ethernet1/43", result["commands"])
+
+    def test_nxos_interfaces_negotiate_auto_enable(self):
+        """Setting negotiate_auto: true on an interface that has 'no negotiate auto'
+        should emit 'negotiate auto' to restore the default."""
+        self.exec_get_defaults.return_value = {
+            "default_mode": "layer3",
+            "L2_enabled": False,
+        }
+        self.execute_show_command.return_value = dedent(
+            """\
+          interface Ethernet1/43
+            speed 1000
+            duplex full
+            no negotiate auto
+        """,
+        )
+
+        playbook = dict(
+            config=[
+                dict(
+                    name="Ethernet1/43",
+                    negotiate_auto=True,
+                ),
+            ],
+            state="merged",
+        )
+
+        set_module_args(playbook)
+        result = self.execute_module(changed=True)
+        self.assertIn("negotiate auto", result["commands"])
+        self.assertIn("interface Ethernet1/43", result["commands"])


### PR DESCRIPTION
## Summary

- Adds a new `negotiate_auto` boolean attribute to `nxos_interfaces` so users can manage auto-negotiation on Ethernet interfaces.
- `negotiate_auto: false` configures `no negotiate auto` (disables auto-negotiation).
- `negotiate_auto: true` configures `negotiate auto` (re-enables auto-negotiation).
- Custom handling in `_compare()` is required because the default (enabled) state produces no CLI output — only `no negotiate auto` appears when disabled. The base class `compare()` skips the `bool False vs None` case, so it would never emit `no negotiate auto` without this explicit logic.

## Motivation

It is currently not possible to configure auto-negotiation through the `cisco.nxos.nxos_interfaces` resource module. NX-OS uses `no negotiate auto` to disable it (unlike IOS which uses `speed nonegotiate`), so a new NX-OS-specific attribute is needed.

Example usage:
```yaml
- name: Disable auto-negotiation on Ethernet1/43
  cisco.nxos.nxos_interfaces:
    config:
      - name: Ethernet1/43
        speed: 1000
        duplex: full
        negotiate_auto: false
    state: merged
```

## Changes

- `argspec/interfaces/interfaces.py` — add `negotiate_auto: bool` option
- `rm_templates/interfaces.py` — add parser matching `no negotiate auto` → `negotiate_auto: False`
- `config/interfaces/interfaces.py` — handle `negotiate_auto` in `_compare()` with explicit logic
- `plugins/modules/nxos_interfaces.py` — document the new suboption
- `tests/unit/modules/network/nxos/test_nxos_interfaces.py` — two new unit tests
- `changelogs/fragments/nxos_interfaces_negotiate_auto.yaml` — changelog entry

## Test plan

- [x] `test_nxos_interfaces_negotiate_auto_disable` — verifies `no negotiate auto` is emitted when `negotiate_auto: false` and interface currently has auto-neg enabled (no command in config)
- [x] `test_nxos_interfaces_negotiate_auto_enable` — verifies `negotiate auto` is emitted when `negotiate_auto: true` and interface currently has `no negotiate auto` in config
- [x] All 14 existing unit tests continue to pass
- [x] Tested against a Cisco Nexus 93180YC-FX running NX-OS 10.4(5) — fact gathering, `merged` state (disable and re-enable), and `replaced` state all behave as expected