### PR TITLE
fix: nxos_interfaces reports default-shutdown SVIs as enabled

### DIFF
--- a/plugins/module_utils/network/nxos/facts/interfaces/interfaces.py
+++ b/plugins/module_utils/network/nxos/facts/interfaces/interfaces.py
@@ -57,7 +57,8 @@ class InterfacesFacts(object):
 
         data = re.sub(
             r"(?m)^(interface Vlan\S+\n)((?:[ \t]+.*\n?)*)",
-            lambda m: m.group(1) + (m.group(2) if "shutdown" in m.group(2) else "  shutdown\n" + m.group(2)),
+            lambda m: m.group(1)
+            + (m.group(2) if "shutdown" in m.group(2) else "  shutdown\n" + m.group(2)),
             data,
         )
 

--- a/plugins/module_utils/network/nxos/facts/interfaces/interfaces.py
+++ b/plugins/module_utils/network/nxos/facts/interfaces/interfaces.py
@@ -15,6 +15,8 @@ for a given resource, parsed, and the facts tree is populated
 based on the configuration.
 """
 
+import re
+
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     utils,
 )
@@ -52,6 +54,12 @@ class InterfacesFacts(object):
 
         if not data:
             data = self._get_interface_config(connection)
+
+        data = re.sub(
+            r"(?m)^(interface Vlan\S+\n)((?:[ \t]+.*\n?)*)",
+            lambda m: m.group(1) + (m.group(2) if "shutdown" in m.group(2) else "  shutdown\n" + m.group(2)),
+            data,
+        )
 
         # parse native config using the Interfaces template
         interfaces_parser = InterfacesTemplate(lines=data.splitlines(), module=self._module)


### PR DESCRIPTION
## Summary

Fixes #83

NX-OS never writes `shutdown` to `show running-config` for interfaces in their default shutdown state. Only `no shutdown` appears, for interfaces explicitly brought up. This causes `nxos_interfaces` to always report default-shutdown SVIs as `enabled: true` and attempt to enable them every run.

## Red Hat solution 7137028

Red Hat [solution 7137028](https://access.redhat.com/solutions/7137028) describes the same class of problem for physical switchports when `system default switchport shutdown` is set, and suggests `no system default switchport shutdown` as a prerequisite.

That workaround does not work. Running-config still shows no admin state for the interface after disabling it:

```
! before
interface Ethernet1/17

! after: no system default switchport shutdown
interface Ethernet1/17
```

Nothing changed. NX-OS does not write the default state regardless of what that default is. This is different from IOS, where `shutdown` is always written explicitly.

The workaround also has no effect on SVIs, which have their own default-shutdown behaviour independent of that global setting.

## Fix

Inject `  shutdown` into any `interface VlanXXX` block in the gathered running-config that has neither `shutdown` nor `no shutdown`, before passing it to the parser. The existing rm_templates already handles `shutdown` -> `enabled: false`.

```python
data = re.sub(
    r"(?m)^(interface Vlan\S+\n)((?:[ \t]+.*\n?)*)",
    lambda m: m.group(1) + (m.group(2) if "shutdown" in m.group(2) else "  shutdown\n" + m.group(2)),
    data,
)
```

## Test

Verified on NX-OS (N9K-C93180YC-FX3H). `Vlan1` in default shutdown state is now reported as `enabled: false` and subsequent runs are idempotent.
