### PR TITLE
Fix nxos_snmp_server replaced state deleting updated SNMPv3 user (AAP-90154)

### DIFF
--- a/changelogs/fragments/nxos_snmp_server_replaced_user.yml
+++ b/changelogs/fragments/nxos_snmp_server_replaced_user.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - >-
+    nxos_snmp_server - stop deleting an SNMPv3 user when ``state: replaced``
+    updates that user (AAP-90154).

--- a/plugins/module_utils/network/nxos/config/snmp_server/snmp_server.py
+++ b/plugins/module_utils/network/nxos/config/snmp_server/snmp_server.py
@@ -239,7 +239,7 @@ class Snmp_server(ResourceModule):
             tmp["communities"] = {entry["name"]: entry for entry in tmp["communities"]}
         if "users" in tmp:
             if "auth" in tmp["users"]:
-                tmp["users"]["auth"] = {_build_key(entry): entry for entry in tmp["users"]["auth"]}
+                tmp["users"]["auth"] = {entry["user"]: entry for entry in tmp["users"]["auth"]}
             if "use_acls" in tmp["users"]:
                 tmp["users"]["use_acls"] = {
                     entry["user"]: entry for entry in tmp["users"]["use_acls"]

--- a/tests/integration/targets/nxos_snmp_server/tests/common/replaced_same_user.yaml
+++ b/tests/integration/targets/nxos_snmp_server/tests/common/replaced_same_user.yaml
@@ -1,0 +1,90 @@
+---
+- ansible.builtin.debug:
+    msg: >-
+      Start nxos_snmp_server replaced same-user integration tests
+      connection={{ ansible_connection }}
+
+- name: Remove test SNMP user from prior run
+  cisco.nxos.nxos_config:
+    lines:
+      - no snmp-server user aap90154_user
+  ignore_errors: true
+
+- name: Create SNMPv3 user for same-user replace test
+  cisco.nxos.nxos_snmp_server:
+    config:
+      users:
+        auth:
+          - user: aap90154_user
+            group: vdc-operator
+            authentication:
+              algorithm: md5
+              password: "0x5632724fb8ac3699296af26281e1d0f1"
+              localized_key: true
+              priv:
+                aes_128: true
+                privacy_password: "0x5632724fb8ac3699296af26281e1d0f1"
+    state: merged
+
+- block:
+    - name: Gather SNMP configuration including test user
+      cisco.nxos.nxos_snmp_server:
+        state: gathered
+      register: snmp_gathered
+
+    - name: Build replaced config with updated credentials for same username
+      ansible.builtin.set_fact:
+        aap90154_replace_config: >-
+          {{
+            snmp_gathered.gathered | combine(
+              {
+                'users': {
+                  'auth': (
+                    snmp_gathered.gathered.users.auth
+                    | rejectattr('user', 'equalto', 'aap90154_user')
+                    | list
+                  ) + [aap90154_user_want],
+                  'use_acls': snmp_gathered.gathered.users.use_acls | default([]),
+                },
+              },
+              recursive=True,
+            )
+          }}
+
+    - name: Replace SNMP config updating same user credentials (AAP-90154)
+      cisco.nxos.nxos_snmp_server:
+        config: "{{ aap90154_replace_config }}"
+        state: replaced
+      register: result
+
+    - name: Assert module did not delete the user being updated
+      ansible.builtin.assert:
+        that:
+          - >-
+            result.commands
+            | select('search', '^no snmp-server user aap90154_user$')
+            | list
+            | length == 0
+          - >-
+            result.commands
+            | select('search', 'snmp-server user aap90154_user vdc-operator auth md5')
+            | list
+            | length > 0
+        fail_msg: "AAP-90154: replaced emitted no snmp-server user for same-user update"
+
+    - name: Verify user still present on device
+      cisco.nxos.nxos_command:
+        commands: show running-config | section '^snmp-server user aap90154_user'
+      register: user_show
+
+    - name: Assert user exists after replace
+      ansible.builtin.assert:
+        that:
+          - user_show.stdout[0] is search('snmp-server user aap90154_user')
+
+  always:
+    - name: Remove test SNMP user
+      cisco.nxos.nxos_config:
+        lines:
+          - no snmp-server user aap90154_user
+      ignore_errors: true

--- a/tests/integration/targets/nxos_snmp_server/vars/main.yml
+++ b/tests/integration/targets/nxos_snmp_server/vars/main.yml
@@ -15,6 +15,18 @@ snmp_test_user_acls:
     ipv4: acl1
     ipv6: acl2
 
+# Same-user credential change for replaced_same_user.yaml (AAP-90154).
+aap90154_user_want:
+  user: aap90154_user
+  group: vdc-operator
+  authentication:
+    algorithm: md5
+    password: "0x7d425fbf09417c44bca69e1d9e9ce889"
+    localized_key: true
+    priv:
+      aes_128: true
+      privacy_password: "0x7d425fbf09417c44bca69e1d9e9ce889"
+
 merged:
   before:
     users:

--- a/tests/unit/modules/network/nxos/test_nxos_snmp_server.py
+++ b/tests/unit/modules/network/nxos/test_nxos_snmp_server.py
@@ -1058,6 +1058,44 @@ class TestNxosSnmpServerModule(TestNxosModule):
         result = self.execute_module(changed=False)
         self.assertEqual(result["parsed"], parsed)
 
+    def test_nxos_snmp_server_users_replaced_same_user(self):
+        self.get_config.return_value = dedent(
+            """\
+            snmp-server user snmpv3_user vdc-operator auth sha AuthPassword123 priv aes-128 PrivPassword123 localizedV2key
+            """,
+        )
+        set_module_args(
+            dict(
+                config=dict(
+                    users=dict(
+                        auth=[
+                            dict(
+                                user="snmpv3_user",
+                                group="vdc-operator",
+                                authentication=dict(
+                                    algorithm="sha",
+                                    password="NewAuthPassword123",
+                                    localizedv2_key=True,
+                                    priv=dict(
+                                        privacy_password="NewPrivPassword123",
+                                        aes_128=True,
+                                    ),
+                                ),
+                            ),
+                        ],
+                    ),
+                ),
+                state="replaced",
+            ),
+            ignore_provider_arg,
+        )
+        commands = [
+            "snmp-server user snmpv3_user vdc-operator auth sha NewAuthPassword123 priv aes-128"
+            " NewPrivPassword123 localizedV2key",
+        ]
+        result = self.execute_module(changed=True)
+        self.assertEqual(result["commands"], commands)
+
     def test_nxos_snmp_server_rendered(self):
         # test rendered
         set_module_args(


### PR DESCRIPTION
## Description

This PR fixes customer-reported bug **AAP-90154** in `nxos_snmp_server`: `state: replaced` could delete an SNMPv3 user immediately after updating it.

### What is being changed?

1. **Compare logic (`config/snmp_server/snmp_server.py`)** — Key `users.auth` entries by **username** instead of a fingerprint of all auth/priv fields, so updating an existing user does not emit a spurious `no snmp-server user`.
2. **Regression test** — `test_nxos_snmp_server_users_replaced_same_user` asserts no trailing delete for same-user replace.
3. **Changelog fragment** — User-facing bugfix entry referencing AAP-90154.

### Why is this change needed?

When an existing SNMPv3 user needed a credential or priv change and the playbook used `state: replaced`, the module generated an update command followed by `no snmp-server user <name>`. NX-OS applied the update, then deleted the user. The module reported success while SNMP validation failed with **Unknown user name**. A second identical run recreated the user, masking the bug.

### How does this change address the issue?

`_list_to_dict` previously fingerprinted the full auth blob for `users.auth`. Same username + different password produced two dict keys → add want entry, then negate leftover have entry via `remval: snmp-server user {{ user }}`. Keying by `entry["user"]` (same as `users.use_acls`) yields only the update command for that user.

---

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New module (adding a new module to the collection)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Collection release
- [ ] CI maintenance
- [ ] Workflow maintenance
- [ ] Configuration change

## Related Issue

- Related to Red Hat Jira [AAP-90154](https://redhat.atlassian.net/browse/AAP-90154) — `state: replaced` deletes SNMPv3 user after update

## Component Name

`nxos_snmp_server` — resource module and `plugins/module_utils/network/nxos/config/snmp_server/snmp_server.py`

---

## Problem detail (before fix)

When an existing SNMPv3 user needed a credential or priv change and the playbook used `state: replaced`, the module generated:

```text
snmp-server user <name> <new-parameters>
no snmp-server user <name>
```

**Expected behavior:** after successful `replaced`, the user in the playbook must exist with desired parameters — no trailing `no snmp-server user` for the same username.

**Root cause:** `_compare_lists` keyed `users.auth` by a fingerprint of every nested field. Same username + different password → two dict keys → add want entry, then negate leftover have entry.

---

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [x] I have removed all commented code (no commented code should be merged)
- [ ] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment
- [x] I have verified the changes work with the target NX-OS version(s)
- [x] I have reviewed the acceptance criteria for related tickets

## Testing Instructions

### Prerequisites

- NX-OS Version: 10.4(2) C9300v (lab); customer reported on production NX-OS
- Hardware Platform: Nexus 9000v (CML)
- Test Topology: Single switch, `network_cli` / libssh

### Steps to Test

**Unit (required):**

```bash
ansible-test units --python 3.12 tests/unit/modules/network/nxos/test_nxos_snmp_server.py
```

1. Run `test_nxos_snmp_server_users_replaced_same_user`.
2. Confirm `commands` is a single update line with **no** `no snmp-server user snmpv3_user`.

**Live (optional, lab inventory):**

1. Apply `state: replaced` on an existing SNMPv3 user with changed credentials on lab NX-OS.
2. Confirm user remains in `show running-config | section '^snmp-server user'`.

### Expected Results

- All 22 unit tests pass on this branch.
- Same-user `replaced` emits only the update command.
- Live replace leaves SNMPv3 user on device.

### Test Results

```
ansible-test units test_nxos_snmp_server.py: 22 passed in 1.73s
Live validation on NX-OS 10.4(2) lab switch: PASS
```

## Acceptance Criteria Verification

- [x] All acceptance criteria have been reviewed and verified
- [x] Acceptance criteria checklist:

- [x] `state: replaced` updates an existing SNMPv3 user without deleting it afterward
- [x] Successful run leaves the user present with desired auth/priv
- [x] Unit test asserts no trailing `no snmp-server user` for same-user replace

## Additional Context


**Out of scope for this PR:** community `remval` fix (AAP-87440 / separate PR) — stock `replaced` integration still fails on community delete assertions until that lands. SNMP **user** behavior is fixed and validated separately.

### Command Output / Logs

**Before fix (simulated command order):**

```text
snmp-server user snmpv3_user vdc-operator auth sha NewAuthPassword123 priv aes-128 NewPrivPassword123 localizedV2key
no snmp-server user snmpv3_user
```

**After fix:**

```text
snmp-server user snmpv3_user vdc-operator auth sha NewAuthPassword123 priv aes-128 NewPrivPassword123 localizedV2key
```

### Required Actions

- [ ] Requires documentation updates
- [x] Requires changelog fragment
- [ ] Requires integration test updates
- [x] Requires unit test updates
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: #XXX

### Breaking Changes

None.

Assisted-by: Cursor / Auto (Cursor)
